### PR TITLE
doc: add current-implementation specification for secmodel_jail stack

### DIFF
--- a/doc/jail-stack-specification.txt
+++ b/doc/jail-stack-specification.txt
@@ -1,0 +1,276 @@
+secmodel_jail / jailctl / jailmgr
+Current Implementation Specification
+===================================
+
+Status
+------
+This document describes the behavior implemented by the current tree for:
+
+- secmodel_jail (kernel security model)
+- jailctl (low-level userland control utility)
+- jailmgr (higher-level multi-jail manager)
+
+The scope is intentionally pragmatic: process isolation first, host networking
+by design (not virtualized), and simple operational workflows.
+
+
+1. Design Goals
+---------------
+
+1.1 Primary Goal: Process Isolation
+- Isolate service processes into jail membership domains identified by jail IDs.
+- Restrict process visibility and signal delivery across jail boundaries.
+- Keep host-root (effective uid 0, jail id 0) as the explicit control plane.
+
+1.2 Explicit Networking Model: Use Host Network Stack
+- The solution deliberately reuses the host network stack.
+- There is no attempt to virtualize per-jail network namespaces, interfaces,
+  routing tables, or independent TCP/IP stacks.
+- Optional per-jail bind-port allow-lists are enforced as an authorization
+  layer, not as network virtualization.
+
+1.3 Operational Simplicity and Low Overhead
+- Favor lightweight primitives already present in NetBSD:
+  - kauth listeners
+  - sysctl control points
+  - chroot-based root switching
+  - mount_null / tmpfs composition in shell tooling
+- Keep workflows close to service management usage (container-like operation)
+  while avoiding full VM complexity.
+
+1.4 Security Improvements at Obvious Control Points
+- Restrict inter-jail process signaling and process discovery.
+- Optionally restrict bind() to host-approved non-zero ports.
+- Optionally apply CPU and memory limits per jail.
+
+1.5 Out-of-Scope / Non-Goals
+- No full-system virtualization semantics.
+- No per-jail network stack virtualization.
+- No claim of hypervisor-grade isolation boundaries.
+- For stronger tenant isolation or virtualized networking, use full
+  virtualization (for example Xen) instead of this jail model.
+
+
+2. Architecture Overview
+------------------------
+
+2.1 Layer Responsibilities
+- secmodel_jail (kernel):
+  - owns jail IDs and jail metadata
+  - enforces process/network/resource policy
+  - exposes sysctl API for create/enter/list/destroy and resource mode
+- jailctl (C utility):
+  - thin operational interface to the secmodel_jail sysctls
+  - creates named jails with root path + optional limits/policies
+  - enters jails and executes commands
+  - supervises jail command output through syslog in detached mode
+- jailmgr (sh utility):
+  - manages many jails from one config
+  - builds and mounts layered filesystem layout
+  - starts/stops jails via jailctl
+
+2.2 Security Boundary Model
+- Membership is encoded in credential-specific data (jail id).
+- Kernel policy checks compare caller jail id vs target process jail id.
+- Host root in host jail remains globally privileged.
+
+
+3. secmodel_jail Specification (Kernel)
+---------------------------------------
+
+3.1 Jail Identity and Metadata
+- Jail IDs are monotonic uint32 IDs starting at 1.
+- Jail ID 0 is reserved for host context.
+- Each jail entry stores:
+  - jail id
+  - name
+  - root path (metadata for userland workflows)
+  - optional CPU limit
+  - optional memory limit
+  - optional allowed bind ports
+- Jail destroy is refused while any process (including zombies) still has that
+  jail ID.
+
+3.2 Privilege Model
+- Host root is defined as: effective uid 0 and jail id 0.
+- Only host root may:
+  - create jails
+  - destroy jails
+  - read/write jail id sysctl
+  - read jail list
+  - change resource mode
+- Entering a jail is a privileged operation.
+
+3.3 Process Isolation Rules
+- KAUTH_PROCESS_CANSEE: deny cross-jail visibility.
+- KAUTH_PROCESS_SIGNAL: deny cross-jail signaling.
+- Host root bypasses these restrictions.
+
+3.4 Credential Lifecycle Integration
+- New credentials initialize with jail id 0.
+- Credential copies preserve jail id.
+
+3.5 Network Bind Authorization
+- Hook point: KAUTH_NETWORK_BIND.
+- Applies when jail has an allowed-port list.
+- Supports AF_INET and AF_INET6 bind checks.
+- Port 0 (ephemeral bind request) is not blocked by allow-list logic.
+- Non-zero ports not present in configured allow-list are denied.
+- This is authorization-only; it does not rewrite addresses or virtualize
+  networking.
+
+3.6 Resource Enforcement
+
+3.6.1 Modes
+- security.models.jail.resource_mode:
+  - 0 = RLIMIT mode (per-process RLIMIT_CPU / RLIMIT_AS at jail entry)
+  - 1 = Aggregate mode (default): jail-wide accounting based admission checks
+    and memory growth veto
+
+3.6.2 RLIMIT Mode
+- On jail entry, configured CPU/memory limits are applied to the entering
+  process via dosetrlimit().
+- CPU milliseconds are rounded up to seconds for RLIMIT_CPU.
+- Existing processes are not retroactively rewritten when mode changes.
+
+3.6.3 Aggregate Mode
+- Jail-wide usage is computed by summing per-process runtime CPU and VM map size.
+- Admission checks:
+  - deny jail entry when over configured limit
+  - deny fork when over configured limit
+- Memory growth check:
+  - secmodel_jail registers a UVM callback and denies growth with ENOMEM when
+    projected jail memory usage would exceed configured limit
+- CPU behavior is explicitly admission-oriented in aggregate mode:
+  - no asynchronous kill/throttle of already-running members from aggregate CPU
+    policy
+
+3.7 Sysctl API
+- security.models.jail.id
+  - read current process jail id
+  - write to request entering a jail id
+- security.models.jail.create
+  - create jail entry (legacy integer or struct jail_create)
+- security.models.jail.destroy
+  - destroy jail id (must be empty)
+- security.models.jail.list
+  - list active jails with metadata + process refcounts
+- security.models.jail.resource_mode
+  - select RLIMIT vs aggregate behavior
+
+3.8 Logging
+- Logs on module load/unload.
+- Logs successful create/destroy operations.
+- Logs rate-limited informational resource veto events (e.g., enter/fork/uvm).
+
+
+4. jailctl Specification (Userland Control Tool)
+-------------------------------------------------
+
+4.1 Command Surface
+- create [-c cpu-ms] [-m bytes] [-p ports] -n name <root>
+- supervise [-p priority] [-t tag] <jail-id|name> <command...>
+- destroy <jail-id|name>
+- exec <jail-id|name> [command...]
+- list
+
+4.2 Data Flow
+- Uses sysctlbyname() on security.models.jail.* nodes.
+- Uses struct jail_create for metadata and optional limits/policies.
+
+4.3 Create Behavior
+- Requires unique jail name.
+- Stores jail name and root string in kernel metadata.
+- Optional policies:
+  - CPU limit in milliseconds
+  - memory limit in bytes
+  - comma-separated allowed bind ports
+
+4.4 Exec Behavior
+- chdir(root), chroot("."), chdir("/")
+- enter target jail id via security.models.jail.id
+- execute command, or interactive shell when omitted
+
+4.5 Supervise Behavior
+- Forks into detached monitor and child command process.
+- Child runs in target jail root and jail id.
+- Child stdout/stderr are streamed to syslog with jail name/id context.
+- On supervisor shutdown signal:
+  - sends SIGTERM to child process group
+  - escalates to SIGKILL after grace timeout
+
+4.6 Listing and Resolution
+- list prints id, process count, name, root.
+- Target selection accepts either numeric jail ID or jail name.
+
+
+5. jailmgr Specification (Operational Manager)
+-----------------------------------------------
+
+5.1 Purpose
+- Simplify provisioning and lifecycle management for multiple jails.
+- Provide a container-like service management workflow on top of jailctl.
+
+5.2 Filesystem Composition Model
+- Shared read-only base layer extracted from base.tar.xz.
+- Per-jail writable directories for:
+  - etc, var, tmp, home
+  - optional local /dev tmpfs with MAKEDEV population
+- Root composition via mount_null overlays.
+
+5.3 Configuration Model
+- Global config: /etc/jailmgr.conf (or JAILMGR_CONF override).
+- Per-jail config: ${JAIL_DATA_DIR}/<name>/jail.conf.
+- Supports global and per-jail supervised command selection.
+- Supports per-jail JAIL_PORTS passed through to jailctl create -p.
+
+5.4 Commands
+- bootstrap:
+  - ensure secmodel_jail module loaded and persisted in modules.conf
+  - fetch base.tar.xz and etc.tar.xz
+  - build shared base layer
+- prepare <name>:
+  - create per-jail directory structure
+  - initialize etc layer and basic defaults
+  - generate jail.conf metadata
+- start <name>|--all:
+  - mount composed root
+  - create jail (with optional bind-port policy)
+  - run jailctl supervise with configured service command
+- stop <name>|--all:
+  - stop supervise process
+  - destroy jail
+  - unmount root composition
+- restart <name>|--all:
+  - stop then start
+- status:
+  - jailctl list plus mount status
+- gen-rc:
+  - generate rc.d wrapper script
+
+
+6. Security and Operational Positioning
+---------------------------------------
+
+6.1 What This Stack Is Good At
+- Efficient service isolation and management on one host.
+- Lightweight container-like operations with low conceptual overhead.
+- Clear host-centric control over process interaction and bind permissions.
+
+6.2 What This Stack Does Not Attempt
+- It does not emulate full VM isolation characteristics.
+- It does not virtualize networking per jail.
+
+6.3 Recommended Escalation Path
+- If requirements include hard tenant isolation, deep network isolation,
+  or virtual hardware semantics, prefer full virtualization (e.g. Xen).
+
+
+7. Compatibility and Evolution Notes
+------------------------------------
+- resource_mode switching affects future checks only.
+- Existing process RLIMIT values are not rewritten on mode switch.
+- Port policy is deny-by-default only when a list is configured.
+- Process isolation behavior depends on jail ID assignment in credentials;
+  host-root control plane remains intentionally global.
+


