### PR TITLE
jailctl: link libutil for openpty

### DIFF
--- a/usr.sbin/jailctl/Makefile
+++ b/usr.sbin/jailctl/Makefile
@@ -3,4 +3,7 @@
 PROG=jailctl
 MAN=jailctl.8
 
+DPADD+=	${LIBUTIL}
+LDADD+=	-lutil
+
 .include <bsd.prog.mk>


### PR DESCRIPTION
### Motivation
- `jailctl` calls `openpty(3)`, which is provided by `libutil`, and the missing linkage caused an undefined reference at link time.

### Description
- Add `DPADD+= ${LIBUTIL}` and `LDADD+= -lutil` to `usr.sbin/jailctl/Makefile` so the `jailctl` binary is linked against `libutil`.

### Testing
- Ran `make -n jailctl`, which failed in this environment because GNU `make` rejects BSD `Makefile` syntax, and `bmake -n jailctl` is not available here, so the actual link step could not be executed in-container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872fdfd838832a8f8cb45d38824759)