### PR TITLE
jailmgr: use mount_tmpfs for jail /dev setup

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -92,7 +92,7 @@ need_root() {
 }
 
 require_tools() {
-	for t in jailctl tar mount umount ifconfig ps; do
+	for t in jailctl tar mount mount_tmpfs umount ifconfig ps; do
 		command -v "${t}" >/dev/null 2>&1 || {
 			echo "missing required tool: ${t}" >&2
 			exit 1
@@ -192,7 +192,7 @@ setup_local_dev() {
 
 	mkdir -p "${ROOT_DIR}/dev"
 	if ! mount | awk -v p="on ${ROOT_DIR}/dev " 'index($0,p){found=1} END{exit !found}'; then
-		mount -t tmpfs -o "size=${JAIL_DEV_SIZE}" tmpfs "${ROOT_DIR}/dev"
+		mount_tmpfs -s "${JAIL_DEV_SIZE}" tmpfs "${ROOT_DIR}/dev"
 	fi
 
 	if [ -f "${ROOT_DIR}/dev/MAKEDEV" ]; then


### PR DESCRIPTION
### Motivation
- Use the NetBSD helper `mount_tmpfs` for creating the jail `/dev` tmpfs as requested, and prefer the native `-s` size option over Linux-style `-o size=...` invocation.

### Description
- Replace the `mount -t tmpfs -o "size=${JAIL_DEV_SIZE}" tmpfs "${ROOT_DIR}/dev"` call with `mount_tmpfs -s "${JAIL_DEV_SIZE}" tmpfs "${ROOT_DIR}/dev"` in `setup_local_dev`.
- Add `mount_tmpfs` to the `require_tools` check so the script fails early with a clear missing-tool message.

### Testing
- Ran a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698edd01c900832abd4b4838bb49be09)