### PR DESCRIPTION
### Motivation
- Provide a concise, human-readable specification describing the current implementation and operational intent for `secmodel_jail`, `jailctl`, and `jailmgr` so maintainers and operators can reason about behavior and trade-offs. 
- Capture explicit design goals: prioritize process isolation, intentionally reuse the host network stack (no per-jail network virtualization), keep the solution lightweight and simple, and document targeted security controls such as process signaling restrictions and host-defined bind-port allow-lists. 

### Description
- Add `doc/jail-stack-specification.txt` containing an English specification that documents architecture, kernel policy, resource modes, the `sysctl` API, `jailctl` command semantics, and `jailmgr` operational workflows. 
- The document records kernel semantics including jail ID lifecycle, credential integration, `KAUTH` hooks for process visibility and `KAUTH_NETWORK_BIND` for port allow-lists, RLIMIT vs aggregate resource modes, and logging behavior. 
- The document summarizes `jailctl` behavior (create/exec/supervise/destroy/list), how it uses the `security.models.jail.*` `sysctl` nodes, and the `jailmgr` provisioning and mount/composition model for multi-jail management. 
- No kernel or userland code paths were changed; this is documentation-only and the file is placed under `doc/` at the source root. 

### Testing
- Verified the new file was written to `doc/jail-stack-specification.txt` and recorded in the repository by successfully staging and committing the file. 
- Performed repository checks (`git status --short`) to confirm there are no uncommitted changes; no automated unit tests were applicable because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69907b8a88e0832ab84bc0b28bfc2a84)