### PR TITLE
usr.sbin/jailctl: add `attach` subcommand to enter existing jail

### DIFF
--- a/sys/secmodel/files.secmodel
+++ b/sys/secmodel/files.secmodel
@@ -31,3 +31,8 @@ include "secmodel/overlay/files.overlay"
 # Multi-position keylock
 #
 include "secmodel/keylock/files.keylock"
+
+#
+# Jail isolation
+#
+include "secmodel/jail/files.jail"

--- a/sys/secmodel/jail/files.jail
+++ b/sys/secmodel/jail/files.jail
@@ -1,0 +1,5 @@
+# $NetBSD$
+
+defflag secmodel_jail
+
+file	secmodel/jail/secmodel_jail.c	secmodel_jail

--- a/sys/secmodel/jail/jail.h
+++ b/sys/secmodel/jail/jail.h
@@ -1,0 +1,48 @@
+/* $NetBSD$ */
+/*-
+ * Copyright (c) 2025
+ * The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _SECMODEL_JAIL_JAIL_H_
+#define _SECMODEL_JAIL_JAIL_H_
+
+/*
+ * secmodel_jail enforces process visibility and signal delivery based on a
+ * jail id stored in credentials. Host root (jail id 0) bypasses these checks.
+ */
+#define SECMODEL_JAIL_ID   "org.netbsd.secmodel.jail"
+#define SECMODEL_JAIL_NAME "NetBSD Jail"
+
+void secmodel_jail_init(void);
+void secmodel_jail_start(void);
+void secmodel_jail_stop(void);
+
+int secmodel_jail_process_cb(kauth_cred_t, kauth_action_t, void *,
+    void *, void *, void *, void *);
+int secmodel_jail_cred_cb(kauth_cred_t, kauth_action_t, void *,
+    void *, void *, void *, void *);
+
+#endif /* !_SECMODEL_JAIL_JAIL_H_ */

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -1,0 +1,648 @@
+/* $NetBSD$ */
+/*-
+ * Copyright (c) 2025
+ * The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__KERNEL_RCSID(0, "$NetBSD$");
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/kauth.h>
+#include <sys/module.h>
+#include <sys/sysctl.h>
+#include <sys/mutex.h>
+#include <sys/kmem.h>
+#include <sys/proc.h>
+#include <sys/queue.h>
+#include <sys/jail.h>
+
+#include <secmodel/secmodel.h>
+#include <secmodel/jail/jail.h>
+
+MODULE(MODULE_CLASS_SECMODEL, secmodel_jail, NULL);
+
+static kauth_listener_t l_process;
+static kauth_listener_t l_cred;
+
+static secmodel_t jail_sm;
+static kauth_key_t jail_key;
+
+/*
+ * Each jail is tracked by an entry in a global list. The entry only stores the
+ * jail id and is used for creation/destruction and sysctl listing. Actual
+ * membership is stored per-credential via kauth specificdata.
+ */
+struct jail_entry {
+	jailid_t je_id;
+	LIST_ENTRY(jail_entry) je_entry;
+};
+
+static LIST_HEAD(, jail_entry) jail_list =
+    LIST_HEAD_INITIALIZER(jail_list);
+static kmutex_t jail_lock;
+static jailid_t jail_next_id = 1;
+
+/*
+ * Fetch the jail id associated with a credential. The value lives in the
+ * secmodel-specific kauth data slot.
+ */
+static jailid_t
+secmodel_jail_cred_id(kauth_cred_t cred)
+{
+	void *data;
+
+	data = kauth_cred_getdata(cred, jail_key);
+	return (jailid_t)(uintptr_t)data;
+}
+
+/*
+ * Set the jail id on a credential. This is the only state we store for
+ * membership; all policy checks rely on this value.
+ */
+static void
+secmodel_jail_cred_setid(kauth_cred_t cred, jailid_t id)
+{
+	kauth_cred_setdata(cred, jail_key, (void *)(uintptr_t)id);
+}
+
+/*
+ * Host root (euid 0, jail id 0) bypasses jail restrictions.
+ */
+static bool
+secmodel_jail_is_host_root(kauth_cred_t cred)
+{
+	return kauth_cred_geteuid(cred) == 0 &&
+	    secmodel_jail_cred_id(cred) == JAILID_HOST;
+}
+
+/*
+ * Determine whether a credential can interact with a target process.
+ * Host root can always interact. Otherwise, both must be in the same jail.
+ */
+static bool
+secmodel_jail_match(kauth_cred_t cred, struct proc *p)
+{
+	if (secmodel_jail_is_host_root(cred))
+		return true;
+
+	return secmodel_jail_cred_id(cred) ==
+	    secmodel_jail_cred_id(p->p_cred);
+}
+
+/*
+ * Look up a jail entry by id. Callers must hold jail_lock.
+ */
+static struct jail_entry *
+secmodel_jail_lookup(jailid_t id)
+{
+	struct jail_entry *entry;
+
+	LIST_FOREACH(entry, &jail_list, je_entry) {
+		if (entry->je_id == id)
+			return entry;
+	}
+
+	return NULL;
+}
+
+/*
+ * Create a new jail id. The id is monotonic, starting at 1, and 0 is reserved
+ * for the host. Returns the new id to the caller.
+ */
+static int
+secmodel_jail_create(jailid_t *idp)
+{
+	struct jail_entry *entry;
+	jailid_t id;
+
+	mutex_enter(&jail_lock);
+	if (jail_next_id == 0) {
+		mutex_exit(&jail_lock);
+		return EOVERFLOW;
+	}
+
+	id = jail_next_id++;
+	entry = kmem_zalloc(sizeof(*entry), KM_SLEEP);
+	entry->je_id = id;
+	LIST_INSERT_HEAD(&jail_list, entry, je_entry);
+	mutex_exit(&jail_lock);
+
+	*idp = id;
+	return 0;
+}
+
+/*
+ * Check whether any process (including zombies) currently belongs to the
+ * specified jail id. Used to prevent destroying active jails.
+ */
+static bool
+secmodel_jail_has_processes(jailid_t id)
+{
+	struct proc *p;
+	bool found = false;
+
+	mutex_enter(&proc_lock);
+	PROCLIST_FOREACH(p, &allproc) {
+		if (secmodel_jail_cred_id(p->p_cred) == id) {
+			found = true;
+			break;
+		}
+	}
+	if (!found) {
+		PROCLIST_FOREACH(p, &zombproc) {
+			if (secmodel_jail_cred_id(p->p_cred) == id) {
+				found = true;
+				break;
+			}
+		}
+	}
+	mutex_exit(&proc_lock);
+
+	return found;
+}
+
+/*
+ * Remove a jail entry. This does not touch processes; callers should ensure
+ * there are no remaining members before destroying.
+ */
+static int
+secmodel_jail_destroy(jailid_t id)
+{
+	struct jail_entry *entry;
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry == NULL) {
+		mutex_exit(&jail_lock);
+		return ENOENT;
+	}
+
+	LIST_REMOVE(entry, je_entry);
+	mutex_exit(&jail_lock);
+
+	kmem_free(entry, sizeof(*entry));
+	return 0;
+}
+
+/*
+ * Move the calling process into the specified jail id.
+ *
+ * This is a privileged operation: only host root can enter (and only into
+ * an existing jail). The jail id is stored in the process credentials to
+ * ensure it follows the process and its children.
+ */
+static int
+secmodel_jail_enter(struct lwp *l, jailid_t id)
+{
+	struct proc *p;
+	kauth_cred_t cred, ncred;
+	jailid_t cur;
+
+	p = l->l_proc;
+	proc_crmod_enter();
+	cred = p->p_cred;
+	cur = secmodel_jail_cred_id(cred);
+
+	if (!secmodel_jail_is_host_root(l->l_cred)) {
+		proc_crmod_leave(cred, NULL, false);
+		return EPERM;
+	}
+
+	if (cur != JAILID_HOST && cur != id) {
+		proc_crmod_leave(cred, NULL, false);
+		return EPERM;
+	}
+
+	if (id != JAILID_HOST) {
+		mutex_enter(&jail_lock);
+		if (secmodel_jail_lookup(id) == NULL) {
+			mutex_exit(&jail_lock);
+			proc_crmod_leave(cred, NULL, false);
+			return ENOENT;
+		}
+		mutex_exit(&jail_lock);
+	}
+
+	if (cur == id) {
+		proc_crmod_leave(cred, NULL, false);
+		return 0;
+	}
+
+	ncred = kauth_cred_alloc();
+	kauth_cred_clone(cred, ncred);
+	secmodel_jail_cred_setid(ncred, id);
+	proc_crmod_leave(ncred, cred, true);
+
+	return 0;
+}
+
+/*
+ * sysctl handler for security.models.jail.create
+ *
+ * Writing a value allocates a new jail id. The newly created id is returned
+ * to userland.
+ */
+static int
+secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
+{
+	uint32_t id;
+	int error;
+	uint32_t dummy;
+
+	if (newp == NULL)
+		return EINVAL;
+
+	if (!secmodel_jail_is_host_root(l->l_cred))
+		return EPERM;
+
+	if (newlen < sizeof(dummy))
+		return EINVAL;
+
+	error = sysctl_copyin(l, newp, &dummy, sizeof(dummy));
+	if (error != 0)
+		return error;
+
+	error = secmodel_jail_create(&id);
+	if (error != 0)
+		return error;
+
+	if (oldp == NULL) {
+		*oldlenp = 0;
+		return 0;
+	}
+
+	if (*oldlenp < sizeof(id))
+		return ENOMEM;
+
+	*oldlenp = sizeof(id);
+	return sysctl_copyout(l, &id, oldp, sizeof(id));
+}
+
+/*
+ * sysctl handler for security.models.jail.destroy
+ *
+ * Writing a jail id destroys it if there are no remaining processes.
+ */
+static int
+secmodel_jail_sysctl_destroy(SYSCTLFN_ARGS)
+{
+	uint32_t id;
+	int error;
+
+	if (newp == NULL)
+		return EINVAL;
+
+	if (!secmodel_jail_is_host_root(l->l_cred))
+		return EPERM;
+
+	if (newlen < sizeof(id))
+		return EINVAL;
+
+	error = sysctl_copyin(l, newp, &id, sizeof(id));
+	if (error != 0)
+		return error;
+
+	if (id == JAILID_HOST)
+		return EINVAL;
+
+	if (secmodel_jail_has_processes(id))
+		return EBUSY;
+
+	return secmodel_jail_destroy(id);
+}
+
+/*
+ * sysctl handler for security.models.jail.id
+ *
+ * Reading returns the current process jail id. Writing an id requests the
+ * process to enter that jail.
+ */
+static int
+secmodel_jail_sysctl_id(SYSCTLFN_ARGS)
+{
+	jailid_t id;
+	int error;
+	struct sysctlnode node;
+
+	id = secmodel_jail_cred_id(l->l_cred);
+
+	node = *rnode;
+	node.sysctl_data = &id;
+	node.sysctl_size = sizeof(id);
+
+	error = sysctl_lookup(SYSCTLFN_CALL(&node));
+	if (error || newp == NULL)
+		return error;
+
+	if (!secmodel_jail_is_host_root(l->l_cred))
+		return EPERM;
+
+	return secmodel_jail_enter(l, id);
+}
+
+/*
+ * sysctl handler for security.models.jail.list
+ *
+ * Reading returns an array of jail_info entries with current process counts.
+ */
+static int
+secmodel_jail_sysctl_list(SYSCTLFN_ARGS)
+{
+	struct jail_entry *entry;
+	struct jail_info *entries;
+	size_t count, i, needed;
+	int error;
+	struct proc *p;
+
+	if (newp != NULL)
+		return EPERM;
+
+	mutex_enter(&jail_lock);
+	count = 0;
+	LIST_FOREACH(entry, &jail_list, je_entry)
+		count++;
+
+	if (count == 0) {
+		mutex_exit(&jail_lock);
+		*oldlenp = 0;
+		return 0;
+	}
+
+	entries = kmem_zalloc(count * sizeof(*entries), KM_SLEEP);
+	i = 0;
+	LIST_FOREACH(entry, &jail_list, je_entry) {
+		entries[i].ji_id = entry->je_id;
+		entries[i].ji_refcount = 0;
+		i++;
+	}
+	mutex_exit(&jail_lock);
+
+	mutex_enter(&proc_lock);
+	PROCLIST_FOREACH(p, &allproc) {
+		jailid_t id;
+
+		id = secmodel_jail_cred_id(p->p_cred);
+		for (i = 0; i < count; i++) {
+			if (entries[i].ji_id == id) {
+				entries[i].ji_refcount++;
+				break;
+			}
+		}
+	}
+	PROCLIST_FOREACH(p, &zombproc) {
+		jailid_t id;
+
+		id = secmodel_jail_cred_id(p->p_cred);
+		for (i = 0; i < count; i++) {
+			if (entries[i].ji_id == id) {
+				entries[i].ji_refcount++;
+				break;
+			}
+		}
+	}
+	mutex_exit(&proc_lock);
+
+	needed = count * sizeof(*entries);
+	if (oldp == NULL) {
+		*oldlenp = needed;
+		kmem_free(entries, needed);
+		return 0;
+	}
+
+	if (*oldlenp < needed) {
+		kmem_free(entries, needed);
+		return ENOMEM;
+	}
+
+	error = 0;
+	for (i = 0; i < count; i++) {
+		error = sysctl_copyout(l, &entries[i], oldp,
+		    sizeof(*entries));
+		if (error != 0)
+			break;
+		oldp = (char *)oldp + sizeof(*entries);
+	}
+
+	if (error == 0)
+		*oldlenp = needed;
+
+	kmem_free(entries, needed);
+	return error;
+}
+
+/*
+ * Create the sysctl tree for jail controls under security.models.jail.
+ */
+SYSCTL_SETUP(sysctl_security_jail_setup, "secmodel_jail sysctl")
+{
+	const struct sysctlnode *rnode;
+
+	sysctl_createv(clog, 0, NULL, &rnode,
+	       CTLFLAG_PERMANENT,
+	       CTLTYPE_NODE, "models", NULL,
+	       NULL, 0, NULL, 0,
+	       CTL_SECURITY, CTL_CREATE, CTL_EOL);
+
+	sysctl_createv(clog, 0, &rnode, &rnode,
+	       CTLFLAG_PERMANENT,
+	       CTLTYPE_NODE, "jail",
+	       SYSCTL_DESCR("Jail security model"),
+	       NULL, 0, NULL, 0,
+	       CTL_CREATE, CTL_EOL);
+
+	sysctl_createv(clog, 0, &rnode, NULL,
+	       CTLFLAG_PERMANENT,
+	       CTLTYPE_STRING, "name", NULL,
+	       NULL, 0, __UNCONST(SECMODEL_JAIL_NAME), 0,
+	       CTL_CREATE, CTL_EOL);
+
+	sysctl_createv(clog, 0, &rnode, NULL,
+	       CTLFLAG_PERMANENT|CTLFLAG_READWRITE,
+	       CTLTYPE_INT, "id",
+	       SYSCTL_DESCR("Current process jail id"),
+	       secmodel_jail_sysctl_id, 0, NULL, 0,
+	       CTL_CREATE, CTL_EOL);
+
+	sysctl_createv(clog, 0, &rnode, NULL,
+	       CTLFLAG_PERMANENT|CTLFLAG_READWRITE,
+	       CTLTYPE_INT, "create",
+	       SYSCTL_DESCR("Create a new jail id"),
+	       secmodel_jail_sysctl_create, 0, NULL, 0,
+	       CTL_CREATE, CTL_EOL);
+
+	sysctl_createv(clog, 0, &rnode, NULL,
+	       CTLFLAG_PERMANENT|CTLFLAG_READWRITE,
+	       CTLTYPE_INT, "destroy",
+	       SYSCTL_DESCR("Destroy a jail id with no processes"),
+	       secmodel_jail_sysctl_destroy, 0, NULL, 0,
+	       CTL_CREATE, CTL_EOL);
+
+	sysctl_createv(clog, 0, &rnode, NULL,
+	       CTLFLAG_PERMANENT|CTLFLAG_READONLY,
+	       CTLTYPE_STRUCT, "list",
+	       SYSCTL_DESCR("List active jail ids"),
+	       secmodel_jail_sysctl_list, 0, NULL, 0,
+	       CTL_CREATE, CTL_EOL);
+}
+
+/*
+ * Initialize secmodel jail structures and register per-credential storage.
+ */
+void
+secmodel_jail_init(void)
+{
+	mutex_init(&jail_lock, MUTEX_DEFAULT, IPL_NONE);
+	if (kauth_register_key(jail_sm, &jail_key) != 0)
+		printf("secmodel_jail: unable to register kauth key\n");
+}
+
+/*
+ * Register kauth listeners for process checks and credential lifecycle hooks.
+ */
+void
+secmodel_jail_start(void)
+{
+	l_process = kauth_listen_scope(KAUTH_SCOPE_PROCESS,
+	    secmodel_jail_process_cb, NULL);
+	l_cred = kauth_listen_scope(KAUTH_SCOPE_CRED,
+	    secmodel_jail_cred_cb, NULL);
+}
+
+/*
+ * Unregister listeners and clean up jail data.
+ */
+void
+secmodel_jail_stop(void)
+{
+	struct jail_entry *entry;
+
+	kauth_unlisten_scope(l_process);
+	kauth_unlisten_scope(l_cred);
+	kauth_deregister_key(jail_key);
+
+	mutex_enter(&jail_lock);
+	while ((entry = LIST_FIRST(&jail_list)) != NULL) {
+		LIST_REMOVE(entry, je_entry);
+		kmem_free(entry, sizeof(*entry));
+	}
+	mutex_exit(&jail_lock);
+	mutex_destroy(&jail_lock);
+}
+
+/*
+ * kauth(9) listener for process scope.
+ *
+ * Enforces that signals and process visibility are limited to the same jail,
+ * except for host root which is allowed everywhere.
+ */
+int
+secmodel_jail_process_cb(kauth_cred_t cred, kauth_action_t action,
+    void *cookie, void *arg0, void *arg1, void *arg2, void *arg3)
+{
+	struct proc *p;
+
+	(void)cookie;
+	(void)arg1;
+	(void)arg2;
+	(void)arg3;
+
+	switch (action) {
+	case KAUTH_PROCESS_CANSEE:
+	case KAUTH_PROCESS_SIGNAL:
+		p = arg0;
+		if (!secmodel_jail_match(cred, p))
+			return KAUTH_RESULT_DENY;
+		return KAUTH_RESULT_DEFER;
+	default:
+		return KAUTH_RESULT_DEFER;
+	}
+}
+
+/*
+ * kauth(9) listener for credential scope.
+ *
+ * Initializes new credentials to host jail (id 0) and preserves the jail id
+ * when credentials are copied.
+ */
+int
+secmodel_jail_cred_cb(kauth_cred_t cred, kauth_action_t action,
+    void *cookie, void *arg0, void *arg1, void *arg2, void *arg3)
+{
+	(void)cookie;
+	(void)arg1;
+	(void)arg2;
+	(void)arg3;
+
+	switch (action) {
+	case KAUTH_CRED_INIT:
+		secmodel_jail_cred_setid(cred, JAILID_HOST);
+		return KAUTH_RESULT_ALLOW;
+	case KAUTH_CRED_COPY:
+		secmodel_jail_cred_setid(arg0, secmodel_jail_cred_id(cred));
+		return KAUTH_RESULT_ALLOW;
+	default:
+		return KAUTH_RESULT_DEFER;
+	}
+}
+
+/*
+ * Module command handler: register/deregister the security model.
+ */
+static int
+secmodel_jail_modcmd(modcmd_t cmd, void *arg)
+{
+	int error = 0;
+
+	switch (cmd) {
+	case MODULE_CMD_INIT:
+		error = secmodel_register(&jail_sm,
+		    SECMODEL_JAIL_ID, SECMODEL_JAIL_NAME,
+		    NULL, NULL, NULL);
+		if (error != 0)
+			printf("secmodel_jail_modcmd::init: "
+			    "secmodel_register returned %d\n", error);
+
+		secmodel_jail_init();
+		secmodel_jail_start();
+		break;
+
+	case MODULE_CMD_FINI:
+		secmodel_jail_stop();
+
+		error = secmodel_deregister(jail_sm);
+		if (error != 0)
+			printf("secmodel_jail_modcmd::fini: "
+			    "secmodel_deregister returned %d\n", error);
+		break;
+
+	default:
+		error = ENOTTY;
+		break;
+	}
+
+	return error;
+}

