### PR TITLE
jailmgr: fix generated rc.d command path

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -505,7 +505,7 @@ gen_rc() {
 
 name="jailmgr"
 rcvar=jailmgr
-command="/usr/local/sbin/jailmgr"
+command="/usr/sbin/jailmgr"
 start_cmd="${name}_start"
 stop_cmd="${name}_stop"
 status_cmd="${name}_status"


### PR DESCRIPTION
### Motivation
- Ensure the `gen-rc` output emits the correct installed binary path so generated `/etc/rc.d` wrapper scripts match the in-tree install location and existing documentation.

### Description
- Update the `gen_rc()` template in `usr.sbin/jailmgr/jailmgr` to set `command="/usr/sbin/jailmgr"` instead of `"/usr/local/sbin/jailmgr"`.

### Testing
- Ran `rg -n "/usr/local/sbin/jailmgr|/usr/sbin/jailmgr" usr.sbin/jailmgr -S` to confirm the `gen-rc` snippet now references `/usr/sbin/jailmgr` (search shows the updated line).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f04f41118832aa0a222ca36d03226)