### PR TITLE
uvm: declare jail memlimit hook as extern

### DIFF
--- a/sys/uvm/uvm_extern.h
+++ b/sys/uvm/uvm_extern.h
@@ -694,7 +694,7 @@ void			uvm_cpu_attach(struct cpu_info *);
  * UVM owns the call sites, while secmodel_jail (or another consumer) owns
  * the policy decision and can return non-zero to reject the growth.
  */
-int			(*uvm_proc_jail_memlimit_check)(struct proc *, size_t);
+extern int		(*uvm_proc_jail_memlimit_check)(struct proc *, size_t);
 
 
 /* uvm_init.c */


### PR DESCRIPTION
### Motivation
- Change `uvm_proc_jail_memlimit_check` from a tentative definition to an `extern` declaration to prevent duplicate symbol emission and resolve the linker error `multiple definition of 'rumpns_uvm_proc_jail_memlimit_check'` seen when building `librump.so`.

### Description
- Update `sys/uvm/uvm_extern.h` to replace `int (*uvm_proc_jail_memlimit_check)(struct proc *, size_t);` with `extern int (*uvm_proc_jail_memlimit_check)(struct proc *, size_t);`.

### Testing
- Attempted to run `nbmake -C lib/librump dependall` but `nbmake` is not available in this environment (command not found), and verified the header change with `git diff` and `rg` before committing the patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ccce838c832a8251bb993b6eef44)