### PR TITLE
secmodel_jail: per-jail CPU/memory limits and IPv4 bind restriction; jailctl create flags

### DIFF
--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -38,7 +38,12 @@ __KERNEL_RCSID(0, "$NetBSD$");
 #include <sys/kmem.h>
 #include <sys/proc.h>
 #include <sys/queue.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/systm.h>
 #include <sys/jail.h>
+
+#include <netinet/in.h>
 
 #include <secmodel/secmodel.h>
 #include <secmodel/jail/jail.h>
@@ -47,9 +52,13 @@ MODULE(MODULE_CLASS_SECMODEL, secmodel_jail, NULL);
 
 static kauth_listener_t l_process;
 static kauth_listener_t l_cred;
+static kauth_listener_t l_network;
 
 static secmodel_t jail_sm;
 static kauth_key_t jail_key;
+
+static int	secmodel_jail_network_cb(kauth_cred_t, kauth_action_t,
+		    void *, void *, void *, void *, void *);
 
 /*
  * Each jail is tracked by an entry in a global list. The entry only stores the
@@ -58,6 +67,12 @@ static kauth_key_t jail_key;
  */
 struct jail_entry {
 	jailid_t je_id;
+	bool je_has_cpu_limit;
+	bool je_has_mem_limit;
+	bool je_has_bind4;
+	rlim_t je_cpu_limit;
+	rlim_t je_mem_limit;
+	in_addr_t je_bind4;
 	LIST_ENTRY(jail_entry) je_entry;
 };
 
@@ -65,6 +80,15 @@ static LIST_HEAD(, jail_entry) jail_list =
     LIST_HEAD_INITIALIZER(jail_list);
 static kmutex_t jail_lock;
 static jailid_t jail_next_id = 1;
+
+struct jail_config {
+	bool jc_has_cpu_limit;
+	bool jc_has_mem_limit;
+	bool jc_has_bind4;
+	rlim_t jc_cpu_limit;
+	rlim_t jc_mem_limit;
+	in_addr_t jc_bind4;
+};
 
 /*
  * Fetch the jail id associated with a credential. The value lives in the
@@ -129,12 +153,37 @@ secmodel_jail_lookup(jailid_t id)
 	return NULL;
 }
 
+static bool
+secmodel_jail_get_config(jailid_t id, struct jail_config *config)
+{
+	struct jail_entry *entry;
+
+	if (id == JAILID_HOST)
+		return false;
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry == NULL) {
+		mutex_exit(&jail_lock);
+		return false;
+	}
+	config->jc_has_cpu_limit = entry->je_has_cpu_limit;
+	config->jc_has_mem_limit = entry->je_has_mem_limit;
+	config->jc_has_bind4 = entry->je_has_bind4;
+	config->jc_cpu_limit = entry->je_cpu_limit;
+	config->jc_mem_limit = entry->je_mem_limit;
+	config->jc_bind4 = entry->je_bind4;
+	mutex_exit(&jail_lock);
+
+	return true;
+}
+
 /*
  * Create a new jail id. The id is monotonic, starting at 1, and 0 is reserved
  * for the host. Returns the new id to the caller.
  */
 static int
-secmodel_jail_create(jailid_t *idp)
+secmodel_jail_create(const struct jail_config *config, jailid_t *idp)
 {
 	struct jail_entry *entry;
 	jailid_t id;
@@ -148,6 +197,14 @@ secmodel_jail_create(jailid_t *idp)
 	id = jail_next_id++;
 	entry = kmem_zalloc(sizeof(*entry), KM_SLEEP);
 	entry->je_id = id;
+	if (config != NULL) {
+		entry->je_has_cpu_limit = config->jc_has_cpu_limit;
+		entry->je_has_mem_limit = config->jc_has_mem_limit;
+		entry->je_has_bind4 = config->jc_has_bind4;
+		entry->je_cpu_limit = config->jc_cpu_limit;
+		entry->je_mem_limit = config->jc_mem_limit;
+		entry->je_bind4 = config->jc_bind4;
+	}
 	LIST_INSERT_HEAD(&jail_list, entry, je_entry);
 	mutex_exit(&jail_lock);
 
@@ -221,6 +278,9 @@ secmodel_jail_enter(struct lwp *l, jailid_t id)
 	struct proc *p;
 	kauth_cred_t cred, ncred;
 	jailid_t cur;
+	struct jail_config config;
+	int error;
+	bool has_config;
 
 	p = l->l_proc;
 	proc_crmod_enter();
@@ -247,9 +307,29 @@ secmodel_jail_enter(struct lwp *l, jailid_t id)
 		mutex_exit(&jail_lock);
 	}
 
