### PR TITLE
secmodel_jail: move jail name/root metadata into kernel and update jailctl

### DIFF
--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -67,6 +67,8 @@ static int	secmodel_jail_network_cb(kauth_cred_t, kauth_action_t,
  */
 struct jail_entry {
 	jailid_t je_id;
+	char je_name[JAIL_NAME_MAX + 1];
+	char je_root[JAIL_ROOT_MAX + 1];
 	bool je_has_cpu_limit;
 	bool je_has_mem_limit;
 	bool je_has_bind4;
@@ -153,6 +155,19 @@ secmodel_jail_lookup(jailid_t id)
 	return NULL;
 }
 
+static struct jail_entry *
+secmodel_jail_lookup_name(const char *name)
+{
+	struct jail_entry *entry;
+
+	LIST_FOREACH(entry, &jail_list, je_entry) {
+		if (strcmp(entry->je_name, name) == 0)
+			return entry;
+	}
+
+	return NULL;
+}
+
 static bool
 secmodel_jail_get_config(jailid_t id, struct jail_config *config)
 {
@@ -183,20 +198,32 @@ secmodel_jail_get_config(jailid_t id, struct jail_config *config)
  * for the host. Returns the new id to the caller.
  */
 static int
-secmodel_jail_create(const struct jail_config *config, jailid_t *idp)
+secmodel_jail_create(const struct jail_create *create,
+    const struct jail_config *config, jailid_t *idp)
 {
 	struct jail_entry *entry;
 	jailid_t id;
 
 	mutex_enter(&jail_lock);
+	if (create != NULL && create->jc_name[0] != '\0' &&
+	    secmodel_jail_lookup_name(create->jc_name) != NULL) {
+		mutex_exit(&jail_lock);
+		return EEXIST;
+	}
+
 	if (jail_next_id == 0) {
 		mutex_exit(&jail_lock);
 		return EOVERFLOW;
 	}
 
 	id = jail_next_id++;
+
 	entry = kmem_zalloc(sizeof(*entry), KM_SLEEP);
 	entry->je_id = id;
+	if (create != NULL) {
+		strlcpy(entry->je_name, create->jc_name, sizeof(entry->je_name));
+		strlcpy(entry->je_root, create->jc_root, sizeof(entry->je_root));
+	}
 	if (config != NULL) {
 		entry->je_has_cpu_limit = config->jc_has_cpu_limit;
 		entry->je_has_mem_limit = config->jc_has_mem_limit;
@@ -422,7 +449,17 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 		return EINVAL;
 	}
 
-	error = secmodel_jail_create(configp, &id);
+	if (newlen == sizeof(create)) {
+		if (create.jc_name[0] == '\0' || create.jc_root[0] == '\0')
+			return EINVAL;
+		if (memchr(create.jc_name, '\n', sizeof(create.jc_name)) != NULL ||
+		    memchr(create.jc_root, '\n', sizeof(create.jc_root)) != NULL)
+			return EINVAL;
+		error = secmodel_jail_create(&create, configp, &id);
+	} else {
+		error = secmodel_jail_create(NULL, configp, &id);
+	}
+
 	if (error != 0)
 		return error;
 
@@ -547,6 +584,10 @@ secmodel_jail_sysctl_list(SYSCTLFN_ARGS)
 	LIST_FOREACH(entry, &jail_list, je_entry) {
 		entries[i].ji_id = entry->je_id;
 		entries[i].ji_refcount = 0;
+		strlcpy(entries[i].ji_name, entry->je_name,
+		    sizeof(entries[i].ji_name));
+		strlcpy(entries[i].ji_root, entry->je_root,
+		    sizeof(entries[i].ji_root));
 		i++;
 	}
 	mutex_exit(&jail_lock);

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -33,6 +33,9 @@
 
 typedef uint32_t jailid_t;
 
+#define JAIL_NAME_MAX 63
+#define JAIL_ROOT_MAX 255
+
 #define JAILID_HOST 0
 
 #define JAIL_CREATE_MEMLIMIT	0x00000001
@@ -45,11 +48,15 @@ struct jail_create {
 	uint64_t jc_mem_limit;
 	uint64_t jc_cpu_limit;
 	uint32_t jc_bind4;
+	char jc_name[JAIL_NAME_MAX + 1];
+	char jc_root[JAIL_ROOT_MAX + 1];
 };
 
 struct jail_info {
 	jailid_t ji_id;
 	uint32_t ji_refcount;
+	char ji_name[JAIL_NAME_MAX + 1];
+	char ji_root[JAIL_ROOT_MAX + 1];
 };
 
 #endif /* !_SYS_JAIL_H_ */

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -37,6 +37,7 @@
 .Op Fl c Ar cpu-ms
 .Op Fl i Ar ipv4
 .Op Fl m Ar bytes
+.Fl n Ar name
 .Ar root
 .Op command
 .Op Ar args ...
@@ -44,9 +45,11 @@
 .Cm destroy
 .Ar jail-id
 .Nm
-.Cm enter
-.Ar jail-id
-.Ar root
+.Cm attach
+.Ar jail-id | name
+.Nm
+.Cm exec
+.Ar jail-id | name
 .Op command
 .Op Ar args ...
 .Nm
@@ -61,13 +64,16 @@ jail id, while the host root user (jail id 0) can access all processes.
 .Pp
 The commands are as follows:
 .Bl -tag -width Ds
-.It Cm create Op Fl c Ar cpu-ms Op Fl i Ar ipv4 Op Fl m Ar bytes Ar root \
+.It Cm create Op Fl c Ar cpu-ms Op Fl i Ar ipv4 Op Fl m Ar bytes Fl n Ar name Ar root \
     Op command Op Ar args ...
-Create a new jail id, change the root directory to
-.Ar root ,
-enter the jail, and execute
-.Ar command .
-If no command is provided, an interactive shell is started.
+Create a new jail id, assign it the unique
+.Ar name ,
+store jail name and root metadata in the kernel jail model, and start
+.Ar command
+in the background inside the jail.
+If no command is provided, an interactive shell is started in the background.
+The command can later be reached via
+.Cm attach .
 .Pp
 The optional flags set per-jail limits and bind restrictions:
 .Bl -tag -width Ds
@@ -80,16 +86,24 @@ Set a virtual memory limit (in bytes) for processes in the jail.
 .El
 .It Cm destroy Ar jail-id
 Destroy a jail id that has no remaining processes.
-.It Cm enter Ar jail-id Ar root Op command Op Ar args ...
-Enter a jail with id
-.Ar jail-id ,
-change the root directory to
-.Ar root ,
-and execute
+.It Cm attach Ar jail-id | name
+Attach the local terminal to the background command started with
+.Cm create
+for jail
+.Ar jail-id
+or
+.Ar name ,
+providing interactive stdin/stdout/stderr forwarding.
+.It Cm exec Ar jail-id | name Op command Op Ar args ...
+Enter a running jail selected by
+.Ar jail-id
+or
+.Ar name
+using the root stored in kernel jail metadata and execute
 .Ar command .
 If no command is provided, an interactive shell is started.
 .It Cm list
-List active jail ids and their process counts.
+List active jail ids, process counts, configured jail names, and roots.
 .El
 .Sh SEE ALSO
 .Xr chroot 2 ,

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -34,19 +34,55 @@ __RCSID("$NetBSD$");
 #include <sys/types.h>
 #include <sys/jail.h>
 #include <sys/sysctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
 
 #include <arpa/inet.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
+#include <limits.h>
+#include <poll.h>
 #include <paths.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <termios.h>
 #include <unistd.h>
+#include <util.h>
+#include <sys/wait.h>
+
+#define JAILCTL_STATEDIR "/var/run/jailctl"
+#define JAILCTL_CMD_MAX 511
+
+struct jail_context {
+	jailid_t	id;
+	char		command[JAILCTL_CMD_MAX + 1];
+	int		stdin_fd;
+	int		stdout_fd;
+	int		stderr_fd;
+	char		sockpath[PATH_MAX];
+};
 
 static void	usage(void) __dead;
+
+static void	jail_attach(const struct jail_context *);
+static void	jail_exec(jailid_t, const char *, char *[]);
+static void	jail_run_manager(const struct jail_context *, int, pid_t);
+static void	jail_spawn_detached(jailid_t, const char *, const struct jail_context *, char *[]);
+static void	path_context(jailid_t, char *, size_t);
+static void	path_socket(jailid_t, char *, size_t);
+static void	sanitize_field(const char *, char *, size_t);
+static bool	context_load(jailid_t, struct jail_context *);
+static bool	jail_lookup_by_name(const char *, struct jail_info *);
+static bool	jail_lookup_by_id(jailid_t, struct jail_info *);
+static bool	context_save(const struct jail_context *);
+static void	context_delete(jailid_t);
+static void	build_command_line(int, char *[], char *, size_t);
+static jailid_t	resolve_jail_target(const char *, struct jail_info *);
 
 static struct jail_info *
 jail_fetch_list(size_t *countp)
@@ -135,12 +171,380 @@ jail_list(void)
 		return;
 	}
 
-	printf("%-8s %-8s\n", "ID", "PROCS");
-	for (i = 0; i < count; i++)
-		printf("%-8" PRIu32 " %-8" PRIu32 "\n",
-		    entries[i].ji_id, entries[i].ji_refcount);
+	printf("%-8s %-8s %-16s %s\n", "ID", "PROCS", "NAME", "ROOT");
+	for (i = 0; i < count; i++) {
+		printf("%-8" PRIu32 " %-8" PRIu32 " %-16s %s\n",
+		    entries[i].ji_id, entries[i].ji_refcount,
+		    entries[i].ji_name[0] != '\0' ? entries[i].ji_name : "-",
+		    entries[i].ji_root[0] != '\0' ? entries[i].ji_root : "-");
+	}
 
 	free(entries);
+}
+
+static void
+path_context(jailid_t id, char *path, size_t sz)
+{
+
+	(void)snprintf(path, sz, "%s/%" PRIu32 ".ctx", JAILCTL_STATEDIR, id);
+}
+
+static void
+path_socket(jailid_t id, char *path, size_t sz)
+{
+
+	(void)snprintf(path, sz, "%s/%" PRIu32 ".sock", JAILCTL_STATEDIR, id);
+}
+
+static void
+sanitize_field(const char *src, char *dst, size_t dsz)
+{
+	size_t i, j;
+
+	for (i = 0, j = 0; src[i] != '\0' && j + 1 < dsz; i++) {
+		if (src[i] == '\n' || src[i] == '\r' || src[i] == '\t')
+			dst[j++] = ' ';
+		else
+			dst[j++] = src[i];
+	}
+	dst[j] = '\0';
+}
+
+static bool
+context_save(const struct jail_context *ctx)
+{
+	char path[PATH_MAX];
+	FILE *fp;
+
+	if (mkdir(JAILCTL_STATEDIR, 0700) == -1 && errno != EEXIST)
+		err(1, "mkdir %s", JAILCTL_STATEDIR);
+
+	path_context(ctx->id, path, sizeof(path));
+	fp = fopen(path, "w");
+	if (fp == NULL)
+		err(1, "%s", path);
+
+	if (fprintf(fp, "command=%s\nstdin=%d\nstdout=%d\nstderr=%d\nsock=%s\n",
+	    ctx->command, ctx->stdin_fd,
+	    ctx->stdout_fd, ctx->stderr_fd, ctx->sockpath) < 0)
+		err(1, "write %s", path);
+
+	if (fclose(fp) == EOF)
+		err(1, "close %s", path);
+
+	return true;
+}
+
+static bool
+context_load(jailid_t id, struct jail_context *ctx)
+{
+	char path[PATH_MAX], line[PATH_MAX + JAILCTL_CMD_MAX + 32];
+	FILE *fp;
+
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->id = id;
+	path_context(id, path, sizeof(path));
+	fp = fopen(path, "r");
+	if (fp == NULL)
+		return false;
+
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		char *eq, *nl;
+
+		eq = strchr(line, '=');
+		if (eq == NULL)
+			continue;
+		*eq++ = '\0';
+		nl = strchr(eq, '\n');
+		if (nl != NULL)
+			*nl = '\0';
+
+		if (strcmp(line, "command") == 0)
+			strlcpy(ctx->command, eq, sizeof(ctx->command));
+		else if (strcmp(line, "stdin") == 0)
+			ctx->stdin_fd = atoi(eq);
+		else if (strcmp(line, "stdout") == 0)
+			ctx->stdout_fd = atoi(eq);
+		else if (strcmp(line, "stderr") == 0)
+			ctx->stderr_fd = atoi(eq);
+		else if (strcmp(line, "sock") == 0)
+			strlcpy(ctx->sockpath, eq, sizeof(ctx->sockpath));
+	}
+
+	(void)fclose(fp);
+	return ctx->sockpath[0] != '\0';
+}
+
+static bool
+jail_lookup_by_id(jailid_t id, struct jail_info *jip)
+{
+	struct jail_info *entries;
+	size_t count, i;
+
+	entries = jail_fetch_list(&count);
+	for (i = 0; i < count; i++) {
+		if (entries[i].ji_id == id) {
+			*jip = entries[i];
+			free(entries);
+			return true;
+		}
+	}
+	free(entries);
+	return false;
+}
+
+static bool
+jail_lookup_by_name(const char *name, struct jail_info *jip)
+{
+	struct jail_info *entries;
+	size_t count, i;
+
+	entries = jail_fetch_list(&count);
+	for (i = 0; i < count; i++) {
+		if (strcmp(entries[i].ji_name, name) == 0) {
+			*jip = entries[i];
+			free(entries);
+			return true;
+		}
+	}
+	free(entries);
+	return false;
+}
+
+static void
+context_delete(jailid_t id)
+{
+	char path[PATH_MAX], sock[PATH_MAX];
+
+	path_context(id, path, sizeof(path));
+	if (unlink(path) == -1 && errno != ENOENT)
+		warn("unlink %s", path);
+
+	path_socket(id, sock, sizeof(sock));
+	if (unlink(sock) == -1 && errno != ENOENT)
+		warn("unlink %s", sock);
+}
+
+static void
+build_command_line(int argc, char *argv[], char *dst, size_t dsz)
+{
+	size_t used;
+	int i;
+
+	if (argc <= 0) {
+		dst[0] = '\0';
+		return;
+	}
+
+	used = 0;
+	for (i = 0; i < argc; i++) {
+		int n;
+
+		n = snprintf(dst + used, dsz - used, "%s%s",
+		    i == 0 ? "" : " ", argv[i]);
+		if (n < 0 || (size_t)n >= dsz - used)
+			break;
+		used += (size_t)n;
+	}
+
+	dst[dsz - 1] = '\0';
+}
+
+static void
+jail_exec(jailid_t id, const char *root, char *cmd[])
+{
+	const char *shell;
+
+	if (chdir(root) == -1 || chroot(".") == -1)
+		err(1, "%s", root);
+
+	if (chdir("/") == -1)
+		err(1, "/");
+
+	jail_enter(id);
+
+	if (cmd != NULL) {
+		execvp(cmd[0], cmd);
+		err(1, "%s", cmd[0]);
+	}
+
+	if ((shell = getenv("SHELL")) == NULL)
+		shell = _PATH_BSHELL;
+	execlp(shell, shell, "-i", NULL);
+	err(1, "%s", shell);
+}
+
+static void
+jail_run_manager(const struct jail_context *ctx, int pty_master, pid_t child)
+{
+	int server, client;
+	struct sockaddr_un sun;
+
+	server = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (server == -1)
+		err(1, "socket");
+
+	memset(&sun, 0, sizeof(sun));
+	sun.sun_family = AF_UNIX;
+	strlcpy(sun.sun_path, ctx->sockpath, sizeof(sun.sun_path));
+	unlink(ctx->sockpath);
+
+	if (bind(server, (struct sockaddr *)&sun, sizeof(sun)) == -1)
+		err(1, "bind %s", ctx->sockpath);
+	if (listen(server, 1) == -1)
+		err(1, "listen %s", ctx->sockpath);
+
+	for (;;) {
+		struct pollfd pfd;
+		int rv, status;
+
+		if (waitpid(child, &status, WNOHANG) == child)
+			break;
+
+		pfd.fd = server;
+		pfd.events = POLLIN;
+		rv = poll(&pfd, 1, 500);
+		if (rv <= 0)
+			continue;
+
+		client = accept(server, NULL, NULL);
+		if (client == -1)
+			continue;
+
+		for (;;) {
+			struct pollfd io[2];
+			char buf[4096];
+			ssize_t n;
+
+			io[0].fd = client;
+			io[0].events = POLLIN;
+			io[1].fd = pty_master;
+			io[1].events = POLLIN;
+
+			rv = poll(io, 2, 500);
+			if (rv == -1 && errno == EINTR)
+				continue;
+			if (rv <= 0) {
+				if (waitpid(child, &status, WNOHANG) == child)
+					goto out;
+				continue;
+			}
+
+			if (io[0].revents & POLLIN) {
+				n = read(client, buf, sizeof(buf));
+				if (n <= 0 || write(pty_master, buf, (size_t)n) == -1)
+					break;
+			}
+
+			if (io[1].revents & POLLIN) {
+				n = read(pty_master, buf, sizeof(buf));
+				if (n <= 0 || write(client, buf, (size_t)n) == -1)
+					break;
+			}
+		}
+
+		close(client);
+	}
+out:
+	close(server);
+	close(pty_master);
+	context_delete(ctx->id);
+	_exit(0);
+}
+
+static void
+jail_spawn_detached(jailid_t id, const char *root, const struct jail_context *ctx, char *cmd[])
+{
+	int mfd, sfd;
+	pid_t child, mgr;
+
+	if (openpty(&mfd, &sfd, NULL, NULL, NULL) == -1)
+		err(1, "openpty");
+
+	child = fork();
+	if (child == -1)
+		err(1, "fork");
+	if (child == 0) {
+		close(mfd);
+		if (dup2(sfd, STDIN_FILENO) == -1 ||
+		    dup2(sfd, STDOUT_FILENO) == -1 ||
+		    dup2(sfd, STDERR_FILENO) == -1)
+			err(1, "dup2");
+		if (sfd > STDERR_FILENO)
+			close(sfd);
+		jail_exec(id, root, cmd);
+	}
+
+	close(sfd);
+
+	mgr = fork();
+	if (mgr == -1)
+		err(1, "fork");
+	if (mgr == 0)
+		jail_run_manager(ctx, mfd, child);
+
+	close(mfd);
+	printf("jail %" PRIu32 "\n", id);
+}
+
+static void
+jail_attach(const struct jail_context *ctx)
+{
+	int fd, rv;
+	struct sockaddr_un sun;
+	struct termios oldt, raw;
+	bool tty;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd == -1)
+		err(1, "socket");
+
+	memset(&sun, 0, sizeof(sun));
+	sun.sun_family = AF_UNIX;
+	strlcpy(sun.sun_path, ctx->sockpath, sizeof(sun.sun_path));
+
+	if (connect(fd, (struct sockaddr *)&sun, sizeof(sun)) == -1)
+		err(1, "connect %s", ctx->sockpath);
+
+	tty = isatty(STDIN_FILENO);
+	if (tty && tcgetattr(STDIN_FILENO, &oldt) == 0) {
+		raw = oldt;
+		cfmakeraw(&raw);
+		(void)tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+	}
+
+	for (;;) {
+		struct pollfd io[2];
+		char buf[4096];
+		ssize_t n;
+
+		io[0].fd = STDIN_FILENO;
+		io[0].events = POLLIN;
+		io[1].fd = fd;
+		io[1].events = POLLIN;
+
+		rv = poll(io, 2, -1);
+		if (rv == -1 && errno == EINTR)
+			continue;
+		if (rv <= 0)
+			break;
+
+		if (io[0].revents & POLLIN) {
+			n = read(STDIN_FILENO, buf, sizeof(buf));
+			if (n <= 0 || write(fd, buf, (size_t)n) == -1)
+				break;
+		}
+
+		if (io[1].revents & POLLIN) {
+			n = read(fd, buf, sizeof(buf));
+			if (n <= 0 || write(STDOUT_FILENO, buf, (size_t)n) == -1)
+				break;
+		}
+	}
+
+	if (tty)
+		(void)tcsetattr(STDIN_FILENO, TCSAFLUSH, &oldt);
+	close(fd);
 }
 
 static int
