### PR TITLE
jailmgr: use NetBSD tmpfs -s size flag

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -192,7 +192,7 @@ setup_local_dev() {
 
 	mkdir -p "${ROOT_DIR}/dev"
 	if ! mount | awk -v p="on ${ROOT_DIR}/dev " 'index($0,p){found=1} END{exit !found}'; then
-		mount -t tmpfs -o "size=${JAIL_DEV_SIZE}" tmpfs "${ROOT_DIR}/dev"
+		mount -t tmpfs -s "${JAIL_DEV_SIZE}" tmpfs "${ROOT_DIR}/dev"
 	fi
 
 	if [ -f "${ROOT_DIR}/dev/MAKEDEV" ]; then


### PR DESCRIPTION
### Motivation
- The code previously attempted a Linux-style `-o "size=..."` tmpfs mount with a fallback, but on NetBSD the correct and simpler approach is to use the native `-s` size flag.

### Description
- Replace the conditional Linux-style mount/fallback in `usr.sbin/jailmgr/jailmgr` with a single NetBSD-style mount call: `mount -t tmpfs -s "${JAIL_DEV_SIZE}" tmpfs "${ROOT_DIR}/dev"`.

### Testing
- Ran a syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698edd01c900832abd4b4838bb49be09)