### PR TITLE
secmodel_jail: forward-declare `struct jail_config` to fix prototype conflicts

### DIFF
--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -62,6 +62,8 @@ static kauth_listener_t l_network;
 static secmodel_t jail_sm;
 static kauth_key_t jail_key;
 
+struct jail_config;
+
 enum jail_resource_mode {
 	JAIL_RESOURCE_RLIMIT = 0,
 	JAIL_RESOURCE_AGGREGATE = 1,


### PR DESCRIPTION
### Motivation
- Resolve `-Werror` compilation failures caused by a block-scoped incomplete `struct jail_config` introduced via parameter lists so prototypes and the later file-scope `struct` definition refer to the same type.

### Description
- Add a forward declaration `struct jail_config;` near the top of `sys/secmodel/jail/secmodel_jail.c` so static function prototypes using `const struct jail_config *` are consistent with the later `struct jail_config` definition.

### Testing
- Attempted automated build checks with `nbmake` and `bmake` (invoked as `cd sys/modules/secmodel_jail && nbmake secmodel_jail.o` and `cd sys/modules/secmodel_jail && bmake secmodel_jail.o`) but the tools are not available in this execution environment so the change could not be built here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69890ad95df8832a880918cecf5b3a99)