### PR TITLE
Fix jailctl Makefile targets

### DIFF
--- a/usr.sbin/jailctl/Makefile
+++ b/usr.sbin/jailctl/Makefile
@@ -1,6 +1,6 @@
 #	$NetBSD$
 
-PROG=\tjailctl
-MAN=\tjailctl.8
+PROG=jailctl
+MAN=jailctl.8
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
### Motivation
- The `usr.sbin/jailctl/Makefile` contained literal tab-escape sequences in variable assignments which prevented `make` from recognizing the `jailctl` target and caused the build to abort with an error about `\tjailctl.c`.

### Description
- Replace `PROG=\tjailctl` and `MAN=\tjailctl.8` with `PROG=jailctl` and `MAN=jailctl.8` in `usr.sbin/jailctl/Makefile` to remove stray tab escapes.

### Testing
- No automated tests were run on this trivial Makefile fix; the change was staged and committed successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e7ddef264832a95864b4bcea88aee)