### PR TITLE
jailmgr: run jailctl supervise in background during start

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -471,9 +471,11 @@ start_jail() {
 	require_supervise_cmd
 	# shellcheck disable=SC2086
 	set -- ${JAIL_SUPERVISE_CMD}
-	# Start under nohup so rc(8)/run_rc_command SIGHUP does not terminate
-	# the jailctl supervisor right after boot-time startup.
-	nohup jailctl supervise "${name}" "$@" >/dev/null 2>&1
+	# Start under nohup *and* in the background so rc(8)/run_rc_command does
+	# not keep it as the rc script foreground process.  Otherwise the
+	# supervisor can be tied to rc script lifetime and disappear once startup
+	# handling completes.
+	nohup jailctl supervise "${name}" "$@" >/dev/null 2>&1 &
 	echo "Started jail ${name} at ${ip}"
 }
 


### PR DESCRIPTION
### Motivation
- When `jailmgr` is launched via the generated rc.d script, `jailctl supervise` was started with `nohup` but left in the foreground, which can tie the supervisor to the rc script lifetime and cause the jail to stop after startup completes.

### Description
- Modify `start_jail()` in `usr.sbin/jailmgr/jailmgr` to run `jailctl supervise` with `nohup ... &` so the supervisor is backgrounded and detached from the rc script.
- Clarify the inline comment explaining why backgrounding is required when invoked from `rc(8)`.

### Testing
- Ran a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded.
- Inspected the resulting diff to confirm only the supervise launch semantics and comment were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f848855c8832a994143f7d0b7d133)