### PR TITLE
jailctl: remove attach subcommand and use enter exclusively

### DIFF
--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -41,7 +41,7 @@
 .Cm destroy
 .Ar jail-id
 .Nm
-.Cm attach
+.Cm enter
 .Ar jail-id
 .Ar root
 .Op command
@@ -66,14 +66,13 @@ enter the jail, and execute
 If no command is provided, an interactive shell is started.
 .It Cm destroy Ar jail-id
 Destroy a jail id that has no remaining processes.
-.It Cm attach Ar jail-id Ar root Op command Op Ar args ...
-Enter an existing jail with id
+.It Cm enter Ar jail-id Ar root Op command Op Ar args ...
+Enter a jail with id
 .Ar jail-id ,
 change the root directory to
 .Ar root ,
 and execute
 .Ar command .
-The jail must already have running processes.
 If no command is provided, an interactive shell is started.
 .It Cm list
 List active jail ids and their process counts.

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -215,7 +215,7 @@ main(int argc, char *argv[])
 		return 0;
 	}
 
-	if (strcmp(argv[1], "attach") == 0) {
+	if (strcmp(argv[1], "enter") == 0) {
 		if (argc < 4)
 			usage();
 
@@ -235,9 +235,6 @@ main(int argc, char *argv[])
 
 		if (!found)
 			errx(1, "jail %" PRIu32 " not found", id);
-		if (info.ji_refcount == 0)
-			errx(1, "jail %" PRIu32 " has no running processes",
-			    id);
 
 		if (chdir(root) == -1 || chroot(".") == -1)
 			err(1, "%s", root);
@@ -275,7 +272,7 @@ usage(void)
 {
 	fprintf(stderr,
 	    "usage: %s create <root> [command [args...]]\n"
-	    "       %s attach <jail-id> <root> [command [args...]]\n"
+	    "       %s enter <jail-id> <root> [command [args...]]\n"
 	    "       %s destroy <jail-id>\n"
 	    "       %s list\n",
 	    getprogname(), getprogname(), getprogname(), getprogname());


### PR DESCRIPTION
### Motivation
- Simplify the interface by removing the legacy `attach` subcommand since `enter` covers both entering running jails and entering empty jails.
- Preserve expected behavior for entering a jail while removing the special-case refcount check that enforced running processes for `attach`.

### Description
- Deleted handling for the `attach` subcommand in `usr.sbin/jailctl/jailctl.c` and made `enter` the single command path for entering a jail.
- Removed the `ji_refcount` check that prevented entering jails with no running processes, so `enter` can be used for both cases.
- Updated the usage output in `usr.sbin/jailctl/jailctl.c` and adjusted the manual page `usr.sbin/jailctl/jailctl.8` to remove `attach` and document only `enter`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848b757590832ab4e546c725e6b656)