### PR TITLE
jailmgr: fix supervisor PID lookup in stop path

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -100,7 +100,7 @@ require_tools() {
 jail_monitor_pid() {
 	name=$1
 	jid=$2
-	ps -axo pid=,command= | awk -v n="${name}" -v j="${jid}" '
+	ps -axo pid,command | awk -v n="${name}" -v j="${jid}" '
 		$0 ~ "jailctl supervise jail=" n " jid=" j { print $1; exit }
 	'
 }


### PR DESCRIPTION
### Motivation
- The `jailmgr stop` path could not find the `jailctl` supervisor process because the `awk` filter expects `ps` output with column headers, not the `pid=,command=` form. 

### Description
- Change `jail_monitor_pid()` in `usr.sbin/jailmgr/jailmgr` to call `ps -axo pid,command` (instead of `ps -axo pid=,command=`) and keep the existing `awk` match logic so the supervisor PID is found reliably.

### Testing
- Ran a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698efe3cbfe4832aa8b50402d4bb3278)