### PR TITLE
jailmgr: simplify stop by terminating jailctl supervise process

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -69,7 +69,7 @@ Commands:
   host-net-down                  Remove host aliases for all jail IPs
   start <name> [ip]              Mount jail root and supervise jail via jailctl
   start --all                    Alias host IPs and start all configured jails
-  stop <name>                    Gracefully stop one jail, then destroy and unmount root
+  stop <name>                    Stop one jail by terminating its jailctl supervisor
   stop --all                     Stop all configured jails
   npf-sync                       Generate/update NPF rdr snippet from NPF_RDR_LIST
   status                         Show jailctl list and mount status
@@ -97,11 +97,6 @@ require_tools() {
 	done
 }
 
-jail_pids() {
-	jid=$1
-	ps -axo pid=,jid= | awk -v j="${jid}" '$2==j{print $1}'
-}
-
 jail_monitor_pid() {
 	name=$1
 	jid=$2
@@ -115,26 +110,11 @@ stop_jail_processes() {
 	jid=$2
 	monitor_pid=$(jail_monitor_pid "${name}" "${jid}" || true)
 
-	# Best effort inside-jail shutdown hook.
-	jailctl exec "${jid}" /bin/sh -c 'if [ -x /etc/rc.shutdown ]; then /etc/rc.shutdown; fi' >/dev/null 2>&1 || true
+	[ -n "${monitor_pid}" ] || return
 
-	for sig in TERM KILL; do
-		pids=$(jail_pids "${jid}" | tr '\n' ' ')
-		[ -n "${pids}" ] || break
-		# shellcheck disable=SC2086
-		kill -${sig} ${pids} >/dev/null 2>&1 || true
-		for _ in 1 2 3 4 5; do
-			sleep 1
-			pids=$(jail_pids "${jid}" | tr '\n' ' ')
-			[ -z "${pids}" ] && break
-		done
-	done
-
-	if [ -n "${monitor_pid}" ]; then
-		kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
-		sleep 1
-		kill -KILL "${monitor_pid}" >/dev/null 2>&1 || true
-	fi
+	kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
+	sleep 1
+	kill -KILL "${monitor_pid}" >/dev/null 2>&1 || true
 }
 
 fetch_sets() {

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -94,11 +94,10 @@ and then start all jails found under
 with a
 .Pa jail.conf .
 .It Cm stop Ar name
-Request graceful shutdown for processes in the jail named
-.Ar name ,
-terminate any remaining jail processes and the corresponding
+Terminate the corresponding
 .Xr jailctl 8
-monitor process if needed,
+supervise process for the jail named
+.Ar name ,
 then destroy the jail by name through
 .Xr jailctl 8
 and unmount its root composition.


### PR DESCRIPTION
### Motivation

- The existing `stop` flow performed in-jail `rc.shutdown` and iterated over all jail PIDs, making shutdown logic complex and brittle. 
- Stop should instead rely on the supervisor-driven lifecycle and terminate the `jailctl supervise` process for the jail to let the supervisor handle process teardown.

### Description

- Replace the previous multi-step shutdown in `stop_jail_processes()` with a direct termination of the `jailctl supervise` monitor (send `TERM`, wait, then `KILL`).
- Remove the in-jail `/etc/rc.shutdown` invocation and the per-PID `TERM`/`KILL` loop and delete the now-unused `jail_pids()` helper. 
- Use the existing `jail_monitor_pid()` lookup (via `ps`/`awk`) to find the supervisor PID and early-return if not present.
- Update the usage/help text in `usr.sbin/jailmgr/jailmgr` and the man page `usr.sbin/jailmgr/jailmgr.8` to document the new behaviour.

### Testing

- Ran a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698efbe44b68832a81bd3a48cc670be7)