--- a/sys/sys/Makefile
+++ b/sys/sys/Makefile
@@ -27,7 +27,7 @@ INCS=	acct.h acl.h agpio.h aio.h ansi.h aout_mids.h ataio.h atomic.h \
 	hook.h idtype.h ieee754.h intr.h intrio.h inttypes.h ioccom.h ioctl.h \
 	ioctl_compat.h iostat.h ipc.h ipmi.h \
 	joystick.h \
-	kcore.h kcov.h kcpuset.h kgdb.h kmem.h ksem.h ksyms.h ktrace.h \
+	jail.h kcore.h kcov.h kcpuset.h kgdb.h kmem.h ksem.h ksyms.h ktrace.h \
 	localcount.h localedef.h lock.h lockf.h lua.h lwp.h lwpctl.h \
 	malloc.h mallocvar.h mbuf.h md4.h md5.h midiio.h \
 	mman.h module.h mount.h mqueue.h msg.h msgbuf.h mtio.h mutex.h \

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -1,0 +1,43 @@
+/* $NetBSD$ */
+/*-
+ * Copyright (c) 2025
+ * The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _SYS_JAIL_H_
+#define _SYS_JAIL_H_
+
+#include <sys/types.h>
+
+typedef uint32_t jailid_t;
+
+#define JAILID_HOST 0
+
+struct jail_info {
+	jailid_t ji_id;
+	uint32_t ji_refcount;
+};
+
+#endif /* !_SYS_JAIL_H_ */