@@ -175,15 +579,33 @@ parse_jailid(const char *arg)
 	return (jailid_t)num;
 }
 
+static jailid_t
+resolve_jail_target(const char *arg, struct jail_info *ji)
+{
+	uintmax_t num;
+
+	if (getnum(arg, &num) == 0 && num <= UINT32_MAX) {
+		if (!jail_lookup_by_id((jailid_t)num, ji))
+			errx(1, "jail %" PRIu32 " not found", (jailid_t)num);
+		return (jailid_t)num;
+	}
+
+	if (jail_lookup_by_name(arg, ji))
+		return ji->ji_id;
+
+	errx(1, "jail '%s' not found", arg);
+}
+
 int
 main(int argc, char *argv[])
 {
 	jailid_t id;
-	struct jail_info *entries;
 	const char *root;
+	const char *name;
 	const char *shell;
-	size_t count, i;
-	bool found;
+	char cmdbuf[JAILCTL_CMD_MAX + 1];
+	struct jail_context ctx;
+	struct jail_info ji;
 
 	if (argc < 2)
 		usage();
@@ -196,8 +618,9 @@ main(int argc, char *argv[])
 		int ch;
 
 		memset(&create, 0, sizeof(create));
+		name = NULL;
 		optind = 2;
-		while ((ch = getopt(argc, argv, "c:i:m:")) != -1) {
+		while ((ch = getopt(argc, argv, "c:i:m:n:")) != -1) {
 			switch (ch) {
 			case 'c':
 				errno = 0;
@@ -221,40 +644,48 @@ main(int argc, char *argv[])
 				create.jc_flags |= JAIL_CREATE_MEMLIMIT;
 				create.jc_mem_limit = num;
 				break;
+			case 'n':
+				name = optarg;
+				break;
 			default:
 				usage();
 			}
 		}
 
-		if (optind >= argc)
+		if (optind >= argc || name == NULL)
 			usage();
+		if (strlen(name) > JAIL_NAME_MAX)
+			errx(1, "name too long");
+
+		if (jail_lookup_by_name(name, &ji))
+			errx(1, "name already exists: %s", name);
 
 		root = argv[optind];
-		if (create.jc_flags != 0)
-			id = jail_create(&create);
-		else
-			id = jail_create(NULL);
+		sanitize_field(name, create.jc_name, sizeof(create.jc_name));
+		sanitize_field(root, create.jc_root, sizeof(create.jc_root));
+		id = jail_create(&create);
 
-		if (chdir(root) == -1 || chroot(".") == -1)
-			err(1, "%s", root);
-
-		if (chdir("/") == -1)
-			err(1, "/");
-
-		jail_enter(id);
-
-		printf("jail %" PRIu32 "\n", id);
-		fflush(stdout);
-
+		memset(&ctx, 0, sizeof(ctx));
+		ctx.id = id;
+		ctx.stdin_fd = STDIN_FILENO;
+		ctx.stdout_fd = STDOUT_FILENO;
+		ctx.stderr_fd = STDERR_FILENO;
 		if (argc > optind + 1) {
-			execvp(argv[optind + 1], &argv[optind + 1]);
-			err(1, "%s", argv[optind + 1]);
+			build_command_line(argc - (optind + 1), &argv[optind + 1],
+			    cmdbuf, sizeof(cmdbuf));
+			sanitize_field(cmdbuf, cmdbuf, sizeof(cmdbuf));
+		} else {
+			if ((shell = getenv("SHELL")) == NULL)
+				shell = _PATH_BSHELL;
+			sanitize_field(shell, cmdbuf, sizeof(cmdbuf));
 		}
+		strlcpy(ctx.command, cmdbuf, sizeof(ctx.command));
+		path_socket(id, ctx.sockpath, sizeof(ctx.sockpath));
+		(void)context_save(&ctx);
 
-		if ((shell = getenv("SHELL")) == NULL)
-			shell = _PATH_BSHELL;
-		execlp(shell, shell, "-i", NULL);
-		err(1, "%s", shell);
+		jail_spawn_detached(id, create.jc_root, &ctx,
+		    argc > optind + 1 ? &argv[optind + 1] : NULL);
+		return 0;
 	}
 
 	if (strcmp(argv[1], "destroy") == 0) {
@@ -263,46 +694,28 @@ main(int argc, char *argv[])
 
 		id = parse_jailid(argv[2]);
 		jail_destroy(id);
+		context_delete(id);
 		return 0;
 	}
 
-	if (strcmp(argv[1], "enter") == 0) {
-		if (argc < 4)
+	if (strcmp(argv[1], "exec") == 0) {
+		if (argc < 3)
 			usage();
 
-		id = parse_jailid(argv[2]);
-		root = argv[3];
-		found = false;
+		id = resolve_jail_target(argv[2], &ji);
 
-		entries = jail_fetch_list(&count);
-		for (i = 0; i < count; i++) {
-			if (entries[i].ji_id == id) {
-				found = true;
-				break;
-			}
-		}
-		free(entries);
+		jail_exec(id, ji.ji_root, argc > 3 ? &argv[3] : NULL);
+	}
 
-		if (!found)
-			errx(1, "jail %" PRIu32 " not found", id);
+	if (strcmp(argv[1], "attach") == 0) {
+		if (argc != 3)
+			usage();
 
-		if (chdir(root) == -1 || chroot(".") == -1)
-			err(1, "%s", root);
-
-		if (chdir("/") == -1)
-			err(1, "/");
-
-		jail_enter(id);
-
-		if (argc > 4) {
-			execvp(argv[4], &argv[4]);
-			err(1, "%s", argv[4]);
-		}
-
-		if ((shell = getenv("SHELL")) == NULL)
-			shell = _PATH_BSHELL;
-		execlp(shell, shell, "-i", NULL);
-		err(1, "%s", shell);
+		id = resolve_jail_target(argv[2], &ji);
+		if (!context_load(id, &ctx))
+			errx(1, "context for jail %" PRIu32 " not found", id);
+		jail_attach(&ctx);
+		return 0;
 	}
 
 	if (strcmp(argv[1], "list") == 0) {
@@ -321,11 +734,13 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s create [-c cpu-ms] [-i ipv4] [-m bytes] <root> "
+	    "usage: %s create [-c cpu-ms] [-i ipv4] [-m bytes] -n name <root> "
 	    "[command [args...]]\n"
-	    "       %s enter <jail-id> <root> [command [args...]]\n"
+	    "       %s attach <jail-id|name>\n"
+	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id>\n"
 	    "       %s list\n",
-	    getprogname(), getprogname(), getprogname(), getprogname());
+	    getprogname(), getprogname(), getprogname(), getprogname(),
+	    getprogname());
 	exit(1);
 }


