### PR TITLE
jailctl: ignore SIGHUP in supervise monitor (rc startup fix)

### DIFF
--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -307,8 +307,16 @@ jail_run_monitor(jailid_t id, const char *name, const char *logtag,
 	sigemptyset(&sa.sa_mask);
 	if (sigaction(SIGTERM, &sa, NULL) == -1 ||
 	    sigaction(SIGINT, &sa, NULL) == -1 ||
-	    sigaction(SIGHUP, &sa, NULL) == -1 ||
 	    sigaction(SIGQUIT, &sa, NULL) == -1)
+		err(1, "sigaction");
+
+	/*
+	 * Keep supervise mode detached from caller terminal/session lifetime.
+	 * If started via rc(8), startup completion can trigger SIGHUP delivery
+	 * to background jobs; treating SIGHUP as shutdown would stop the jail.
+	 */
+	sa.sa_handler = SIG_IGN;
+	if (sigaction(SIGHUP, &sa, NULL) == -1)
 		err(1, "sigaction");
 
 	monitor_shutdown_requested = 0;

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -471,9 +471,11 @@ start_jail() {
 	require_supervise_cmd
 	# shellcheck disable=SC2086
 	set -- ${JAIL_SUPERVISE_CMD}
-	# Start under nohup so rc(8)/run_rc_command SIGHUP does not terminate
-	# the jailctl supervisor right after boot-time startup.
-	nohup jailctl supervise "${name}" "$@" >/dev/null 2>&1
+	# Start under nohup *and* in the background so rc(8)/run_rc_command does
+	# not keep it as the rc script foreground process.  Otherwise the
+	# supervisor can be tied to rc script lifetime and disappear once startup
+	# handling completes.
+	nohup jailctl supervise "${name}" "$@" >/dev/null 2>&1 &
 	echo "Started jail ${name} at ${ip}"
 }
 


### PR DESCRIPTION
### Motivation
- Starting the supervisor under `nohup` alone was not sufficient when `rc(8)` or the caller session can still deliver `SIGHUP` to background jobs, causing the supervise monitor to treat `SIGHUP` as a shutdown and stop the jail. 
- The change aims to make supervision robust across rc/startup session detachment so supervised jails do not exit when startup bookkeeping completes.

### Description
- In `usr.sbin/jailctl/jailctl.c` update `jail_run_monitor()` signal setup to explicitly ignore `SIGHUP` by setting `sa.sa_handler = SIG_IGN` and calling `sigaction(SIGHUP, &sa, NULL)`; `SIGTERM`, `SIGINT`, and `SIGQUIT` remain handled by the existing shutdown handler. 
- Add an explanatory inline comment documenting that `SIGHUP` must be ignored to detach supervise mode from caller terminal/session lifetime and avoid rc(8)-triggered shutdowns.
- This complements the earlier change that backgrounds `jailctl supervise` from `jailmgr` so the supervisor is detached both at invocation and inside the monitor.

### Testing
- Ran `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded (shell syntax check passed). 
- Attempted to build `usr.sbin/jailctl` with `make`, which failed in this environment due to BSD makefile incompatibility with GNU `make` (`missing separator`). 
- Attempted to run `bmake` but `bmake` is not available in the container, so a native NetBSD build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f848855c8832a994143f7d0b7d133)