### PR TITLE
jailmgr: make per-jail IPv4 binding optional

### DIFF
--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -1,6 +1,6 @@
 # jailmgr (jailctl helper)
 
-`jailmgr` provisions and runs multiple IP-bound `jailctl` jails from one host-side configuration.
+`jailmgr` provisions and runs multiple `jailctl` jails from one host-side configuration.
 It uses one shared read-only base layer (from `base.tar.xz`) and per-jail writable state:
 
 - `etc`
@@ -16,8 +16,8 @@ It can also:
 
 ## Important command semantics
 
-- `prepare <name> <ip>` is the **only** command that takes an IP address.
-- `start <name>` and `restart <name>` always read the jail IP from `${JAIL_DATA_DIR}/<name>/jail.conf`.
+- `prepare <name> [ip]` optionally takes an IPv4 address.
+- `start <name>` and `restart <name>` always read the jail IP from `${JAIL_DATA_DIR}/<name>/jail.conf` (if set).
 - `start --all` / `restart --all` work on all configured jails.
 
 ## Workflow
@@ -46,7 +46,7 @@ It can also:
 
    ```sh
    /usr/sbin/jailmgr prepare jail1 10.0.0.1
-   /usr/sbin/jailmgr prepare jail2 10.0.0.2
+   /usr/sbin/jailmgr prepare jail2
    ```
 
 5. Start jails:
@@ -73,8 +73,8 @@ If `NPF_ENABLE=YES`, run:
 
 This writes `NPF_CONF_SNIPPET` with:
 
-- per-jail egress NAT (`map`) rules for each configured jail IP (when `NPF_NAT_ENABLE=YES`), and
-- `rdr` rules from each jail's `JAIL_NPF_RDR_LIST` in `${JAIL_DATA_DIR}/<name>/jail.conf`.
+- per-jail egress NAT (`map`) rules for each jail with `JAIL_IPV4` set (when `NPF_NAT_ENABLE=YES`), and
+- `rdr` rules from each jail's `JAIL_NPF_RDR_LIST` in `${JAIL_DATA_DIR}/<name>/jail.conf` when `JAIL_IPV4` is set.
 
 Include that snippet from `/etc/npf.conf` and optionally set `NPF_AUTO_RELOAD=YES`.
 
@@ -88,7 +88,7 @@ JAIL_NPF_RDR_LIST="2221:22 8080:80"
 ## Notes
 
 - The host must route the jail subnet appropriately (loopback aliases are handled by `jailmgr`).
-- `jailctl create -i <ip>` enforces per-jail IPv4 bind restrictions.
+- `jailctl create -i <ip>` enforces per-jail IPv4 bind restrictions; if no IP is configured, `jailmgr` creates the jail without `-i`.
 - `jailmgr start` uses `jailctl create` followed by `jailctl supervise`.
 - By default, bootstrap derives the set URL from `RELEASE` and `MACHINE_ARCH` as:
   `https://cdn.netbsd.org/pub/NetBSD/NetBSD-${RELEASE}/${MACHINE_ARCH}/binary/sets`

--- a/usr.sbin/jailmgr/examples/jailmgr.conf.sample
+++ b/usr.sbin/jailmgr/examples/jailmgr.conf.sample
@@ -16,7 +16,7 @@ JAIL_RELEASE_DIR=/var/jailmgr/releases
 JAIL_HOST_IF=lo0
 
 # Jail-specific settings are stored in ${JAIL_DATA_DIR}/<name>/jail.conf
-# and created/updated by: jailmgr prepare <name> <IPv4>
+# and created/updated by: jailmgr prepare <name> [IPv4]
 
 # User to create inside each jail (if not already present in master.passwd)
 JAIL_DEFAULT_USER=user

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Build and manage IP-bound jailctl jails with a shared read-only base layer.
+# Build and manage jailctl jails with a shared read-only base layer.
 #
 # Layout:
 #   /var/jailmgr/releases/<release>/<arch>/{base,etc}.tar.xz
@@ -64,7 +64,7 @@ Usage: $0 <command> [args]
 
 Commands:
   bootstrap                      Download sets and build shared base layer
-  prepare <name> <ip>            Create jail instance directories and persist jail.conf
+  prepare <name> [ip]            Create jail instance directories and persist jail.conf
   host-net-up                    Add host aliases (default on JAIL_HOST_IF=lo0) for all jail IPs
   host-net-down                  Remove host aliases for all jail IPs
   start <name>                   Mount jail root and supervise jail via jailctl
