### PR TITLE
distrib/sets: add missing jailmgr and secmodel_jail entries to set lists

### DIFF
--- a/distrib/sets/lists/base/mi
+++ b/distrib/sets/lists/base/mi
@@ -1560,6 +1560,7 @@
 ./usr/sbin/ispppcontrol				base-obsolete		obsolete
 ./usr/sbin/iwictl				base-sysutil-bin
 ./usr/sbin/jailctl				base-sysutil-bin
+./usr/sbin/jailmgr				base-sysutil-bin
 ./usr/sbin/kadmin				base-krb5-bin		kerberos
 ./usr/sbin/kcm					base-krb5-bin		kerberos
 ./usr/sbin/kdc					base-krb5-bin		kerberos
@@ -2514,6 +2515,9 @@
 ./usr/share/examples/hostapd			base-netutil-examples
 ./usr/share/examples/ipf			base-netutil-examples
 ./usr/share/examples/isdn			base-obsolete	obsolete
+./usr/share/examples/jailmgr			base-sysutil-examples
+./usr/share/examples/jailmgr/README		base-sysutil-examples	share
+./usr/share/examples/jailmgr/jailmgr.conf.sample	base-sysutil-examples	share
 ./usr/share/examples/kerberos			base-krb5-examples
 ./usr/share/examples/lua			base-sys-examples
 ./usr/share/examples/lua/README			base-sys-examples	share

--- a/distrib/sets/lists/comp/mi
+++ b/distrib/sets/lists/comp/mi
@@ -20964,6 +20964,7 @@
 ./usr/share/man/html9/secmodel_deregister.html	comp-sys-htmlman	html
 ./usr/share/man/html9/secmodel_eval.html	comp-sys-htmlman	html
 ./usr/share/man/html9/secmodel_extensions.html	comp-sys-htmlman	html
+./usr/share/man/html9/secmodel_jail.html	comp-sys-htmlman	html
 ./usr/share/man/html9/secmodel_overlay.html	comp-sys-htmlman	html
 ./usr/share/man/html9/secmodel_register.html	comp-sys-htmlman	html
 ./usr/share/man/html9/secmodel_securelevel.html comp-sys-htmlman	html
@@ -29501,6 +29502,7 @@
 ./usr/share/man/man9/secmodel_deregister.9	comp-sys-man		.man
 ./usr/share/man/man9/secmodel_eval.9		comp-sys-man		.man
 ./usr/share/man/man9/secmodel_extensions.9	comp-sys-man		.man
+./usr/share/man/man9/secmodel_jail.9		comp-sys-man		.man
 ./usr/share/man/man9/secmodel_overlay.9		comp-sys-man		.man
 ./usr/share/man/man9/secmodel_register.9	comp-sys-man		.man
 ./usr/share/man/man9/secmodel_securelevel.9	comp-sys-man		.man

--- a/distrib/sets/lists/man/mi
+++ b/distrib/sets/lists/man/mi
@@ -6133,6 +6133,7 @@
 ./usr/share/man/html8/iteconfig.html		man-sysutil-htmlman	html
 ./usr/share/man/html8/iwictl.html		man-sysutil-htmlman	html
 ./usr/share/man/html8/jailctl.html		man-sysutil-htmlman	html
+./usr/share/man/html8/jailmgr.html		man-sysutil-htmlman	html
 ./usr/share/man/html8/kadmin.html		man-krb5-htmlman	kerberos,html
 ./usr/share/man/html8/kadmind.html		man-krb5-htmlman	kerberos,html
 ./usr/share/man/html8/kcm.html			man-krb5-htmlman	kerberos,html
@@ -9510,6 +9511,7 @@
 ./usr/share/man/man8/iteconfig.8		man-sysutil-man		.man
 ./usr/share/man/man8/iwictl.8			man-sysutil-man		.man
 ./usr/share/man/man8/jailctl.8			man-sysutil-man		.man
+./usr/share/man/man8/jailmgr.8			man-sysutil-man		.man
 ./usr/share/man/man8/kadmin.8			man-krb5-man		kerberos,.man
 ./usr/share/man/man8/kadmind.8			man-krb5-man		kerberos,.man
 ./usr/share/man/man8/kcm.8			man-krb5-man		kerberos,.man


### PR DESCRIPTION
### Motivation
- Fix a release-time `checkflist` failure caused by files present in DESTDIR but missing from the distrib set lists (the `jailmgr` binary, its example files, and the related manpages). 

### Description
- Add `./usr/sbin/jailmgr` and example files to `distrib/sets/lists/base/mi` (`./usr/share/examples/jailmgr`, `README`, and `jailmgr.conf.sample`).
- Add `./usr/share/man/html8/jailmgr.html` and `./usr/share/man/man8/jailmgr.8` to `distrib/sets/lists/man/mi`.
- Add `./usr/share/man/html9/secmodel_jail.html` and `./usr/share/man/man9/secmodel_jail.9` to `distrib/sets/lists/comp/mi`.

### Testing
- Verified each previously missing path is now present by running `rg -n` against the modified list files and confirming matches for all added entries.
- Inspected the modified regions with `nl -ba` and `sed` to confirm insertion positions and surrounding context.
- Reviewed the produced diff to ensure only the intended lines were inserted and no other list entries were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989cf829814832a87338b999c3ed1a2)