### PR TITLE
mtree: add /usr/share/examples/jailmgr to NetBSD.dist.base

### DIFF
--- a/etc/mtree/NetBSD.dist.base
+++ b/etc/mtree/NetBSD.dist.base
@@ -493,6 +493,7 @@
 ./usr/share/examples/getdate
 ./usr/share/examples/hostapd
 ./usr/share/examples/ipf
+./usr/share/examples/jailmgr
 ./usr/share/examples/kerberos
 ./usr/share/examples/kyua-cli
 ./usr/share/examples/libsaslc


### PR DESCRIPTION
### Motivation
- The `./usr/share/examples/jailmgr` directory was not predeclared in the mtree manifest, causing `make release`/`install` to fail with `mkstemp: No such file or directory` when installing jailmgr example files.

### Description
- Add the missing `./usr/share/examples/jailmgr` entry to `etc/mtree/NetBSD.dist.base` so the examples directory is declared during install/release stages.

### Testing
- Verified the new entry exists using `rg -n "usr/share/examples/jailmgr" etc/mtree/NetBSD.dist.base`, which succeeded. 
- Verified the file contents at the expected location with `nl -ba etc/mtree/NetBSD.dist.base | sed -n '488,502p'`, which showed the inserted line. 
- Created a commit (metadata-only change) to record the update, and `git status --short` shows a clean working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69897fee13f4832a8f36f0b27a563db0)