@@ -193,7 +193,7 @@ load_jail_conf() {
 	name=$1
 	jail_paths "${name}"
 	if [ ! -r "${JAIL_CONF}" ]; then
-		echo "missing ${JAIL_CONF}; run prepare ${name} <ip> first" >&2
+		echo "missing ${JAIL_CONF}; run prepare ${name} [ip] first" >&2
 		exit 1
 	fi
 
@@ -209,10 +209,6 @@ load_jail_conf() {
 	fi
 	if [ "${JAIL_NAME}" != "${name}" ]; then
 		echo "jail.conf mismatch: expected JAIL_NAME=${name}, got ${JAIL_NAME}" >&2
-		exit 1
-	fi
-	if [ -z "${JAIL_IPV4:-}" ]; then
-		echo "JAIL_IPV4 missing in ${JAIL_CONF}" >&2
 		exit 1
 	fi
 }
@@ -314,7 +310,7 @@ prepare_jail() {
 	need_root
 	require_tools
 	name=$1
-	ip=$2
+	ip=${2:-}
 
 	jail_paths "${name}"
 	mkdir -p "${ROOT_DIR}" "${ETC_DIR}" "${VAR_DIR}" "${TMP_DIR}" "${HOME_DIR}" \
@@ -335,7 +331,11 @@ JAIL_ARCH=${MACHINE_ARCH}
 JAIL_NPF_RDR_LIST=
 CONF
 
-	echo "Prepared jail ${name} (${ip})"
+	if [ -n "${ip}" ]; then
+		echo "Prepared jail ${name} (${ip})"
+	else
+		echo "Prepared jail ${name} (no IPv4 bind limit)"
+	fi
 }
 
 jail_exists() {
@@ -374,6 +374,7 @@ host_net_up() {
 host_net_up_one() {
 	name=$1
 	load_jail_conf "${name}"
+	[ -n "${JAIL_IPV4:-}" ] || return
 	add_alias "${JAIL_IPV4}"
 }
 
@@ -387,6 +388,7 @@ host_net_down() {
 host_net_down_one() {
 	name=$1
 	load_jail_conf "${name}"
+	[ -n "${JAIL_IPV4:-}" ] || return
 	del_alias "${JAIL_IPV4}"
 }
 
@@ -438,8 +440,10 @@ npf_sync() {
 			name=${jail_conf%/jail.conf}
 			name=${name##*/}
 			load_jail_conf "${name}"
-			if [ -n "${JAIL_NPF_RDR_LIST:-}" ]; then
+			if [ -n "${JAIL_NPF_RDR_LIST:-}" ] && [ -n "${JAIL_IPV4:-}" ]; then
 				emit_rdr_rules_for_jail "${name}" "${JAIL_IPV4}" "${JAIL_NPF_RDR_LIST}"
+			elif [ -n "${JAIL_NPF_RDR_LIST:-}" ]; then
+				echo "# skipped ${name}: JAIL_NPF_RDR_LIST set but JAIL_IPV4 is empty" >&2
 			fi
 		done
 
@@ -483,14 +487,16 @@ start_jail() {
 	name=$1
 
 	load_jail_conf "${name}"
-	ip=${JAIL_IPV4}
+	ip=${JAIL_IPV4:-}
 	if [ -n "${JAIL_SUPERVISE_CMD_LOCAL:-}" ]; then
 		JAIL_SUPERVISE_CMD=${JAIL_SUPERVISE_CMD_LOCAL}
 	fi
 
 	jail_paths "${name}"
 	[ -d "${ROOT_DIR}" ] || prepare_jail "${name}" "${ip}"
-	add_alias "${ip}"
+	if [ -n "${ip}" ]; then
+		add_alias "${ip}"
+	fi
 	mount_jail_root
 
 	if jail_exists "${name}"; then
@@ -498,7 +504,11 @@ start_jail() {
 		return
 	fi
 
-	jailctl create -n "${name}" -i "${ip}" "${ROOT_DIR}"
+	if [ -n "${ip}" ]; then
+		jailctl create -n "${name}" -i "${ip}" "${ROOT_DIR}"
+	else
+		jailctl create -n "${name}" "${ROOT_DIR}"
+	fi
 	require_supervise_cmd
 	# shellcheck disable=SC2086
 	set -- ${JAIL_SUPERVISE_CMD}
@@ -507,7 +517,11 @@ start_jail() {
 	# supervisor can be tied to rc script lifetime and disappear once startup
 	# handling completes.
 	nohup jailctl supervise "${name}" "$@" >/dev/null 2>&1 &
-	echo "Started jail ${name} at ${ip}"
+	if [ -n "${ip}" ]; then
+		echo "Started jail ${name} at ${ip}"
+	else
+		echo "Started jail ${name}"
+	fi
 }
 
 stop_jail() {
@@ -611,8 +625,14 @@ case "${cmd}" in
 		build_base
 		;;
 	prepare)
-		[ $# -eq 3 ] || { usage; exit 1; }
-		prepare_jail "$2" "$3"
+		if [ $# -eq 2 ]; then
+			prepare_jail "$2"
+		elif [ $# -eq 3 ]; then
+			prepare_jail "$2" "$3"
+		else
+			usage
+			exit 1
+		fi
 		;;
 	host-net-up)
 		host_net_up

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -30,7 +30,7 @@ and a jail-local
 .Pa /dev ,
 and
 .It
-IP-based jail naming and lifecycle management via
+optional IPv4-bound jail naming and lifecycle management via
 .Xr jailctl 8 .
 .El
 .Pp
@@ -45,7 +45,7 @@ environment variable.
 Most commands require superuser privileges.
 .Sh COMMANDS
 The following commands are supported:
-.Bl -tag -width "prepare name ip"
+.Bl -tag -width "prepare name [ip]"
 .It Cm bootstrap
 Download
 .Pa base.tar.xz
@@ -65,7 +65,7 @@ Then
 extract
 .Pa base.tar.xz
 into the configured shared base layer directory.
-.It Cm prepare Ar name Ar ip
+.It Cm prepare Ar name Op Ar ip
 Create directories and metadata for one jail:
 .Pa root ,
 .Pa etc ,
@@ -90,8 +90,11 @@ on interface
 Remove those host-side IPv4 aliases.
 .It Cm start Ar name
 Mount the composed jail root and start the jail with
-.Xr jailctl 8 , using the IPv4 address stored in
+.Xr jailctl 8 , using the optional IPv4 address stored in
 .Pa jail.conf .
+When no IPv4 is set, the jail is created without
+.Fl i
+binding restrictions.
 .It Cm start Cm --all
 Run
 .Cm host-net-up
@@ -119,7 +122,7 @@ for jail
 .Ar name
 and then
 .Cm start
-for the same jail, using the IPv4 address from
+for the same jail, using the optional IPv4 address from
 .Pa jail.conf .
 .It Cm restart Cm --all
 Run
@@ -133,7 +136,8 @@ When
 .Ev NPF_NAT_ENABLE
 is
 .Dq YES ,
-egress NAT rules are generated for each configured jail IP
+egress NAT rules are generated for each jail with a configured
+.Ev JAIL_IPV4
 .Pq one Li map rule per jail .
 Additionally, redirection rules are generated from each jail's
 .Ev JAIL_NPF_RDR_LIST
@@ -245,6 +249,11 @@ to generate
 rules for that jail's
 .Ev JAIL_IPV4
 address.
+If
+.Ev JAIL_IPV4
+is empty, per-jail
+.Li rdr
+rule generation is skipped.
 .El
 .Sh FILES
 .Bl -tag -width "/usr/share/examples/jailmgr/jailmgr.conf.sample"
@@ -262,7 +271,7 @@ Prepare and start all configured jails:
 # vi /etc/jailmgr.conf
 # jailmgr bootstrap
 # jailmgr prepare jail1 10.0.0.1
-# jailmgr prepare jail2 10.0.0.2
+# jailmgr prepare jail2              # no per-jail IPv4 bind limit
 # jailmgr start --all
 .Ed
 .Pp


### PR DESCRIPTION
### Motivation
- Make the per-jail IPv4 bind an opt-in setting so jails can be created and started without a host-side IPv4 alias or `jailctl -i` restriction when an address is not required.

### Description
- Allow `prepare` to accept an optional IPv4 argument (`prepare <name> [ip]`) and persist an empty `JAIL_IPV4` when none is provided by writing `${JAIL_DATA_DIR}/<name>/jail.conf` accordingly.
- Remove the hard requirement for `JAIL_IPV4` when loading a jail config and change error text to match the new `prepare` usage.
- Only add host aliases and pass `-i <ip>` to `jailctl create` when `JAIL_IPV4` is set, otherwise create the jail without `-i`; also only call `add_alias`/`del_alias` when an IP is configured.
- Make `npf-sync` emit per-jail `map`/`rdr` rules only when a jail has `JAIL_IPV4` set and explicitly skip `JAIL_NPF_RDR_LIST` entries if `JAIL_IPV4` is empty, and update the manpage, README, and sample config to document the new behavior.

### Testing
- Performed a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr` which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699037382d9c832aaf0cb41c34e2fdae)