### PR TITLE
jailmgr: shield supervise from rc SIGHUP and tolerate missing supervise on stop

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -110,7 +110,9 @@ stop_jail_processes() {
 	jid=$2
 	monitor_pid=$(jail_monitor_pid "${name}" "${jid}" || true)
 
-	[ -n "${monitor_pid}" ] || return
+	# A jail can be alive without an active supervise process (e.g. it already
+	# exited). In that case we still want stop_jail() to continue with destroy.
+	[ -n "${monitor_pid}" ] || return 0
 
 	kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
 	sleep 1
@@ -450,7 +452,9 @@ start_jail() {
 	require_supervise_cmd
 	# shellcheck disable=SC2086
 	set -- ${JAIL_SUPERVISE_CMD}
-	jailctl supervise "${name}" "$@"
+	# Start under nohup so rc(8)/run_rc_command SIGHUP does not terminate
+	# the jailctl supervisor right after boot-time startup.
+	nohup jailctl supervise "${name}" "$@" >/dev/null 2>&1
 	echo "Started jail ${name} at ${ip}"
 }
 


### PR DESCRIPTION
### Motivation
- The `jailctl` monitor treats `SIGHUP` as a shutdown trigger, which causes supervisors spawned from rc(8) to die immediately when the rc environment delivers a SIGHUP.  
- A jail can be present without an active `jailctl supervise` monitor, and `stop_jail()` should continue to destroy/unmount the jail in that case.

### Description
- In `start_jail()` (`usr.sbin/jailmgr/jailmgr`) run the supervise command under `nohup` and redirect output to `/dev/null` so `SIGHUP` from rc does not terminate the `jailctl supervise` monitor.  
- In `stop_jail_processes()` return success (`return 0`) when `monitor_pid` is empty and add a comment explaining the rationale so `stop_jail()` proceeds to destroy the jail even if no supervise process is found.  
- Changes are limited to `usr.sbin/jailmgr/jailmgr` and preserve existing argument-splitting semantics for `JAIL_SUPERVISE_CMD`.

### Testing
- Performed a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0cf6a7d0832a90616969d7f5d6fe)