### PR TITLE
jailmgr: ensure /home exists in base layer before null mount

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -214,6 +214,9 @@ setup_etc() {
 }
 
 mount_jail_root() {
+	# Ensure mount targets exist in the base layer before mounting it read-only.
+	mkdir -p "${BASE_LAYER}/home"
+
 	if mount | awk -v p="on ${ROOT_DIR} " 'index($0,p){found=1} END{exit !found}'; then
 		return
 	fi


### PR DESCRIPTION
### Motivation
- Prevent the later `mount -t null "${HOME_DIR}" "${ROOT_DIR}/home"` from failing when the base set lacks a `/home` directory by ensuring the mount target exists in the base layer before mounting it read-only.

### Description
- Add `mkdir -p "${BASE_LAYER}/home"` at the start of `mount_jail_root()` so the `${BASE_LAYER}` contains the `/home` target before `mount -t null -o ro "${BASE_LAYER}" "${ROOT_DIR}"` is performed.

### Testing
- Performed a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr` which succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ed72457dc832abccf0da1f71630b1)