### PR TITLE
Build secmodel_jail as a kernel module

### DIFF
--- a/distrib/sets/lists/debug/module.mi
+++ b/distrib/sets/lists/debug/module.mi
@@ -344,6 +344,8 @@
 ./usr/libdata/debug/@MODULEDIR@/secmodel_bsd44/secmodel_bsd44.kmod.debug	modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/secmodel_extensions		modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/secmodel_extensions/secmodel_extensions.kmod.debug	modules-base-kernel	kmod,debug
+./usr/libdata/debug/@MODULEDIR@/secmodel_jail			modules-base-kernel	kmod,debug
+./usr/libdata/debug/@MODULEDIR@/secmodel_jail/secmodel_jail.kmod.debug	modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/secmodel_overlay			modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/secmodel_overlay/secmodel_overlay.kmod.debug	modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/securelevel			modules-base-kernel	kmod,debug

--- a/distrib/sets/lists/modules/mi
+++ b/distrib/sets/lists/modules/mi
@@ -409,6 +409,8 @@
 ./@MODULEDIR@/secmodel_bsd44/secmodel_bsd44.kmod	modules-base-kernel	kmod
 ./@MODULEDIR@/secmodel_extensions		modules-base-kernel	kmod
 ./@MODULEDIR@/secmodel_extensions/secmodel_extensions.kmod	modules-base-kernel	kmod
+./@MODULEDIR@/secmodel_jail			modules-base-kernel	kmod
+./@MODULEDIR@/secmodel_jail/secmodel_jail.kmod	modules-base-kernel	kmod
 ./@MODULEDIR@/secmodel_overlay			modules-base-kernel	kmod
 ./@MODULEDIR@/secmodel_overlay/secmodel_overlay.kmod	modules-base-kernel	kmod
 ./@MODULEDIR@/securelevel			modules-base-kernel	kmod

--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -160,6 +160,7 @@ SUBDIR+=	scsiverbose
 SUBDIR+=	sdtemp
 SUBDIR+=	secmodel_bsd44
 SUBDIR+=	secmodel_extensions
+SUBDIR+=	secmodel_jail
 SUBDIR+=	secmodel_overlay
 SUBDIR+=	securelevel
 SUBDIR+=	sequencer


### PR DESCRIPTION
### Motivation
- Ensure `secmodel_jail` is built as a separate, loadable kernel module and included in the module installation lists so it can be packaged and installed like other security-model modules.

### Description
- Added `secmodel_jail` to the kernel modules build list in `sys/modules/Makefile` by adding `SUBDIR+= secmodel_jail`.
- Included `secmodel_jail` and its `.kmod` entry in the standard modules set at `distrib/sets/lists/modules/mi`.
- Included `secmodel_jail` and its debug package entry in the debug modules set at `distrib/sets/lists/debug/module.mi`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ae991a5c832a9c5297375c54f707)