### PR TITLE
jailmgr: prevent per-jail supervise command from leaking between jails

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -404,12 +404,16 @@ start_jail() {
 	name=$1
 
 	load_jail_conf "${name}"
+	effective_supervise_cmd=${JAIL_SUPERVISE_CMD}
 	if [ -n "${JAIL_SUPERVISE_CMD_LOCAL:-}" ]; then
-		JAIL_SUPERVISE_CMD=${JAIL_SUPERVISE_CMD_LOCAL}
+		effective_supervise_cmd=${JAIL_SUPERVISE_CMD_LOCAL}
 	fi
 	ports=${JAIL_PORTS:-}
 	validate_jail_ports "${ports}"
-	require_supervise_cmd
+	if [ -z "${effective_supervise_cmd}" ]; then
+		echo "JAIL_SUPERVISE_CMD must be set in ${CONF_FILE} (example: /bin/sh /etc/rc)" >&2
+		exit 1
+	fi
 
 	jail_paths "${name}"
 	[ -d "${ROOT_DIR}" ] || prepare_jail "${name}"
@@ -426,7 +430,7 @@ start_jail() {
 		jailctl create -n "${name}" "${ROOT_DIR}"
 	fi
 	# shellcheck disable=SC2086
-	set -- ${JAIL_SUPERVISE_CMD}
+	set -- ${effective_supervise_cmd}
 	# Start under nohup *and* in the background so rc(8)/run_rc_command does
 	# not keep it as the rc script foreground process.  Otherwise the
 	# supervisor can be tied to rc script lifetime and disappear once startup


### PR DESCRIPTION
### Motivation
- Fix a bug where a per-jail `JAIL_SUPERVISE_CMD_LOCAL` could overwrite the global `JAIL_SUPERVISE_CMD` and be unintentionally reused for subsequent jails when running `start --all`.
- Ensure per-jail overrides are applied only to the current jail so behavior is deterministic per jail.

### Description
- Compute a per-jail `effective_supervise_cmd` initialized from the global `JAIL_SUPERVISE_CMD` and override it with `JAIL_SUPERVISE_CMD_LOCAL` when present.
- Stop mutating the global `JAIL_SUPERVISE_CMD` value inside `start_jail()` to avoid state leakage across iterations.
- Validate that `effective_supervise_cmd` is set and use it for `set --` before invoking `jailctl supervise` so each jail gets the correct supervise command.

### Testing
- The script passes a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d13e6540832a8b2a48c989577670)