### PR TITLE
jailctl: forward detached jail I/O to syslog; simplify attach flow; harden jailmgr stop

### DIFF
--- a/usr.sbin/jailctl/examples/jailmgr
+++ b/usr.sbin/jailctl/examples/jailmgr
@@ -61,7 +61,7 @@ Commands:
   host-net-down                  Remove host aliases for all jail IPs
   start-jail <name> <ip>         Mount jail root and start jail via jailctl
   start-all                      Alias host IPs and start all jails listed in JAIL_LIST
-  stop-jail <name>               Destroy one jail and unmount root
+  stop-jail <name>               Gracefully stop one jail, then destroy and unmount root
   stop-all                       Stop all jails listed in JAIL_LIST
   npf-sync                       Generate/update NPF rdr snippet from NPF_RDR_LIST
   status                         Show jailctl list and mount status
@@ -80,12 +80,52 @@ need_root() {
 }
 
 require_tools() {
-	for t in jailctl tar mount umount ifconfig; do
+	for t in jailctl tar mount umount ifconfig ps; do
 		command -v "${t}" >/dev/null 2>&1 || {
 			echo "missing required tool: ${t}" >&2
 			exit 1
 		}
 	done
+}
+
+jail_pids() {
+	jid=$1
+	ps -axo pid=,jid= | awk -v j="${jid}" '$2==j{print $1}'
+}
+
+jail_monitor_pid() {
+	name=$1
+	jid=$2
+	ps -axo pid=,command= | awk -v n="${name}" -v j="${jid}" '
+		$0 ~ "jailctl monitor jail=" n " jid=" j { print $1; exit }
+	'
+}
+
+stop_jail_processes() {
+	name=$1
+	jid=$2
+	monitor_pid=$(jail_monitor_pid "${name}" "${jid}" || true)
+
+	# Best effort inside-jail shutdown hook.
+	jailctl exec "${jid}" /bin/sh -c 'if [ -x /etc/rc.shutdown ]; then /etc/rc.shutdown; fi' >/dev/null 2>&1 || true
+
+	for sig in TERM KILL; do
+		pids=$(jail_pids "${jid}" | tr '\n' ' ')
+		[ -n "${pids}" ] || break
+		# shellcheck disable=SC2086
+		kill -${sig} ${pids} >/dev/null 2>&1 || true
+		for _ in 1 2 3 4 5; do
+			sleep 1
+			pids=$(jail_pids "${jid}" | tr '\n' ' ')
+			[ -z "${pids}" ] && break
+		done
+	done
+
+	if [ -n "${monitor_pid}" ]; then
+		kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
+		sleep 1
+		kill -KILL "${monitor_pid}" >/dev/null 2>&1 || true
+	fi
 }
 
 fetch_sets() {
@@ -320,6 +360,7 @@ stop_jail() {
 
 	if jail_exists "${name}"; then
 		jid=$(jailctl list | awk -v n="${name}" '$3==n{print $1}')
+		stop_jail_processes "${name}" "${jid}"
 		jailctl destroy "${jid}"
 		echo "Destroyed jail ${name} (jid ${jid})"
 	fi

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -35,6 +35,7 @@
 .Nm
 .Cm create
 .Op Fl c Ar cpu-ms
+.Op Fl f Ar facility
 .Op Fl i Ar ipv4
 .Op Fl m Ar bytes
 .Fl n Ar name
@@ -43,9 +44,6 @@
 .Op Ar args ...
 .Nm
 .Cm destroy
-.Ar jail-id | name
-.Nm
-.Cm attach
 .Ar jail-id | name
 .Nm
 .Cm exec
@@ -64,7 +62,7 @@ jail id, while the host root user (jail id 0) can access all processes.
 .Pp
 The commands are as follows:
 .Bl -tag -width Ds
-.It Cm create Op Fl c Ar cpu-ms Op Fl i Ar ipv4 Op Fl m Ar bytes Fl n Ar name Ar root \
+.It Cm create Op Fl c Ar cpu-ms Op Fl f Ar facility Op Fl i Ar ipv4 Op Fl m Ar bytes Fl n Ar name Ar root \
     Op command Op Ar args ...
 Create a new jail id, assign it the unique
 .Ar name ,
@@ -72,35 +70,45 @@ store jail name and root metadata in the kernel jail model, and start
 .Ar command
 in the background inside the jail.
 If no command is provided, an interactive shell is started in the background.
-The command can later be reached via
-.Cm attach .
+The jailed command's standard output and standard error are forwarded to
+host syslog.
 .Pp
 The optional flags set per-jail limits and bind restrictions:
 .Bl -tag -width Ds
 .It Fl c Ar cpu-ms
 Set a CPU time limit (in milliseconds) for processes in the jail.
+.It Fl f Ar facility
+Set the syslog facility used when forwarding output from the jailed command.
+Supported values are
+.Dq auth ,
+.Dq authpriv ,
+.Dq daemon ,
+.Dq kern ,
+.Dq lpr ,
+.Dq mail ,
+.Dq news ,
+.Dq syslog ,
+.Dq user ,
+.Dq uucp ,
+and
+.Dq local0
+through
+.Dq local7 .
 .It Fl i Ar ipv4
 Restrict IPv4 socket binds inside the jail to the specified address.
 .It Fl m Ar bytes
 Set a virtual memory limit (in bytes) for processes in the jail.
 .El
+.Pp
+The background monitor process is shown in process listings as
+.Dq jailctl monitor jail=<name> jid=<id>
+to distinguish it from one-shot create invocations.
 .It Cm destroy Ar jail-id | name
 Destroy a jail selected by
 .Ar jail-id
 or
 .Ar name
 that has no remaining processes.
-.It Cm attach Ar jail-id | name
-Attach the local terminal to the background command started with
-.Cm create
-for jail
-.Ar jail-id
-or
-.Ar name ,
-providing interactive stdin/stdout/stderr forwarding.
-When attached from a terminal, type
-.Ic Ctrl-]
-to detach without terminating the jailed process.
 .It Cm exec Ar jail-id | name Op command Op Ar args ...
 Enter a running jail selected by
 .Ar jail-id

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -36,6 +36,7 @@
 .Cm create
 .Op Fl c Ar cpu-ms
 .Op Fl f Ar facility
+.Op Fl t Ar tag
 .Op Fl i Ar ipv4
 .Op Fl m Ar bytes
 .Fl n Ar name
@@ -62,7 +63,7 @@ jail id, while the host root user (jail id 0) can access all processes.
 .Pp
 The commands are as follows:
 .Bl -tag -width Ds
-.It Cm create Op Fl c Ar cpu-ms Op Fl f Ar facility Op Fl i Ar ipv4 Op Fl m Ar bytes Fl n Ar name Ar root \
+.It Cm create Op Fl c Ar cpu-ms Op Fl f Ar facility Op Fl t Ar tag Op Fl i Ar ipv4 Op Fl m Ar bytes Fl n Ar name Ar root \
     Op command Op Ar args ...
 Create a new jail id, assign it the unique
 .Ar name ,
@@ -94,6 +95,11 @@ and
 .Dq local0
 through
 .Dq local7 .
+.It Fl t Ar tag
+Set the syslog tag used for forwarded jailed-command output.
+If omitted,
+.Dq jailctl
+is used.
 .It Fl i Ar ipv4
 Restrict IPv4 socket binds inside the jail to the specified address.
 .It Fl m Ar bytes

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -52,12 +52,15 @@ __RCSID("$NetBSD$");
 #include <sys/wait.h>
 
 #define JAILCTL_LOG_MAX 511
+#define JAILCTL_TAG_MAX 63
 
 static void	usage(void) __dead;
 
 static void	jail_exec(jailid_t, const char *, char *[]);
-static void	jail_run_monitor(jailid_t, const char *, int, int, pid_t, int);
-static void	jail_spawn_detached(jailid_t, const char *, const char *, char *[], int);
+static void	jail_run_monitor(jailid_t, const char *, const char *, int, int,
+		    pid_t, int);
+static void	jail_spawn_detached(jailid_t, const char *, const char *,
+		    const char *, char *[], int);
 static int	parse_log_facility(const char *);
 static void	sanitize_field(const char *, char *, size_t);
 static bool	jail_lookup_by_name(const char *, struct jail_info *);
@@ -265,7 +268,8 @@ log_stream_data(int priority, const char *stream, jailid_t id, const char *name,
 }
 
 static void
-jail_run_monitor(jailid_t id, const char *name, int outfd, int errfd,
+jail_run_monitor(jailid_t id, const char *name, const char *logtag,
+    int outfd, int errfd,
     pid_t child, int facility)
 {
 	char outline[JAILCTL_LOG_MAX];
@@ -275,7 +279,7 @@ jail_run_monitor(jailid_t id, const char *name, int outfd, int errfd,
 	int status;
 
 	setproctitle("jailctl monitor jail=%s jid=%" PRIu32, name, id);
-	openlog("jailctl", LOG_PID | LOG_NDELAY, facility);
+	openlog(logtag, LOG_PID | LOG_NDELAY, facility);
 
 	outused = 0;
 	errused = 0;
@@ -361,7 +365,7 @@ jail_run_monitor(jailid_t id, const char *name, int outfd, int errfd,
 
 static void
 jail_spawn_detached(jailid_t id, const char *root, const char *name,
-    char *cmd[], int facility)
+    const char *logtag, char *cmd[], int facility)
 {
 	int outpipe[2], errpipe[2], devnull;
 	pid_t child, mgr;
@@ -398,7 +402,8 @@ jail_spawn_detached(jailid_t id, const char *root, const char *name,
 	if (mgr == -1)
 		err(1, "fork");
 	if (mgr == 0)
-		jail_run_monitor(id, name, outpipe[0], errpipe[0], child, facility);
+		jail_run_monitor(id, name, logtag, outpipe[0], errpipe[0], child,
+		    facility);
 
 	close(outpipe[0]);
 	close(errpipe[0]);
@@ -493,12 +498,14 @@ main(int argc, char *argv[])
 		uintmax_t num;
 		struct in_addr addr;
 		int ch, facility;
+		char logtag[JAILCTL_TAG_MAX + 1];
 
 		memset(&create, 0, sizeof(create));
 		name = NULL;
 		facility = LOG_DAEMON;
+		strlcpy(logtag, "jailctl", sizeof(logtag));
 		optind = 2;
-		while ((ch = getopt(argc, argv, "c:f:i:m:n:")) != -1) {
+		while ((ch = getopt(argc, argv, "c:f:i:m:n:t:")) != -1) {
 			switch (ch) {
 			case 'c':
 				errno = 0;
@@ -528,6 +535,11 @@ main(int argc, char *argv[])
 			case 'n':
 				name = optarg;
 				break;
+			case 't':
+				sanitize_field(optarg, logtag, sizeof(logtag));
+				if (logtag[0] == '\0')
+					errx(1, "invalid log tag");
+				break;
 			default:
 				usage();
 			}
@@ -546,7 +558,7 @@ main(int argc, char *argv[])
 		sanitize_field(root, create.jc_root, sizeof(create.jc_root));
 		id = jail_create(&create);
 
-		jail_spawn_detached(id, create.jc_root, create.jc_name,
+		jail_spawn_detached(id, create.jc_root, create.jc_name, logtag,
 		    argc > optind + 1 ? &argv[optind + 1] : NULL, facility);
 		return 0;
 	}
@@ -585,7 +597,7 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s create [-c cpu-ms] [-f facility] [-i ipv4] [-m bytes] -n name <root> "
+	    "usage: %s create [-c cpu-ms] [-f facility] [-t tag] [-i ipv4] [-m bytes] -n name <root> "
 	    "[command [args...]]\n"
 	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id|name>\n"

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -34,10 +34,6 @@ __RCSID("$NetBSD$");
 #include <sys/types.h>
 #include <sys/jail.h>
 #include <sys/sysctl.h>
-#include <sys/socket.h>
-#include <sys/stat.h>
-#include <sys/un.h>
-#include <sys/ioctl.h>
 
 #include <arpa/inet.h>
 #include <err.h>
@@ -51,36 +47,23 @@ __RCSID("$NetBSD$");
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <termios.h>
+#include <syslog.h>
 #include <unistd.h>
-#include <util.h>
 #include <sys/wait.h>
 
-#define JAILCTL_STATEDIR "/var/run/jailctl"
-#define JAILCTL_CMD_MAX 511
-#define JAILCTL_DETACH_KEY 0x1d	/* Ctrl-] */
-
-struct jail_context {
-	jailid_t	id;
-	char		command[JAILCTL_CMD_MAX + 1];
-	char		sockpath[PATH_MAX];
-};
+#define JAILCTL_LOG_MAX 511
 
 static void	usage(void) __dead;
 
-static void	jail_attach(const struct jail_context *);
 static void	jail_exec(jailid_t, const char *, char *[]);
-static void	jail_run_manager(const struct jail_context *, int, pid_t);
-static void	jail_spawn_detached(jailid_t, const char *, const struct jail_context *, char *[]);
-static void	path_context(jailid_t, char *, size_t);
-static void	path_socket(jailid_t, char *, size_t);
+static void	jail_run_monitor(jailid_t, const char *, int, int, pid_t, int);
+static void	jail_spawn_detached(jailid_t, const char *, const char *, char *[], int);
+static int	parse_log_facility(const char *);
 static void	sanitize_field(const char *, char *, size_t);
-static bool	context_load(jailid_t, struct jail_context *);
 static bool	jail_lookup_by_name(const char *, struct jail_info *);
 static bool	jail_lookup_by_id(jailid_t, struct jail_info *);
-static bool	context_save(const struct jail_context *);
-static void	context_delete(jailid_t);
-static void	build_command_line(int, char *[], char *, size_t);
+static void	log_stream_data(int, const char *, jailid_t, const char *,
+		    char *, size_t *, const char *, size_t);
 static jailid_t	resolve_jail_target(const char *, struct jail_info *);
 
 static struct jail_info *
@@ -182,20 +165,6 @@ jail_list(void)
 }
 
 static void
-path_context(jailid_t id, char *path, size_t sz)
-{
-
-	(void)snprintf(path, sz, "%s/%" PRIu32 ".ctx", JAILCTL_STATEDIR, id);
-}
-
-static void
-path_socket(jailid_t id, char *path, size_t sz)
-{
-
-	(void)snprintf(path, sz, "%s/%" PRIu32 ".sock", JAILCTL_STATEDIR, id);
-}
-
-static void
 sanitize_field(const char *src, char *dst, size_t dsz)
 {
 	size_t i, j;
@@ -207,64 +176,6 @@ sanitize_field(const char *src, char *dst, size_t dsz)
 			dst[j++] = src[i];
 	}
 	dst[j] = '\0';
-}
-
-static bool
-context_save(const struct jail_context *ctx)
-{
-	char path[PATH_MAX];
-	FILE *fp;
-
-	if (mkdir(JAILCTL_STATEDIR, 0700) == -1 && errno != EEXIST)
-		err(1, "mkdir %s", JAILCTL_STATEDIR);
-
-	path_context(ctx->id, path, sizeof(path));
-	fp = fopen(path, "w");
-	if (fp == NULL)
-		err(1, "%s", path);
-
-	if (fprintf(fp, "command=%s\nsock=%s\n",
-	    ctx->command, ctx->sockpath) < 0)
-		err(1, "write %s", path);
-
-	if (fclose(fp) == EOF)
-		err(1, "close %s", path);
-
-	return true;
-}
-
-static bool
-context_load(jailid_t id, struct jail_context *ctx)
-{
-	char path[PATH_MAX], line[PATH_MAX + JAILCTL_CMD_MAX + 32];
-	FILE *fp;
-
-	memset(ctx, 0, sizeof(*ctx));
-	ctx->id = id;
-	path_context(id, path, sizeof(path));
-	fp = fopen(path, "r");
-	if (fp == NULL)
-		return false;
-
-	while (fgets(line, sizeof(line), fp) != NULL) {
-		char *eq, *nl;
-
-		eq = strchr(line, '=');
-		if (eq == NULL)
-			continue;
-		*eq++ = '\0';
-		nl = strchr(eq, '\n');
-		if (nl != NULL)
-			*nl = '\0';
-
-		if (strcmp(line, "command") == 0)
-			strlcpy(ctx->command, eq, sizeof(ctx->command));
-		else if (strcmp(line, "sock") == 0)
-			strlcpy(ctx->sockpath, eq, sizeof(ctx->sockpath));
-	}
-
-	(void)fclose(fp);
-	return ctx->sockpath[0] != '\0';
 }
 
 static bool
@@ -304,45 +215,6 @@ jail_lookup_by_name(const char *name, struct jail_info *jip)
 }
 
 static void
-context_delete(jailid_t id)
-{
-	char path[PATH_MAX], sock[PATH_MAX];
-
-	path_context(id, path, sizeof(path));
-	if (unlink(path) == -1 && errno != ENOENT)
-		warn("unlink %s", path);
-
-	path_socket(id, sock, sizeof(sock));
-	if (unlink(sock) == -1 && errno != ENOENT)
-		warn("unlink %s", sock);
-}
-
-static void
-build_command_line(int argc, char *argv[], char *dst, size_t dsz)
-{
-	size_t used;
-	int i;
-
-	if (argc <= 0) {
-		dst[0] = '\0';
-		return;
-	}
-
-	used = 0;
-	for (i = 0; i < argc; i++) {
-		int n;
-
-		n = snprintf(dst + used, dsz - used, "%s%s",
-		    i == 0 ? "" : " ", argv[i]);
-		if (n < 0 || (size_t)n >= dsz - used)
-			break;
-		used += (size_t)n;
-	}
-
-	dst[dsz - 1] = '\0';
-}
-
-static void
 jail_exec(jailid_t id, const char *root, char *cmd[])
 {
 	const char *shell;
@@ -367,193 +239,206 @@ jail_exec(jailid_t id, const char *root, char *cmd[])
 }
 
 static void
-jail_run_manager(const struct jail_context *ctx, int pty_master, pid_t child)
+log_stream_data(int priority, const char *stream, jailid_t id, const char *name,
+    char *linebuf, size_t *usedp, const char *chunk, size_t chunklen)
 {
-	int server, client;
-	struct sockaddr_un sun;
+	size_t used;
+	size_t i;
 
-	server = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (server == -1)
-		err(1, "socket");
-
-	memset(&sun, 0, sizeof(sun));
-	sun.sun_family = AF_UNIX;
-	strlcpy(sun.sun_path, ctx->sockpath, sizeof(sun.sun_path));
-	unlink(ctx->sockpath);
-
-	if (bind(server, (struct sockaddr *)&sun, sizeof(sun)) == -1)
-		err(1, "bind %s", ctx->sockpath);
-	if (listen(server, 1) == -1)
-		err(1, "listen %s", ctx->sockpath);
-
-	for (;;) {
-		struct pollfd pfd;
-		int rv, status;
-
-		if (waitpid(child, &status, WNOHANG) == child)
-			break;
-
-		pfd.fd = server;
-		pfd.events = POLLIN;
-		rv = poll(&pfd, 1, 500);
-		if (rv <= 0)
+	used = *usedp;
+	for (i = 0; i < chunklen; i++) {
+		if (chunk[i] == '\n') {
+			syslog(priority, "jail=%s jid=%" PRIu32 " %s: %.*s",
+			    name, id, stream, (int)used, linebuf);
+			used = 0;
 			continue;
+		}
+		if (used + 1 >= JAILCTL_LOG_MAX) {
+			syslog(priority, "jail=%s jid=%" PRIu32 " %s: %.*s",
+			    name, id, stream, (int)used, linebuf);
+			used = 0;
+		}
+		linebuf[used++] = chunk[i];
+	}
 
-		client = accept(server, NULL, NULL);
-		if (client == -1)
-			continue;
+	*usedp = used;
+}
 
-		for (;;) {
-			struct pollfd io[2];
-			char buf[4096];
-			ssize_t n;
+static void
+jail_run_monitor(jailid_t id, const char *name, int outfd, int errfd,
+    pid_t child, int facility)
+{
+	char outline[JAILCTL_LOG_MAX];
+	char errline[JAILCTL_LOG_MAX];
+	size_t outused, errused;
+	bool outopen, erropen;
+	int status;
 
-			io[0].fd = client;
-			io[0].events = POLLIN;
-			io[1].fd = pty_master;
-			io[1].events = POLLIN;
+	setproctitle("jailctl monitor jail=%s jid=%" PRIu32, name, id);
+	openlog("jailctl", LOG_PID | LOG_NDELAY, facility);
 
-			rv = poll(io, 2, 500);
-			if (rv == -1 && errno == EINTR)
-				continue;
-			if (rv <= 0) {
-				if (waitpid(child, &status, WNOHANG) == child)
-					goto out;
-				continue;
-			}
+	outused = 0;
+	errused = 0;
+	outopen = true;
+	erropen = true;
 
-			if (io[0].revents & POLLIN) {
-				n = read(client, buf, sizeof(buf));
-				if (n <= 0 || write(pty_master, buf, (size_t)n) == -1)
-					break;
-			}
+	while (outopen || erropen) {
+		struct pollfd pfd[2];
+		int nfd, rv, i;
 
-			if (io[1].revents & POLLIN) {
-				n = read(pty_master, buf, sizeof(buf));
-				if (n <= 0 || write(client, buf, (size_t)n) == -1)
-					break;
-			}
+		nfd = 0;
+		if (outopen) {
+			pfd[nfd].fd = outfd;
+			pfd[nfd].events = POLLIN;
+			nfd++;
+		}
+		if (erropen) {
+			pfd[nfd].fd = errfd;
+			pfd[nfd].events = POLLIN;
+			nfd++;
 		}
 
-		close(client);
+		rv = poll(pfd, (nfds_t)nfd, 500);
+		if (rv < 0) {
+			if (errno == EINTR)
+				continue;
+			warn("poll");
+			break;
+		}
+		if (rv == 0)
+			continue;
+
+		for (i = 0; i < nfd; i++) {
+			char buf[512];
+			ssize_t n;
+
+			if ((pfd[i].revents & POLLIN) == 0)
+				continue;
+
+			n = read(pfd[i].fd, buf, sizeof(buf));
+			if (n == 0) {
+				if (pfd[i].fd == outfd)
+					outopen = false;
+				else
+					erropen = false;
+				close(pfd[i].fd);
+				continue;
+			}
+			if (n < 0) {
+				if (errno == EINTR)
+					continue;
+				warn("read");
+				if (pfd[i].fd == outfd)
+					outopen = false;
+				else
+					erropen = false;
+				close(pfd[i].fd);
+				continue;
+			}
+
+			if (pfd[i].fd == outfd)
+				log_stream_data(LOG_INFO, "stdout", id, name,
+				    outline, &outused, buf, (size_t)n);
+			else
+				log_stream_data(LOG_ERR, "stderr", id, name,
+				    errline, &errused, buf, (size_t)n);
+		}
 	}
-out:
-	close(server);
-	close(pty_master);
-	context_delete(ctx->id);
+
+	if (outused > 0)
+		syslog(LOG_INFO, "jail=%s jid=%" PRIu32 " stdout: %.*s",
+		    name, id, (int)outused, outline);
+	if (errused > 0)
+		syslog(LOG_ERR, "jail=%s jid=%" PRIu32 " stderr: %.*s",
+		    name, id, (int)errused, errline);
+
+	if (waitpid(child, &status, 0) == -1)
+		warn("waitpid %jd", (intmax_t)child);
+
+	closelog();
 	_exit(0);
 }
 
 static void
-jail_spawn_detached(jailid_t id, const char *root, const struct jail_context *ctx, char *cmd[])
+jail_spawn_detached(jailid_t id, const char *root, const char *name,
+    char *cmd[], int facility)
 {
-	int mfd, sfd;
+	int outpipe[2], errpipe[2], devnull;
 	pid_t child, mgr;
 
-	if (openpty(&mfd, &sfd, NULL, NULL, NULL) == -1)
-		err(1, "openpty");
+	if (pipe(outpipe) == -1 || pipe(errpipe) == -1)
+		err(1, "pipe");
 
 	child = fork();
 	if (child == -1)
 		err(1, "fork");
 	if (child == 0) {
-		close(mfd);
+		close(outpipe[0]);
+		close(errpipe[0]);
 		if (setsid() == -1)
 			err(1, "setsid");
-		if (ioctl(sfd, TIOCSCTTY, 0) == -1)
-			err(1, "TIOCSCTTY");
-		if (dup2(sfd, STDIN_FILENO) == -1 ||
-		    dup2(sfd, STDOUT_FILENO) == -1 ||
-		    dup2(sfd, STDERR_FILENO) == -1)
+		devnull = open(_PATH_DEVNULL, O_RDONLY);
+		if (devnull == -1)
+			err(1, "%s", _PATH_DEVNULL);
+		if (dup2(devnull, STDIN_FILENO) == -1 ||
+		    dup2(outpipe[1], STDOUT_FILENO) == -1 ||
+		    dup2(errpipe[1], STDERR_FILENO) == -1)
 			err(1, "dup2");
-		if (sfd > STDERR_FILENO)
-			close(sfd);
+		if (devnull > STDERR_FILENO)
+			close(devnull);
+		close(outpipe[1]);
+		close(errpipe[1]);
 		jail_exec(id, root, cmd);
 	}
 
-	close(sfd);
+	close(outpipe[1]);
+	close(errpipe[1]);
 
 	mgr = fork();
 	if (mgr == -1)
 		err(1, "fork");
 	if (mgr == 0)
-		jail_run_manager(ctx, mfd, child);
+		jail_run_monitor(id, name, outpipe[0], errpipe[0], child, facility);
 
-	close(mfd);
+	close(outpipe[0]);
+	close(errpipe[0]);
 	printf("jail %" PRIu32 "\n", id);
 }
 
-static void
-jail_attach(const struct jail_context *ctx)
+static int
+parse_log_facility(const char *name)
 {
-	int fd, rv;
-	struct sockaddr_un sun;
-	struct termios oldt, raw;
-	bool tty;
+	struct {
+		const char *name;
+		int facility;
+	} facs[] = {
+		{ "auth", LOG_AUTH },
+		{ "authpriv", LOG_AUTHPRIV },
+		{ "daemon", LOG_DAEMON },
+		{ "kern", LOG_KERN },
+		{ "lpr", LOG_LPR },
+		{ "mail", LOG_MAIL },
+		{ "news", LOG_NEWS },
+		{ "syslog", LOG_SYSLOG },
+		{ "user", LOG_USER },
+		{ "uucp", LOG_UUCP },
+		{ "local0", LOG_LOCAL0 },
+		{ "local1", LOG_LOCAL1 },
+		{ "local2", LOG_LOCAL2 },
+		{ "local3", LOG_LOCAL3 },
+		{ "local4", LOG_LOCAL4 },
+		{ "local5", LOG_LOCAL5 },
+		{ "local6", LOG_LOCAL6 },
+		{ "local7", LOG_LOCAL7 },
+	};
+	size_t i;
 
-	fd = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (fd == -1)
-		err(1, "socket");
-
-	memset(&sun, 0, sizeof(sun));
-	sun.sun_family = AF_UNIX;
-	strlcpy(sun.sun_path, ctx->sockpath, sizeof(sun.sun_path));
-
-	if (connect(fd, (struct sockaddr *)&sun, sizeof(sun)) == -1)
-		err(1, "connect %s", ctx->sockpath);
-
-	tty = isatty(STDIN_FILENO);
-	if (tty && tcgetattr(STDIN_FILENO, &oldt) == 0) {
-		raw = oldt;
-		cfmakeraw(&raw);
-		(void)tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+	for (i = 0; i < __arraycount(facs); i++) {
+		if (strcmp(name, facs[i].name) == 0)
+			return facs[i].facility;
 	}
 
-	for (;;) {
-		struct pollfd io[2];
-		char buf[4096];
-		ssize_t n;
-
-		io[0].fd = STDIN_FILENO;
-		io[0].events = POLLIN;
-		io[1].fd = fd;
-		io[1].events = POLLIN;
-
-		rv = poll(io, 2, -1);
-		if (rv == -1 && errno == EINTR)
-			continue;
-		if (rv <= 0)
-			break;
-
-		if (io[0].revents & POLLIN) {
-			ssize_t i;
-
-			n = read(STDIN_FILENO, buf, sizeof(buf));
-			if (n <= 0)
-				break;
-
-			for (i = 0; i < n; i++) {
-				if ((unsigned char)buf[i] == JAILCTL_DETACH_KEY)
-					break;
-			}
-
-			if (i > 0 && write(fd, buf, (size_t)i) == -1)
-				break;
-
-			if (i < n)
-				break;
-		}
-
-		if (io[1].revents & POLLIN) {
-			n = read(fd, buf, sizeof(buf));
-			if (n <= 0 || write(STDOUT_FILENO, buf, (size_t)n) == -1)
-				break;
-		}
-	}
-
-	if (tty)
-		(void)tcsetattr(STDIN_FILENO, TCSAFLUSH, &oldt);
-	close(fd);
+	errx(1, "invalid log facility: %s", name);
 }
 
 static int
@@ -597,9 +482,6 @@ main(int argc, char *argv[])
 	jailid_t id;
 	const char *root;
 	const char *name;
-	const char *shell;
-	char cmdbuf[JAILCTL_CMD_MAX + 1];
-	struct jail_context ctx;
 	struct jail_info ji;
 
 	if (argc < 2)
@@ -610,12 +492,13 @@ main(int argc, char *argv[])
 		char *endp;
 		uintmax_t num;
 		struct in_addr addr;
-		int ch;
+		int ch, facility;
 
 		memset(&create, 0, sizeof(create));
 		name = NULL;
+		facility = LOG_DAEMON;
 		optind = 2;
-		while ((ch = getopt(argc, argv, "c:i:m:n:")) != -1) {
+		while ((ch = getopt(argc, argv, "c:f:i:m:n:")) != -1) {
 			switch (ch) {
 			case 'c':
 				errno = 0;
@@ -624,6 +507,9 @@ main(int argc, char *argv[])
 					errx(1, "invalid cpu limit: %s", optarg);
 				create.jc_flags |= JAIL_CREATE_CPULIMIT;
 				create.jc_cpu_limit = num;
+				break;
+			case 'f':
+				facility = parse_log_facility(optarg);
 				break;
 			case 'i':
 				if (inet_pton(AF_INET, optarg, &addr) != 1)
@@ -660,23 +546,8 @@ main(int argc, char *argv[])
 		sanitize_field(root, create.jc_root, sizeof(create.jc_root));
 		id = jail_create(&create);
 
-		memset(&ctx, 0, sizeof(ctx));
-		ctx.id = id;
-		if (argc > optind + 1) {
-			build_command_line(argc - (optind + 1), &argv[optind + 1],
-			    cmdbuf, sizeof(cmdbuf));
-			sanitize_field(cmdbuf, cmdbuf, sizeof(cmdbuf));
-		} else {
-			if ((shell = getenv("SHELL")) == NULL)
-				shell = _PATH_BSHELL;
-			sanitize_field(shell, cmdbuf, sizeof(cmdbuf));
-		}
-		strlcpy(ctx.command, cmdbuf, sizeof(ctx.command));
-		path_socket(id, ctx.sockpath, sizeof(ctx.sockpath));
-		(void)context_save(&ctx);
-
-		jail_spawn_detached(id, create.jc_root, &ctx,
-		    argc > optind + 1 ? &argv[optind + 1] : NULL);
+		jail_spawn_detached(id, create.jc_root, create.jc_name,
+		    argc > optind + 1 ? &argv[optind + 1] : NULL, facility);
 		return 0;
 	}
 
@@ -686,7 +557,6 @@ main(int argc, char *argv[])
 
 		id = resolve_jail_target(argv[2], &ji);
 		jail_destroy(id);
-		context_delete(id);
 		return 0;
 	}
 
@@ -697,17 +567,6 @@ main(int argc, char *argv[])
 		id = resolve_jail_target(argv[2], &ji);
 
 		jail_exec(id, ji.ji_root, argc > 3 ? &argv[3] : NULL);
-	}
-
-	if (strcmp(argv[1], "attach") == 0) {
-		if (argc != 3)
-			usage();
-
-		id = resolve_jail_target(argv[2], &ji);
-		if (!context_load(id, &ctx))
-			errx(1, "context for jail %" PRIu32 " not found", id);
-		jail_attach(&ctx);
-		return 0;
 	}
 
 	if (strcmp(argv[1], "list") == 0) {
@@ -726,13 +585,11 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s create [-c cpu-ms] [-i ipv4] [-m bytes] -n name <root> "
+	    "usage: %s create [-c cpu-ms] [-f facility] [-i ipv4] [-m bytes] -n name <root> "
 	    "[command [args...]]\n"
-	    "       %s attach <jail-id|name>\n"
 	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id|name>\n"
 	    "       %s list\n",
-	    getprogname(), getprogname(), getprogname(), getprogname(),
-	    getprogname());
+	    getprogname(), getprogname(), getprogname(), getprogname());
 	exit(1);
 }

--- a/usr.sbin/jailctl/jailmgr
+++ b/usr.sbin/jailctl/jailmgr
@@ -61,7 +61,7 @@ Commands:
   host-net-down                  Remove host aliases for all jail IPs
   start-jail <name> <ip>         Mount jail root and start jail via jailctl
   start-all                      Alias host IPs and start all jails listed in JAIL_LIST
-  stop-jail <name>               Destroy one jail and unmount root
+  stop-jail <name>               Gracefully stop one jail, then destroy and unmount root
   stop-all                       Stop all jails listed in JAIL_LIST
   npf-sync                       Generate/update NPF rdr snippet from NPF_RDR_LIST
   status                         Show jailctl list and mount status
@@ -80,12 +80,52 @@ need_root() {
 }
 
 require_tools() {
-	for t in jailctl tar mount umount ifconfig; do
+	for t in jailctl tar mount umount ifconfig ps; do
 		command -v "${t}" >/dev/null 2>&1 || {
 			echo "missing required tool: ${t}" >&2
 			exit 1
 		}
 	done
+}
+
+jail_pids() {
+	jid=$1
+	ps -axo pid=,jid= | awk -v j="${jid}" '$2==j{print $1}'
+}
+
+jail_monitor_pid() {
+	name=$1
+	jid=$2
+	ps -axo pid=,command= | awk -v n="${name}" -v j="${jid}" '
+		$0 ~ "jailctl monitor jail=" n " jid=" j { print $1; exit }
+	'
+}
+
+stop_jail_processes() {
+	name=$1
+	jid=$2
+	monitor_pid=$(jail_monitor_pid "${name}" "${jid}" || true)
+
+	# Best effort inside-jail shutdown hook.
+	jailctl exec "${jid}" /bin/sh -c 'if [ -x /etc/rc.shutdown ]; then /etc/rc.shutdown; fi' >/dev/null 2>&1 || true
+
+	for sig in TERM KILL; do
+		pids=$(jail_pids "${jid}" | tr '\n' ' ')
+		[ -n "${pids}" ] || break
+		# shellcheck disable=SC2086
+		kill -${sig} ${pids} >/dev/null 2>&1 || true
+		for _ in 1 2 3 4 5; do
+			sleep 1
+			pids=$(jail_pids "${jid}" | tr '\n' ' ')
+			[ -z "${pids}" ] && break
+		done
+	done
+
+	if [ -n "${monitor_pid}" ]; then
+		kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
+		sleep 1
+		kill -KILL "${monitor_pid}" >/dev/null 2>&1 || true
+	fi
 }
 
 fetch_sets() {
@@ -320,6 +360,7 @@ stop_jail() {
 
 	if jail_exists "${name}"; then
 		jid=$(jailctl list | awk -v n="${name}" '$3==n{print $1}')
+		stop_jail_processes "${name}" "${jid}"
 		jailctl destroy "${jid}"
 		echo "Destroyed jail ${name} (jid ${jid})"
 	fi

--- a/usr.sbin/jailctl/jailmgr.8
+++ b/usr.sbin/jailctl/jailmgr.8
@@ -71,9 +71,12 @@ Call
 and start all jails listed in
 .Ev JAIL_LIST .
 .It Cm stop-jail Ar name
-Destroy the jail named
-.Ar name
-and unmount its filesystem layout.
+Request graceful shutdown for processes in the jail named
+.Ar name ,
+terminate any remaining jail processes and the corresponding
+.Xr jailctl 8
+monitor process if needed,
+then destroy the jail and unmount its filesystem layout.
 .It Cm stop-all
 Stop and unmount all jails listed in
 .Ev JAIL_LIST .

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -61,7 +61,7 @@ Commands:
   host-net-down                  Remove host aliases for all jail IPs
   start-jail <name> <ip>         Mount jail root and start jail via jailctl
   start-all                      Alias host IPs and start all jails listed in JAIL_LIST
-  stop-jail <name>               Destroy one jail and unmount root
+  stop-jail <name>               Gracefully stop one jail, then destroy and unmount root
   stop-all                       Stop all jails listed in JAIL_LIST
   npf-sync                       Generate/update NPF rdr snippet from NPF_RDR_LIST
   status                         Show jailctl list and mount status
@@ -80,12 +80,52 @@ need_root() {
 }
 
 require_tools() {
-	for t in jailctl tar mount umount ifconfig; do
+	for t in jailctl tar mount umount ifconfig ps; do
 		command -v "${t}" >/dev/null 2>&1 || {
 			echo "missing required tool: ${t}" >&2
 			exit 1
 		}
 	done
+}
+
+jail_pids() {
+	jid=$1
+	ps -axo pid=,jid= | awk -v j="${jid}" '$2==j{print $1}'
+}
+
+jail_monitor_pid() {
+	name=$1
+	jid=$2
+	ps -axo pid=,command= | awk -v n="${name}" -v j="${jid}" '
+		$0 ~ "jailctl monitor jail=" n " jid=" j { print $1; exit }
+	'
+}
+
+stop_jail_processes() {
+	name=$1
+	jid=$2
+	monitor_pid=$(jail_monitor_pid "${name}" "${jid}" || true)
+
+	# Best effort inside-jail shutdown hook.
+	jailctl exec "${jid}" /bin/sh -c 'if [ -x /etc/rc.shutdown ]; then /etc/rc.shutdown; fi' >/dev/null 2>&1 || true
+
+	for sig in TERM KILL; do
+		pids=$(jail_pids "${jid}" | tr '\n' ' ')
+		[ -n "${pids}" ] || break
+		# shellcheck disable=SC2086
+		kill -${sig} ${pids} >/dev/null 2>&1 || true
+		for _ in 1 2 3 4 5; do
+			sleep 1
+			pids=$(jail_pids "${jid}" | tr '\n' ' ')
+			[ -z "${pids}" ] && break
+		done
+	done
+
+	if [ -n "${monitor_pid}" ]; then
+		kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
+		sleep 1
+		kill -KILL "${monitor_pid}" >/dev/null 2>&1 || true
+	fi
 }
 
 fetch_sets() {
@@ -320,6 +360,7 @@ stop_jail() {
 
 	if jail_exists "${name}"; then
 		jid=$(jailctl list | awk -v n="${name}" '$3==n{print $1}')
+		stop_jail_processes "${name}" "${jid}"
 		jailctl destroy "${jid}"
 		echo "Destroyed jail ${name} (jid ${jid})"
 	fi

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -91,7 +91,12 @@ Run
 and then start all jails in
 .Ev JAIL_LIST .
 .It Cm stop-jail Ar name
-Destroy one jail by name through
+Request graceful shutdown for processes in the jail named
+.Ar name ,
+terminate any remaining jail processes and the corresponding
+.Xr jailctl 8
+monitor process if needed,
+then destroy the jail by name through
 .Xr jailctl 8
 and unmount its root composition.
 .It Cm stop-all


### PR DESCRIPTION
### Motivation

- Replace the interactive attach/context-persistence model with a simpler, more robust detached workflow that forwards jailed process output to host syslog.  
- Allow per-jail syslog facility selection so forwarded output can be routed appropriately.  
- Make `jailmgr` stop semantics more reliable by attempting an in-jail shutdown, escalating TERM→KILL for remaining processes, and ensuring any monitor process is terminated before destroying the jail.  

### Description

- Removed attach/context persistence (socket files, state directory, `openpty`/attach path) from `jailctl` and eliminated the `attach` subcommand.  
- Implemented a detached monitor process (`jail_run_monitor`) that sets a descriptive proctitle (`jailctl monitor jail=<name> jid=<id>`), reads child `stdout`/`stderr` via pipes, and forwards line-buffered output to `syslog`.  
- Added `jailctl create -f <facility>` parsing with `parse_log_facility()` and a `JAILCTL_LOG_MAX` line buffer, and updated `usage()`/manpage text to document syslog forwarding and supported facilities.  
- Reworked `jail_spawn_detached()` to use pipes/devnull and spawn the monitor; removed on-disk context save/load and AF_UNIX socket handling.  
- Hardened `jailmgr` `stop-jail` by adding helper functions `jail_pids()`, `jail_monitor_pid()`, and `stop_jail_processes()` which attempt an in-jail shutdown hook, send TERM/KILL to remaining PIDs, and terminate any matching monitor process; added `ps` to required tools.  
- Updated and synchronized manpages and example `jailmgr` script copies under `usr.sbin/jailctl` to reflect behavior changes and new flags.  

### Testing

- Performed a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr usr.sbin/jailctl/jailmgr usr.sbin/jailctl/examples/jailmgr`, which succeeded.  
- Verified removal of attach/state/pty artifacts with a search: `rg "attach|JAILCTL_STATEDIR|sockpath|openpty|TIOCSCTTY"` against `usr.sbin/jailctl/jailctl.c` and `usr.sbin/jailctl/jailctl.8` (no matches).  
- Attempted `mandoc -Tlint` on the modified manpages but `mandoc` was unavailable in this environment so manpage linting could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3defdfe0832abb0ee91a5e8d03a5)