### PR DESCRIPTION
### Motivation
- Implement a long-term clean design where canonical jail identity (name) and root live in kernel metadata rather than only in userland state files.
- Allow `jailctl` to resolve jails by either id or persistent name and to use kernel-stored root for `exec` so userland/state files only carry transient attach/session data.

### Description
- Extend the kernel ABI in `sys/sys/jail.h` by adding bounded `jc_name`/`jc_root` to `struct jail_create` and `ji_name`/`ji_root` to `struct jail_info`.
- Persist `name` and `root` in secmodel-jail entries and expose them via `security.models.jail.list`, enforce unique names under `jail_lock`, and validate create payloads for non-empty/no-newline metadata in `secmodel_jail` (`sys/secmodel/jail/secmodel_jail.c`).
- Refactor `jailctl` (`usr.sbin/jailctl/jailctl.c`) to fetch name/root from kernel `jail_info` for `list`, to resolve a target by id or name via the kernel list, to use kernel `root` for `exec`, and to keep only session-specific data (command/stdio/socket) in `/var/run/jailctl/*.ctx` files.
- Update the `jailctl(8)` man page to document name/id lookup and that name/root are kernel-managed metadata.

### Testing
- Performed source-level verification and cross-file inspections with `rg`, `sed`, Python scripts, and NUL-byte scans to confirm the intended diffs and in-tree consistency, all succeeded.
- Attempted a local syntax check `cc -std=c99 -Wall -Wextra -Werror -I./sys -I./usr.sbin/jailctl -fsyntax-only usr.sbin/jailctl/jailctl.c` which failed in this environment due to missing NetBSD target headers (e.g. `machine/cdefs.h`), so a full build could not be completed.
- Committed the changes and verified diffs; no automated kernel/userland runtime tests were run in this container due to missing build/runtime environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986d89c1394832ab1d44d3f11b00626)