### PR TITLE
jailctl: avoid discarded-qualifier warning for default start command

### DIFF
--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -617,7 +617,9 @@ main(int argc, char *argv[])
 	}
 
 	if (strcmp(argv[1], "start") == 0) {
-		char *default_cmd[] = { _PATH_BSHELL, "/etc/rc", NULL };
+		char *default_cmd[] = {
+		    __UNCONST(_PATH_BSHELL), __UNCONST("/etc/rc"), NULL
+		};
 		char **cmd;
 		int ch, priority;
 		char logtag[JAILCTL_TAG_MAX + 1];


### PR DESCRIPTION
### Motivation
- Prevent `-Werror=discarded-qualifiers` build failures caused by initializing the `default_cmd` `char *` array from string literals in `usr.sbin/jailctl/jailctl.c`.

### Description
- Replace `char *default_cmd[] = { _PATH_BSHELL, "/etc/rc", NULL };` with `char *default_cmd[] = { __UNCONST(_PATH_BSHELL), __UNCONST("/etc/rc"), NULL };` in `usr.sbin/jailctl/jailctl.c` to avoid discarded-qualifier warnings.

### Testing
- Attempted `make -C usr.sbin/jailctl` which failed in this environment because GNU `make` cannot parse NetBSD makefiles; attempted `bmake -C usr.sbin/jailctl dependall` which could not run because `bmake` is not installed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b250aea1c832aa84dbcfcdb411681)