### PR TITLE
jailctl: drop unused `jail_info` after removing `attach`

### DIFF
--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -41,7 +41,7 @@
 .Cm destroy
 .Ar jail-id
 .Nm
-.Cm attach
+.Cm enter
 .Ar jail-id
 .Ar root
 .Op command
@@ -66,14 +66,13 @@ enter the jail, and execute
 If no command is provided, an interactive shell is started.
 .It Cm destroy Ar jail-id
 Destroy a jail id that has no remaining processes.
-.It Cm attach Ar jail-id Ar root Op command Op Ar args ...
-Enter an existing jail with id
+.It Cm enter Ar jail-id Ar root Op command Op Ar args ...
+Enter a jail with id
 .Ar jail-id ,
 change the root directory to
 .Ar root ,
 and execute
 .Ar command .
-The jail must already have running processes.
 If no command is provided, an interactive shell is started.
 .It Cm list
 List active jail ids and their process counts.

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -168,7 +168,6 @@ main(int argc, char *argv[])
 {
 	jailid_t id;
 	struct jail_info *entries;
-	struct jail_info info;
 	const char *root;
 	const char *shell;
 	size_t count, i;
@@ -215,7 +214,7 @@ main(int argc, char *argv[])
 		return 0;
 	}
 
-	if (strcmp(argv[1], "attach") == 0) {
+	if (strcmp(argv[1], "enter") == 0) {
 		if (argc < 4)
 			usage();
 
@@ -226,7 +225,6 @@ main(int argc, char *argv[])
 		entries = jail_fetch_list(&count);
 		for (i = 0; i < count; i++) {
 			if (entries[i].ji_id == id) {
-				info = entries[i];
 				found = true;
 				break;
 			}
@@ -235,9 +233,6 @@ main(int argc, char *argv[])
 
 		if (!found)
 			errx(1, "jail %" PRIu32 " not found", id);
-		if (info.ji_refcount == 0)
-			errx(1, "jail %" PRIu32 " has no running processes",
-			    id);
 
 		if (chdir(root) == -1 || chroot(".") == -1)
 			err(1, "%s", root);
@@ -275,7 +270,7 @@ usage(void)
 {
 	fprintf(stderr,
 	    "usage: %s create <root> [command [args...]]\n"
-	    "       %s attach <jail-id> <root> [command [args...]]\n"
+	    "       %s enter <jail-id> <root> [command [args...]]\n"
 	    "       %s destroy <jail-id>\n"
 	    "       %s list\n",
 	    getprogname(), getprogname(), getprogname(), getprogname());


### PR DESCRIPTION
### Motivation
- The prior change removed the `attach` command and its special-case logic, leaving an unused `struct jail_info info` that triggered `-Werror=unused-but-set-variable` during build. 

### Description
- Removed the unused `struct jail_info info` declaration from `usr.sbin/jailctl/jailctl.c`.
- Removed the now-redundant assignment to `info` in the loop that scans `jail_fetch_list()` results.
- Kept the simplified `enter` command path and existing removal of the `ji_refcount` check, and preserved the updated usage text in `usage()` and the manpage edits.

### Testing
- A build previously failed with `-Werror=unused-but-set-variable` due to the unused `info`; this change addresses that compile-time error.
- No automated tests or full rebuild were run after this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848b757590832ab4e546c725e6b656)