+	has_config = secmodel_jail_get_config(id, &config);
+	if (has_config && (config.jc_has_cpu_limit || config.jc_has_mem_limit)) {
+		struct rlimit lim;
+
+		if (config.jc_has_cpu_limit) {
+			lim.rlim_cur = config.jc_cpu_limit;
+			lim.rlim_max = config.jc_cpu_limit;
+			error = dosetrlimit(l, p, RLIMIT_CPU, &lim);
+			if (error != 0)
+				goto out;
+		}
+		if (config.jc_has_mem_limit) {
+			lim.rlim_cur = config.jc_mem_limit;
+			lim.rlim_max = config.jc_mem_limit;
+			error = dosetrlimit(l, p, RLIMIT_AS, &lim);
+			if (error != 0)
+				goto out;
+		}
+	}
+
 	if (cur == id) {
-		proc_crmod_leave(cred, NULL, false);
-		return 0;
+		error = 0;
+		goto out;
 	}
 
 	ncred = kauth_cred_alloc();
@@ -258,6 +338,10 @@ secmodel_jail_enter(struct lwp *l, jailid_t id)
 	proc_crmod_leave(ncred, cred, true);
 
 	return 0;
+
+out:
+	proc_crmod_leave(cred, NULL, false);
+	return error;
 }
 
 /*
@@ -272,6 +356,10 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 	uint32_t id;
 	int error;
 	uint32_t dummy;
+	struct jail_create create;
+	struct jail_config config;
+	struct jail_config *configp;
+	uint32_t flags;
 
 	if (newp == NULL)
 		return EINVAL;
@@ -279,16 +367,60 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 	if (!secmodel_jail_is_host_root(l->l_cred))
 		return EPERM;
 
-	if (newlen < sizeof(dummy))
+	if (newlen == sizeof(dummy)) {
+		error = sysctl_copyin(l, newp, &dummy, sizeof(dummy));
+		if (error != 0)
+			return error;
+		configp = NULL;
+	} else if (newlen == sizeof(create)) {
+		error = sysctl_copyin(l, newp, &create, sizeof(create));
+		if (error != 0)
+			return error;
+
+		flags = create.jc_flags;
+		if ((flags & ~(JAIL_CREATE_MEMLIMIT |
+		    JAIL_CREATE_CPULIMIT | JAIL_CREATE_BIND4)) != 0)
+			return EINVAL;
+
+		memset(&config, 0, sizeof(config));
+		if ((flags & JAIL_CREATE_MEMLIMIT) != 0) {
+			if (create.jc_mem_limit == 0)
+				return EINVAL;
+			config.jc_has_mem_limit = true;
+			config.jc_mem_limit = (rlim_t)create.jc_mem_limit;
+		}
+		if ((flags & JAIL_CREATE_CPULIMIT) != 0) {
+			if (create.jc_cpu_limit == 0)
+				return EINVAL;
+			config.jc_has_cpu_limit = true;
+			config.jc_cpu_limit = (rlim_t)create.jc_cpu_limit;
+		}
+		if ((flags & JAIL_CREATE_BIND4) != 0) {
+			if (create.jc_bind4 == INADDR_ANY)
+				return EINVAL;
+			config.jc_has_bind4 = true;
+			config.jc_bind4 = (in_addr_t)create.jc_bind4;
+		}
+		configp = &config;
+	} else {
 		return EINVAL;
+	}
 
-	error = sysctl_copyin(l, newp, &dummy, sizeof(dummy));
+	error = secmodel_jail_create(configp, &id);
 	if (error != 0)
 		return error;
 
-	error = secmodel_jail_create(&id);
-	if (error != 0)
-		return error;
+	if (newlen == sizeof(create)) {
+		create.jc_id = id;
+		if (oldp == NULL) {
+			*oldlenp = sizeof(create);
+			return 0;
+		}
+		if (*oldlenp < sizeof(create))
+			return ENOMEM;
+		*oldlenp = sizeof(create);
+		return sysctl_copyout(l, &create, oldp, sizeof(create));
+	}
 
 	if (oldp == NULL) {
 		*oldlenp = 0;
@@ -348,6 +480,9 @@ secmodel_jail_sysctl_id(SYSCTLFN_ARGS)
 	int error;
 	struct sysctlnode node;
 
+	if (!secmodel_jail_is_host_root(l->l_cred))
+		return EPERM;
+
 	id = secmodel_jail_cred_id(l->l_cred);
 
 	node = *rnode;
@@ -357,9 +492,6 @@ secmodel_jail_sysctl_id(SYSCTLFN_ARGS)
 	error = sysctl_lookup(SYSCTLFN_CALL(&node));
 	if (error || newp == NULL)
 		return error;
-
-	if (!secmodel_jail_is_host_root(l->l_cred))
-		return EPERM;
 
 	return secmodel_jail_enter(l, id);
 }
@@ -379,6 +511,8 @@ secmodel_jail_sysctl_list(SYSCTLFN_ARGS)
 	struct proc *p;
 
 	if (newp != NULL)
+		return EPERM;
+	if (!secmodel_jail_is_host_root(l->l_cred))
 		return EPERM;
 
 	mutex_enter(&jail_lock);
@@ -530,6 +664,8 @@ secmodel_jail_start(void)
 	    secmodel_jail_process_cb, NULL);
 	l_cred = kauth_listen_scope(KAUTH_SCOPE_CRED,
 	    secmodel_jail_cred_cb, NULL);
+	l_network = kauth_listen_scope(KAUTH_SCOPE_NETWORK,
+	    secmodel_jail_network_cb, NULL);
 }
 
 /*
@@ -542,6 +678,7 @@ secmodel_jail_stop(void)
 
 	kauth_unlisten_scope(l_process);
 	kauth_unlisten_scope(l_cred);
+	kauth_unlisten_scope(l_network);
 	kauth_deregister_key(jail_key);
 
 	mutex_enter(&jail_lock);
@@ -607,6 +744,53 @@ secmodel_jail_cred_cb(kauth_cred_t cred, kauth_action_t action,
 	default:
 		return KAUTH_RESULT_DEFER;
 	}
+}
+
+/*
+ * kauth(9) listener for network scope.
+ *
+ * Enforces per-jail bind address restrictions when configured.
+ */
+int
+secmodel_jail_network_cb(kauth_cred_t cred, kauth_action_t action,
+    void *cookie, void *arg0, void *arg1, void *arg2, void *arg3)
+{
+	struct jail_config config;
+	enum kauth_network_req req;
+	struct sockaddr *sa;
+	struct sockaddr_in *sin;
+	jailid_t id;
+
+	(void)cookie;
+	(void)arg1;
+	(void)arg3;
+
+	if (action != KAUTH_NETWORK_BIND)
+		return KAUTH_RESULT_DEFER;
+
+	if (secmodel_jail_is_host_root(cred))
+		return KAUTH_RESULT_DEFER;
+
+	id = secmodel_jail_cred_id(cred);
+	if (!secmodel_jail_get_config(id, &config))
+		return KAUTH_RESULT_DEFER;
+
+	if (!config.jc_has_bind4)
+		return KAUTH_RESULT_DEFER;
+
+	req = (enum kauth_network_req)(uintptr_t)arg0;
+	if (req == KAUTH_REQ_NETWORK_BIND_ANYADDR)
+		return KAUTH_RESULT_DENY;
+
+	sa = arg2;
+	if (sa == NULL || sa->sa_family != AF_INET)
+		return KAUTH_RESULT_DENY;
+
+	sin = (struct sockaddr_in *)sa;
+	if (sin->sin_addr.s_addr != config.jc_bind4)
+		return KAUTH_RESULT_DENY;
+
+	return KAUTH_RESULT_DEFER;
 }
 
 /*

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -306,6 +306,7 @@ secmodel_jail_enter(struct lwp *l, jailid_t id)
 		}
 		mutex_exit(&jail_lock);
 	}
+	proc_crmod_leave(cred, NULL, false);
 
 	has_config = secmodel_jail_get_config(id, &config);
 	if (has_config && (config.jc_has_cpu_limit || config.jc_has_mem_limit)) {
@@ -316,32 +317,47 @@ secmodel_jail_enter(struct lwp *l, jailid_t id)
 			lim.rlim_max = config.jc_cpu_limit;
 			error = dosetrlimit(l, p, RLIMIT_CPU, &lim);
 			if (error != 0)
-				goto out;
+				return error;
 		}
 		if (config.jc_has_mem_limit) {
 			lim.rlim_cur = config.jc_mem_limit;
 			lim.rlim_max = config.jc_mem_limit;
 			error = dosetrlimit(l, p, RLIMIT_AS, &lim);
 			if (error != 0)
-				goto out;
+				return error;
 		}
 	}
 
 	if (cur == id) {
-		error = 0;
-		goto out;
+		return 0;
 	}
 
+	proc_crmod_enter();
+	cred = p->p_cred;
+	cur = secmodel_jail_cred_id(cred);
+	if (!secmodel_jail_is_host_root(l->l_cred)) {
+		proc_crmod_leave(cred, NULL, false);
+		return EPERM;
+	}
+	if (cur != JAILID_HOST && cur != id) {
+		proc_crmod_leave(cred, NULL, false);
+		return EPERM;
+	}
+	if (id != JAILID_HOST) {
+		mutex_enter(&jail_lock);
+		if (secmodel_jail_lookup(id) == NULL) {
+			mutex_exit(&jail_lock);
+			proc_crmod_leave(cred, NULL, false);
+			return ENOENT;
+		}
+		mutex_exit(&jail_lock);
+	}
 	ncred = kauth_cred_alloc();
 	kauth_cred_clone(cred, ncred);
 	secmodel_jail_cred_setid(ncred, id);
 	proc_crmod_leave(ncred, cred, true);
 
 	return 0;
-
-out:
-	proc_crmod_leave(cred, NULL, false);
-	return error;
 }
 
 /*

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -35,6 +35,18 @@ typedef uint32_t jailid_t;
 
 #define JAILID_HOST 0
 
+#define JAIL_CREATE_MEMLIMIT	0x00000001
+#define JAIL_CREATE_CPULIMIT	0x00000002
+#define JAIL_CREATE_BIND4	0x00000004
+
+struct jail_create {
+	uint32_t jc_flags;
+	uint32_t jc_id;
+	uint64_t jc_mem_limit;
+	uint64_t jc_cpu_limit;
+	uint32_t jc_bind4;
+};
+
 struct jail_info {
 	jailid_t ji_id;
 	uint32_t ji_refcount;

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -34,6 +34,9 @@
 .Sh SYNOPSIS
 .Nm
 .Cm create
+.Op Fl c Ar cpu-ms
+.Op Fl i Ar ipv4
+.Op Fl m Ar bytes
 .Ar root
 .Op command
 .Op Ar args ...
@@ -58,12 +61,23 @@ jail id, while the host root user (jail id 0) can access all processes.
 .Pp
 The commands are as follows:
 .Bl -tag -width Ds
-.It Cm create Ar root Op command Op Ar args ...
+.It Cm create Op Fl c Ar cpu-ms Op Fl i Ar ipv4 Op Fl m Ar bytes Ar root \
+    Op command Op Ar args ...
 Create a new jail id, change the root directory to
 .Ar root ,
 enter the jail, and execute
 .Ar command .
 If no command is provided, an interactive shell is started.
+.Pp
+The optional flags set per-jail limits and bind restrictions:
+.Bl -tag -width Ds
+.It Fl c Ar cpu-ms
+Set a CPU time limit (in milliseconds) for processes in the jail.
+.It Fl i Ar ipv4
+Restrict IPv4 socket binds inside the jail to the specified address.
+.It Fl m Ar bytes
+Set a virtual memory limit (in bytes) for processes in the jail.
+.El
 .It Cm destroy Ar jail-id
 Destroy a jail id that has no remaining processes.
 .It Cm enter Ar jail-id Ar root Op command Op Ar args ...

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -35,6 +35,7 @@ __RCSID("$NetBSD$");
 #include <sys/jail.h>
 #include <sys/sysctl.h>
 
+#include <arpa/inet.h>
 #include <err.h>
 #include <errno.h>
 #include <inttypes.h>
@@ -79,18 +80,29 @@ jail_fetch_list(size_t *countp)
 }
 
 static jailid_t
-jail_create(void)
+jail_create(const struct jail_create *create)
 {
 	jailid_t id;
 	size_t len;
 	int one;
 
 	id = 0;
-	len = sizeof(id);
-	one = 1;
-	if (sysctlbyname("security.models.jail.create", &id, &len,
-	    &one, sizeof(one)) == -1)
-		err(1, "create jail");
+	if (create != NULL) {
+		struct jail_create req;
+
+		req = *create;
+		len = sizeof(req);
+		if (sysctlbyname("security.models.jail.create", &req, &len,
+		    &req, sizeof(req)) == -1)
+			err(1, "create jail");
+		id = req.jc_id;
+	} else {
+		len = sizeof(id);
+		one = 1;
+		if (sysctlbyname("security.models.jail.create", &id, &len,
+		    &one, sizeof(one)) == -1)
+			err(1, "create jail");
+	}
 
 	return id;
 }
@@ -177,11 +189,51 @@ main(int argc, char *argv[])
 		usage();
 
 	if (strcmp(argv[1], "create") == 0) {
-		if (argc < 3)
+		struct jail_create create;
+		char *endp;
+		uintmax_t num;
+		struct in_addr addr;
+		int ch;
+
+		memset(&create, 0, sizeof(create));
+		optind = 2;
+		while ((ch = getopt(argc, argv, "c:i:m:")) != -1) {
+			switch (ch) {
+			case 'c':
+				errno = 0;
+				num = strtoumax(optarg, &endp, 0);
+				if (errno != 0 || *endp != '\0')
+					errx(1, "invalid cpu limit: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_CPULIMIT;
+				create.jc_cpu_limit = num;
+				break;
+			case 'i':
+				if (inet_pton(AF_INET, optarg, &addr) != 1)
+					errx(1, "invalid IPv4 address: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_BIND4;
+				create.jc_bind4 = addr.s_addr;
+				break;
+			case 'm':
+				errno = 0;
+				num = strtoumax(optarg, &endp, 0);
+				if (errno != 0 || *endp != '\0')
+					errx(1, "invalid memory limit: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_MEMLIMIT;
+				create.jc_mem_limit = num;
+				break;
+			default:
+				usage();
+			}
+		}
+
+		if (optind >= argc)
 			usage();
 
-		root = argv[2];
-		id = jail_create();
+		root = argv[optind];
+		if (create.jc_flags != 0)
+			id = jail_create(&create);
+		else
+			id = jail_create(NULL);
 
 		if (chdir(root) == -1 || chroot(".") == -1)
 			err(1, "%s", root);
@@ -194,9 +246,9 @@ main(int argc, char *argv[])
 		printf("jail %" PRIu32 "\n", id);
 		fflush(stdout);
 
-		if (argc > 3) {
-			execvp(argv[3], &argv[3]);
-			err(1, "%s", argv[3]);
+		if (argc > optind + 1) {
+			execvp(argv[optind + 1], &argv[optind + 1]);
+			err(1, "%s", argv[optind + 1]);
 		}
 
 		if ((shell = getenv("SHELL")) == NULL)
@@ -269,7 +321,8 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s create <root> [command [args...]]\n"
+	    "usage: %s create [-c cpu-ms] [-i ipv4] [-m bytes] <root> "
+	    "[command [args...]]\n"
 	    "       %s enter <jail-id> <root> [command [args...]]\n"
 	    "       %s destroy <jail-id>\n"
 	    "       %s list\n",


### PR DESCRIPTION
### Motivation
- Limit visibility of jail management sysctls to host root and provide lightweight per-jail resource controls so jails cannot see or modify other jails' state from inside a jail. 
- Allow setting per-jail memory and CPU limits at creation time and enforce them in the kernel for operational safety. 
- Permit assigning a single IPv4 address to a jail and restrict binds inside the jail to that address to simplify firewalling and reduce host-level attack surface.

### Description
- Add a `jail_create` structure and creation flags (`JAIL_CREATE_MEMLIMIT`, `JAIL_CREATE_CPULIMIT`, `JAIL_CREATE_BIND4`) to `sys/sys/jail.h` so structured create requests can carry limits and a bind address.
- Extend the secmodel_jail implementation (`sys/secmodel/jail/secmodel_jail.c`) to store per-jail configuration (cpu/memory limits and IPv4 bind), to apply `RLIMIT_CPU` and `RLIMIT_AS` via `dosetrlimit()` on jail `enter`, and to persist the config with the jail entry.
- Add a `KAUTH_SCOPE_NETWORK` listener in secmodel_jail that denies `bind(2)` calls to `INADDR_ANY` and denies binds to addresses other than the configured per-jail IPv4 when a bind address is configured for that jail.
- Harden sysctl handlers so jail management sysctls (create/list/id) properly restrict operations to host root where appropriate, and extend `security.models.jail.create` to accept and return the structured `jail_create` payload when provided.
- Update `usr.sbin/jailctl` to accept new create flags `-c cpu-ms`, `-m bytes`, `-i ipv4`, marshal them into `struct jail_create` and call the new sysctl create API; update usage and manpage (`jailctl.8`).

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698583d46178832ab660c7ede7a12284)