### PR TITLE
jailmgr: mount writable /usr/pkg for each jail

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -32,7 +32,7 @@
 # Layout:
 #   /var/jailmgr/releases/<release>/<arch>/{base,etc}.tar.xz
 #   /var/jailmgr/base/<release>-<arch>/
-#   /var/jailmgr/jails/<name>/{root,etc,var,tmp,home}
+#   /var/jailmgr/jails/<name>/{root,etc,var,tmp,home,pkg}
 #
 # Config:
 #   /etc/jailmgr.conf
@@ -213,6 +213,7 @@ jail_paths() {
 	VAR_DIR="${JAIL_DIR}/var"
 	TMP_DIR="${JAIL_DIR}/tmp"
 	HOME_DIR="${JAIL_DIR}/home"
+	PKG_DIR="${JAIL_DIR}/pkg"
 	DEV_DIR="${JAIL_DIR}/dev"
 	JAIL_CONF="${JAIL_DIR}/jail.conf"
 }
@@ -318,6 +319,7 @@ setup_etc() {
 mount_jail_root() {
 	# Ensure mount targets exist in the base layer before mounting it read-only.
 	mkdir -p "${BASE_LAYER}/home"
+	mkdir -p "${BASE_LAYER}/usr/pkg"
 
 	if mount | awk -v p="on ${ROOT_DIR} " 'index($0,p){found=1} END{exit !found}'; then
 		return
@@ -328,11 +330,12 @@ mount_jail_root() {
 	mount -t null "${VAR_DIR}" "${ROOT_DIR}/var"
 	mount -t null "${TMP_DIR}" "${ROOT_DIR}/tmp"
 	mount -t null "${HOME_DIR}" "${ROOT_DIR}/home"
+	mount -t null "${PKG_DIR}" "${ROOT_DIR}/usr/pkg"
 	setup_local_dev
 }
 
 umount_jail_root() {
-	for d in dev/pts dev home tmp var etc ""; do
+	for d in dev/pts dev usr/pkg home tmp var etc ""; do
 		mp="${ROOT_DIR}${d:+/$d}"
 		if mount | awk -v p="on ${mp} " 'index($0,p){found=1} END{exit !found}'; then
 			umount "${mp}"
@@ -346,7 +349,7 @@ prepare_jail() {
 	name=$1
 
 	jail_paths "${name}"
-	mkdir -p "${ROOT_DIR}" "${ETC_DIR}" "${VAR_DIR}" "${TMP_DIR}" "${HOME_DIR}" \
+	mkdir -p "${ROOT_DIR}" "${ETC_DIR}" "${VAR_DIR}" "${TMP_DIR}" "${HOME_DIR}" "${PKG_DIR}" \
 		"${DEV_DIR}" "${VAR_DIR}/run" "${VAR_DIR}/log"
 	if [ -n "${JAIL_DEFAULT_USER}" ]; then
 		mkdir -p "${HOME_DIR}/${JAIL_DEFAULT_USER}"

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -26,6 +26,7 @@ per-jail writable directories for
 .Pa /var ,
 .Pa /tmp ,
 .Pa /home ,
+.Pa /usr/pkg ,
 and a jail-local
 .Pa /dev ,
 and
@@ -75,6 +76,7 @@ Create directories and metadata for one jail:
 .Pa var ,
 .Pa tmp ,
 .Pa home ,
+.Pa pkg ,
 and
 .Pa dev .
 If necessary,


### PR DESCRIPTION
### Motivation

- Jails sollen zusätzlich zu den bereits vorhandenen per-jail schreibbaren Verzeichnissen wie `var` auch ein eigenes `usr/pkg` erhalten, damit Paketinstallationen pro Jail möglich und getrennt vom read-only Base-Layer sind.

### Description

- Introduced a per-jail host directory variable `PKG_DIR="${JAIL_DIR}/pkg"` and updated layout comments to include `pkg` in `usr.sbin/jailmgr/jailmgr`.
- Ensure the shared base layer contains the mount target by creating `${BASE_LAYER}/usr/pkg` before mounting the read-only base in `mount_jail_root` and mount `${PKG_DIR}` at the jail path `/usr/pkg`.
- Add `${PKG_DIR}` to the directories created by `prepare_jail` and include `/usr/pkg` in the unmount sequence in `umount_jail_root` so teardown cleans it up.
- Update the `jailmgr(8)` manpage `usr.sbin/jailmgr/jailmgr.8` to document `/usr/pkg`/`pkg` as a per-jail writable directory.

### Testing

- Ran a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded.
- Attempted to lint the manpage with `mandoc -Tlint -Wwarning usr.sbin/jailmgr/jailmgr.8`, but `mandoc` is not available in the environment so this check could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d55b2ef8832aa56e083ab6f293a6)