### PR TITLE
Add secmodel_jail kernel module build files and include it in module lists

### DIFF
--- a/distrib/sets/lists/debug/module.mi
+++ b/distrib/sets/lists/debug/module.mi
@@ -344,6 +344,8 @@
 ./usr/libdata/debug/@MODULEDIR@/secmodel_bsd44/secmodel_bsd44.kmod.debug	modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/secmodel_extensions		modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/secmodel_extensions/secmodel_extensions.kmod.debug	modules-base-kernel	kmod,debug
+./usr/libdata/debug/@MODULEDIR@/secmodel_jail			modules-base-kernel	kmod,debug
+./usr/libdata/debug/@MODULEDIR@/secmodel_jail/secmodel_jail.kmod.debug	modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/secmodel_overlay			modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/secmodel_overlay/secmodel_overlay.kmod.debug	modules-base-kernel	kmod,debug
 ./usr/libdata/debug/@MODULEDIR@/securelevel			modules-base-kernel	kmod,debug

--- a/distrib/sets/lists/modules/mi
+++ b/distrib/sets/lists/modules/mi
@@ -409,6 +409,8 @@
 ./@MODULEDIR@/secmodel_bsd44/secmodel_bsd44.kmod	modules-base-kernel	kmod
 ./@MODULEDIR@/secmodel_extensions		modules-base-kernel	kmod
 ./@MODULEDIR@/secmodel_extensions/secmodel_extensions.kmod	modules-base-kernel	kmod
+./@MODULEDIR@/secmodel_jail			modules-base-kernel	kmod
+./@MODULEDIR@/secmodel_jail/secmodel_jail.kmod	modules-base-kernel	kmod
 ./@MODULEDIR@/secmodel_overlay			modules-base-kernel	kmod
 ./@MODULEDIR@/secmodel_overlay/secmodel_overlay.kmod	modules-base-kernel	kmod
 ./@MODULEDIR@/securelevel			modules-base-kernel	kmod

--- a/sys/modules/Makefile
+++ b/sys/modules/Makefile
@@ -160,6 +160,7 @@ SUBDIR+=	scsiverbose
 SUBDIR+=	sdtemp
 SUBDIR+=	secmodel_bsd44
 SUBDIR+=	secmodel_extensions
+SUBDIR+=	secmodel_jail
 SUBDIR+=	secmodel_overlay
 SUBDIR+=	securelevel
 SUBDIR+=	sequencer

--- a/sys/modules/secmodel_jail/Makefile
+++ b/sys/modules/secmodel_jail/Makefile
@@ -1,0 +1,10 @@
+# $NetBSD$
+
+.include "../Makefile.inc"
+
+.PATH:	${S}/secmodel/jail
+
+KMOD=	secmodel_jail
+SRCS=	secmodel_jail.c
+
+.include <bsd.kmodule.mk>


### PR DESCRIPTION
### Motivation
- Ensure `secmodel_jail` is built as a separate, loadable kernel module so the `sys/modules/secmodel_jail` subdirectory is handled by the module build system. 
- Include the new module in the standard module and debug sets so it can be packaged and installed like other security-model modules.

### Description
- Added `sys/modules/secmodel_jail/Makefile` that follows the existing kernel module pattern with `KMOD= secmodel_jail` and `SRCS= secmodel_jail.c` so the directory can be built. 
- Added `SUBDIR+= secmodel_jail` to `sys/modules/Makefile` so the module is picked up by the top-level modules build. 
- Added `secmodel_jail` entries to `distrib/sets/lists/modules/mi` and `distrib/sets/lists/debug/module.mi` so the module and its debug package are included in the installable sets. 
- Inspected `sys/modules/secmodel_extensions/Makefile` as a template to ensure consistent kmod Makefile layout.

### Testing
- A prior automated release build aborted with `cd: can't cd to .../sys/modules/secmodel_jail` due to the missing module Makefile, which this change fixes. 
- No automated tests or rebuilds were run after adding the Makefile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ae991a5c832a9c5297375c54f707)