### PR TITLE
jailmgr: continue stop when supervise process is absent

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -110,7 +110,9 @@ stop_jail_processes() {
 	jid=$2
 	monitor_pid=$(jail_monitor_pid "${name}" "${jid}" || true)
 
-	[ -n "${monitor_pid}" ] || return
+	# A jail can be alive without an active supervise process (e.g. it already
+	# exited). In that case we still want stop_jail() to continue with destroy.
+	[ -n "${monitor_pid}" ] || return 0
 
 	kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
 	sleep 1


### PR DESCRIPTION
### Motivation
- Prevent `jailmgr stop` from aborting early under `set -e` when no `jailctl supervise` PID is found so the jail is still destroyed and unmounted.

### Description
- Return success (`return 0`) from `stop_jail_processes()` when `monitor_pid` is empty and add a short comment documenting the rationale.

### Testing
- Ran `sh -n usr.sbin/jailmgr/jailmgr` to verify script syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0cf6a7d0832a90616969d7f5d6fe)