### PR TITLE
jailmgr: use /etc/modules.conf for secmodel_jail persistence

### DIFF
--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -39,8 +39,8 @@ It can also:
    During bootstrap, `jailmgr` ensures:
 
    - module `secmodel_jail` is loaded (`modload secmodel_jail` when needed),
-   - `/etc/modules` exists,
-   - `/etc/modules` contains a `secmodel_jail` entry for reboot persistence.
+   - `/etc/modules.conf` exists,
+   - `/etc/modules.conf` contains a `secmodel_jail` entry for reboot persistence.
 
 4. Prepare each jail (writes `${JAIL_DATA_DIR}/<name>/jail.conf`):
 

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -153,13 +153,13 @@ ensure_secmodel_jail() {
 		echo "Loaded secmodel_jail module"
 	fi
 
-	if [ ! -f /etc/modules ]; then
-		: > /etc/modules
+	if [ ! -f /etc/modules.conf ]; then
+		: > /etc/modules.conf
 	fi
 
-	if ! grep -Eq '^[[:space:]]*secmodel_jail([[:space:]]|$)' /etc/modules; then
-		echo "secmodel_jail" >> /etc/modules
-		echo "Added secmodel_jail to /etc/modules"
+	if ! grep -Eq '^[[:space:]]*secmodel_jail([[:space:]]|$)' /etc/modules.conf; then
+		echo "secmodel_jail" >> /etc/modules.conf
+		echo "Added secmodel_jail to /etc/modules.conf"
 	fi
 }
 

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -59,7 +59,7 @@ kernel module is loaded,
 and persist
 .Li secmodel_jail
 in
-.Pa /etc/modules
+.Pa /etc/modules.conf
 for future boots.
 Then
 extract


### PR DESCRIPTION
### Motivation
- The bootstrap logic should persist the `secmodel_jail` module in the correct kernel module config file (`/etc/modules.conf`) so the module is reloaded across boots.

### Description
- Update `usr.sbin/jailmgr/jailmgr` to create and update `/etc/modules.conf` and report messages referring to `/etc/modules.conf` instead of `/etc/modules`, and update the `jailmgr(8)` manpage and the example `README` to reference `/etc/modules.conf`.

### Testing
- Performed a syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f50470ea8832aaebfc7aa99e64ba5)