### PR TITLE
Add jailctl and sys/jail.h to release sets

### DIFF
--- a/distrib/sets/lists/base/mi
+++ b/distrib/sets/lists/base/mi
@@ -1559,6 +1559,7 @@
 ./usr/sbin/isibootd				base-bootserver-bin
 ./usr/sbin/ispppcontrol				base-obsolete		obsolete
 ./usr/sbin/iwictl				base-sysutil-bin
+./usr/sbin/jailctl				base-sysutil-bin
 ./usr/sbin/kadmin				base-krb5-bin		kerberos
 ./usr/sbin/kcm					base-krb5-bin		kerberos
 ./usr/sbin/kdc					base-krb5-bin		kerberos

--- a/distrib/sets/lists/comp/mi
+++ b/distrib/sets/lists/comp/mi
@@ -3371,6 +3371,7 @@
 ./usr/include/sys/iostat.h			comp-c-include
 ./usr/include/sys/ipc.h				comp-c-include
 ./usr/include/sys/ipmi.h			comp-c-include
+./usr/include/sys/jail.h			comp-c-include
 ./usr/include/sys/joystick.h			comp-c-include
 ./usr/include/sys/kcore.h			comp-c-include
 ./usr/include/sys/kcov.h			comp-c-include

--- a/distrib/sets/lists/man/mi
+++ b/distrib/sets/lists/man/mi
@@ -6132,6 +6132,7 @@
 ./usr/share/man/html8/isibootd.html		man-bootserver-htmlman	html
 ./usr/share/man/html8/iteconfig.html		man-sysutil-htmlman	html
 ./usr/share/man/html8/iwictl.html		man-sysutil-htmlman	html
+./usr/share/man/html8/jailctl.html		man-sysutil-htmlman	html
 ./usr/share/man/html8/kadmin.html		man-krb5-htmlman	kerberos,html
 ./usr/share/man/html8/kadmind.html		man-krb5-htmlman	kerberos,html
 ./usr/share/man/html8/kcm.html			man-krb5-htmlman	kerberos,html
@@ -9508,6 +9509,7 @@
 ./usr/share/man/man8/ispppcontrol.8		man-obsolete		obsolete
 ./usr/share/man/man8/iteconfig.8		man-sysutil-man		.man
 ./usr/share/man/man8/iwictl.8			man-sysutil-man		.man
+./usr/share/man/man8/jailctl.8			man-sysutil-man		.man
 ./usr/share/man/man8/kadmin.8			man-krb5-man		kerberos,.man
 ./usr/share/man/man8/kadmind.8			man-krb5-man		kerberos,.man
 ./usr/share/man/man8/kcm.8			man-krb5-man		kerberos,.man


### PR DESCRIPTION
### Motivation
- A `checkflist` run reported extra files in `DESTDIR` (`./usr/sbin/jailctl`, `./usr/include/sys/jail.h`, and associated man/html pages`) which indicates the sets lists were out of date. 
- Update the release lists so the binary, header and documentation are packaged and the release build `checkflist` will no longer treat them as extraneous files.

### Description
- Added `./usr/sbin/jailctl` to `distrib/sets/lists/base/mi` so the binary is included in the base set. 
- Added `./usr/include/sys/jail.h` to `distrib/sets/lists/comp/mi` so the header is included in the comp set. 
- Added `./usr/share/man/html8/jailctl.html` and `./usr/share/man/man8/jailctl.8` entries to `distrib/sets/lists/man/mi` so the man page and HTML documentation are tracked. 
- Changes were staged and committed with the message `Add jailctl and jail.h to release sets`.

### Testing
- No full release build or `checkflist` run was executed after the changes. 
- Verified the insertions using `rg`, `nl` and `sed` to confirm the new lines appear in `distrib/sets/lists/{base,comp,man}/mi` and that `git commit` succeeded. 
- Existing pre-change `checkflist` output was the motivation for this fix and indicated the problem prior to updating the sets lists.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697efafad284832aa30ad12bfd8301bf)