### PR TITLE
jailmgr: use portable MAKEDEV defaults for jail-local /dev

### DIFF
--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -67,4 +67,4 @@ Include that snippet from `/etc/npf.conf` and optionally set
   echo 'jailmgr=YES' >> /etc/rc.conf
   ```
 
-- Local per-jail `/dev` setup is enabled by default (`JAIL_LOCAL_DEV=YES`) and can be tuned with `JAIL_DEV_SIZE` and `JAIL_DEVICES`.
+- Local per-jail `/dev` setup is enabled by default (`JAIL_LOCAL_DEV=YES`) and can be tuned with `JAIL_DEV_SIZE` and `JAIL_DEVICES` (default: `"std ptm"`).

--- a/usr.sbin/jailmgr/examples/jailmgr.conf.sample
+++ b/usr.sbin/jailmgr/examples/jailmgr.conf.sample
@@ -28,7 +28,7 @@ JAIL_SUPERVISE_CMD="/bin/sh /etc/rc"
 # Per-jail local /dev setup (tmpfs + MAKEDEV)
 JAIL_LOCAL_DEV=YES
 JAIL_DEV_SIZE=8m
-JAIL_DEVICES="console null zero tty ptm random urandom pty0 pty1 pty2 pty3"
+JAIL_DEVICES="std ptm"
 
 # Optional NPF integration for forwarding host interface ports to jails.
 NPF_ENABLE=NO

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -32,7 +32,7 @@ JAIL_SUPERVISE_CMD=
 # Per-jail local /dev setup.
 JAIL_LOCAL_DEV=YES
 JAIL_DEV_SIZE=8m
-JAIL_DEVICES="console null zero tty ptm random urandom pty0 pty1 pty2 pty3"
+JAIL_DEVICES="std ptm"
 
 # Host-side alias interface for jail bind IPs.
 JAIL_HOST_IF=lo0


### PR DESCRIPTION
### Motivation
- Avoid `/dev` population failures caused by legacy MAKEDEV targets (e.g. `console`, `null`, `zero`, `tty`) that newer `MAKEDEV` no longer accepts. 
- Prevent creation of legacy BSD pty node sets that trigger security warnings when `ptyfs` is used. 
- Make the default `JAIL_DEVICES` portable and safe across NetBSD releases.

### Description
- Change the default `JAIL_DEVICES` in `usr.sbin/jailmgr/jailmgr` from a long legacy list to the portable target set `"std ptm"`.
- Update the sample configuration `usr.sbin/jailmgr/examples/jailmgr.conf.sample` to match the new default `JAIL_DEVICES="std ptm"`.
- Document the new default in `usr.sbin/jailmgr/examples/README` by noting the default `"std ptm"` for `JAIL_DEVICES`.

### Testing
- Ran a syntax check with `sh -n usr.sbin/jailmgr/jailmgr` which succeeded.
- Verified the updated defaults are present by searching the modified files with `rg` which returned the new `JAIL_DEVICES` value in the script and sample.
- Confirmed the README contains the documented default `"std ptm"` which was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee0461b54832aa816ee6b40f23a6c)