--- a/usr.sbin/Makefile
+++ b/usr.sbin/Makefile
@@ -13,7 +13,7 @@ SUBDIR=	ac accton acpitools altq apm apmd arp autofs \
 	hdaudioctl \
 	i2cscan ifwatchd inetd installboot intrctl iopctl iostat ipwctl irdaattach \
 	isibootd iteconfig iwictl \
-	kgmon \
+	jailctl kgmon \
 	lastlogin ldpd link lockstat lpr \
 	mailwrapper makefs map-mbone mdconfig memswitch mlxctl mmcformat \
 	mopd mountd moused mrinfo mrouted mscdlabel mtrace mtree \

--- a/usr.sbin/jailctl/Makefile
+++ b/usr.sbin/jailctl/Makefile
@@ -1,0 +1,6 @@
+#	$NetBSD$
+
+PROG=	jailctl
+MAN=	jailctl.8
+
+.include <bsd.prog.mk>

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -1,0 +1,83 @@
+." $NetBSD$
+.\"-
+.\" Copyright (c) 2025
+.\" The NetBSD Foundation, Inc.
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+.\" ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+.\" TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+.\" PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+.\" BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"-
+.Dd September 22, 2025
+.Dt JAILCTL 8
+.Os
+.Sh NAME
+.Nm jailctl
+.Nd manage secmodel jail instances
+.Sh SYNOPSIS
+.Nm
+.Cm create
+.Ar root
+.Op command
+.Op Ar args ...
+.Nm
+.Cm destroy
+.Ar jail-id
+.Nm
+.Cm attach
+.Ar root
+.Ar jail-id
+.Op command
+.Op Ar args ...
+.Nm
+.Cm list
+.Sh DESCRIPTION
+The
+.Nm
+utility manages jails provided by the secmodel jail security model.
+Jails are process groups identified by a jail id.
+Processes in a jail can only signal or see other processes with the same
+jail id, while the host root user (jail id 0) can access all processes.
+.Pp
+The commands are as follows:
+.Bl -tag -width Ds
+.It Cm create Ar root Op command Op Ar args ...
+Create a new jail id, change the root directory to
+.Ar root ,
+enter the jail, and execute
+.Ar command .
+If no command is provided, an interactive shell is started.
+.It Cm attach Ar root Ar jail-id Op command Op Ar args ...
+Enter an existing jail id after changing the root directory to
+.Ar root .
+If no command is provided, an interactive shell is started.
+.It Cm destroy Ar jail-id
+Destroy a jail id that has no remaining processes.
+.It Cm list
+List active jail ids and their process counts.
+.El
+.Sh SEE ALSO
+.Xr chroot 2 ,
+.Xr secmodel 9 ,
+.Xr sysctl 8
+.Sh HISTORY
+The
+.Nm
+utility first appeared in NetBSD 10.0.

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -1,0 +1,246 @@
+/* $NetBSD$ */
+/*-
+ * Copyright (c) 2025
+ * The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#ifndef lint
+__RCSID("$NetBSD$");
+#endif /* not lint */
+
+#include <sys/types.h>
+#include <sys/jail.h>
+#include <sys/sysctl.h>
+
+#include <err.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <paths.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void	usage(void) __dead;
+
+static jailid_t
+jail_create(void)
+{
+	jailid_t id;
+	size_t len;
+	int one;
+
+	id = 0;
+	len = sizeof(id);
+	one = 1;
+	if (sysctlbyname("security.models.jail.create", &id, &len,
+	    &one, sizeof(one)) == -1)
+		err(1, "create jail");
+
+	return id;
+}
+
+static void
+jail_destroy(jailid_t id)
+{
+	if (sysctlbyname("security.models.jail.destroy", NULL, 0,
+	    &id, sizeof(id)) == -1)
+		err(1, "destroy jail %" PRIu32, id);
+}
+
+static void
+jail_enter(jailid_t id)
+{
+	if (sysctlbyname("security.models.jail.id", NULL, 0,
+	    &id, sizeof(id)) == -1)
+		err(1, "enter jail %" PRIu32, id);
+}
+
+static void
+jail_list(void)
+{
+	struct jail_info *entries;
+	size_t len, count, i;
+
+	len = 0;
+	if (sysctlbyname("security.models.jail.list", NULL, &len,
+	    NULL, 0) == -1)
+		err(1, "list jails");
+
+	if (len == 0) {
+		printf("no jails\n");
+		return;
+	}
+
+	if (len % sizeof(*entries) != 0)
+		errx(1, "unexpected jail list length");
+
+	entries = calloc(1, len);
+	if (entries == NULL)
+		err(1, "calloc");
+
+	if (sysctlbyname("security.models.jail.list", entries, &len,
+	    NULL, 0) == -1)
+		err(1, "list jails");
+
+	count = len / sizeof(*entries);
+	printf("%-8s %-8s\n", "ID", "PROCS");
+	for (i = 0; i < count; i++)
+		printf("%-8" PRIu32 " %-8" PRIu32 "\n",
+		    entries[i].ji_id, entries[i].ji_refcount);
+
+	free(entries);
+}
+
+static int
+getnum(const char *str, uintmax_t *num)
+{
+	char *ep;
+
+	errno = 0;
+	*num = strtoumax(str, &ep, 0);
+	if (str[0] == '\0' || *ep != '\0') {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (errno == ERANGE && *num == UINTMAX_MAX)
+		return -1;
+
+	return 0;
+}
+
+static jailid_t
+parse_jailid(const char *arg)
+{
+	uintmax_t num;
+
+	if (getnum(arg, &num) == -1)
+		errx(1, "invalid jail id: %s", arg);
+
+	if (num > UINT32_MAX)
+		errx(1, "jail id out of range: %s", arg);
+
+	return (jailid_t)num;
+}
+
+int
+main(int argc, char *argv[])
+{
+	jailid_t id;
+	const char *root;
+	const char *shell;
+
+	if (argc < 2)
+		usage();
+
+	if (strcmp(argv[1], "create") == 0) {
+		if (argc < 3)
+			usage();
+
+		root = argv[2];
+		id = jail_create();
+
+		if (chdir(root) == -1 || chroot(".") == -1)
+			err(1, "%s", root);
+
+		if (chdir("/") == -1)
+			err(1, "/");
+
+		jail_enter(id);
+
+		printf("jail %" PRIu32 "\n", id);
+		fflush(stdout);
+
+		if (argc > 3) {
+			execvp(argv[3], &argv[3]);
+			err(1, "%s", argv[3]);
+		}
+
+		if ((shell = getenv("SHELL")) == NULL)
+			shell = _PATH_BSHELL;
+		execlp(shell, shell, "-i", NULL);
+		err(1, "%s", shell);
+	}
+
+	if (strcmp(argv[1], "attach") == 0) {
+		if (argc < 4)
+			usage();
+
+		root = argv[2];
+		id = parse_jailid(argv[3]);
+
+		if (chdir(root) == -1 || chroot(".") == -1)
+			err(1, "%s", root);
+
+		if (chdir("/") == -1)
+			err(1, "/");
+
+		jail_enter(id);
+
+		if (argc > 4) {
+			execvp(argv[4], &argv[4]);
+			err(1, "%s", argv[4]);
+		}
+
+		if ((shell = getenv("SHELL")) == NULL)
+			shell = _PATH_BSHELL;
+		execlp(shell, shell, "-i", NULL);
+		err(1, "%s", shell);
+	}
+
+	if (strcmp(argv[1], "destroy") == 0) {
+		if (argc != 3)
+			usage();
+
+		id = parse_jailid(argv[2]);
+		jail_destroy(id);
+		return 0;
+	}
+
+	if (strcmp(argv[1], "list") == 0) {
+		if (argc != 2)
+			usage();
+
+		jail_list();
+		return 0;
+	}
+
+	usage();
+	/* NOTREACHED */
+}
+
+static void
+usage(void)
+{
+	fprintf(stderr,
+	    "usage: %s create <root> [command [args...]]\n"
+	    "       %s attach <root> <jail-id> [command [args...]]\n"
+	    "       %s destroy <jail-id>\n"
+	    "       %s list\n",
+	    getprogname(), getprogname(), getprogname(), getprogname());
+	exit(1);
+}


### PR DESCRIPTION
### Motivation
- Provide an `attach` operation for `jailctl` that mirrors `create` but reuses an existing jail id so an operator can chroot into a jail and obtain a shell or run a command inside that jail.

### Description
- Implemented the `attach` subcommand in `usr.sbin/jailctl/jailctl.c`, which parses `root` and `jail-id`, performs `chdir`/`chroot` into `root`, sets the process jail id via the `security.models.jail.id` sysctl (`jail_enter`), and then `exec`s an optional command or an interactive shell; updated `usage()` to include the new form.
- Updated the manual page `usr.sbin/jailctl/jailctl.8` to document the `attach` subcommand and adjusted the SYNOPSIS and DESCRIPTION to match the new behaviour.

### Testing
- No automated tests or builds were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ae18d5fbc832a8821757ca8466e62)