### PR TITLE
npf: add `jail` rule qualifier and align jail docs with process-isolation intent

### DIFF
--- a/doc/NPF-jail-qualifier-integration-spec.txt
+++ b/doc/NPF-jail-qualifier-integration-spec.txt
@@ -1,0 +1,201 @@
+NPF + Jail Qualifier Integration Specification
+=============================================
+
+Overview
+--------
+This document describes the implemented end-to-end integration of jail-aware
+matching in NPF filter rules.
+
+Primary goals:
+- Allow policy authors to bind a rule to jail ownership using `jail <name>`.
+- Prevent accidental host/jail service exposure overlap by making inbound
+  ownership policy explicit.
+- Keep rule intent preserved from parser -> userspace rule object -> kernel
+  rule representation -> runtime packet evaluation.
+
+
+1) User-visible Rule Semantics
+------------------------------
+1.1 Optional jail qualifier
+- A filter rule may include an optional jail selector:
+  - `jail <name>`
+- `<name>` is matched against jail name in credentials.
+
+1.2 Outbound semantics
+- For outbound packets, `jail <name>` is evaluated against the jail attached
+  to the originating socket credentials.
+- If `jail` is not present, no jail-name restriction is applied for outbound.
+
+1.3 Inbound semantics
+- For inbound TCP/UDP packets, `jail <name>` is evaluated against the jail of
+  the local socket owner (service endpoint) resolved by PCB lookup.
+- For inbound rules without `jail`, host-only semantics are enforced when a
+  local service socket owner is identified (equivalent to jail id 0).
+
+1.4 Inbound traffic that has no local socket owner context
+- Inbound jail ownership checks are service-owner checks.
+- If no local socket owner can be resolved (for example pure transit/non-local
+  traffic), behavior is:
+  - explicit `jail <name>`: rule does not match,
+  - no `jail` qualifier: legacy/non-jail-restricted behavior is preserved.
+
+
+2) Configuration Parsing, Build, and API Flow
+---------------------------------------------
+2.1 `npfctl` grammar and parser
+- `jail` is accepted as an optional rule clause.
+- Parsed value is carried through rule construction.
+
+2.2 Rule build metadata
+- Rule builder stores the parsed qualifier as rule metadata key:
+  - `jail-name`
+
+2.3 libnpf API extension
+- Rule metadata setter added:
+  - `npf_rule_setjailname(...)`
+
+
+3) Kernel Rule Representation
+-----------------------------
+- Kernel NPF rule object carries optional jail metadata:
+  - jail name string
+- Metadata is imported/exported via nvlist key:
+  - `jail-name`
+
+
+4) Runtime Enforcement Model (Packet Path)
+------------------------------------------
+4.1 Hooking model
+- IPv4/IPv6 input/output paths call pfil hooks.
+- NPF runs on both directions (`PFIL_IN`, `PFIL_OUT`).
+
+4.2 Outbound path
+- Before `PFIL_OUT`, IPv4/IPv6 output paths tag mbufs with:
+  - `PACKET_TAG_SO` containing `struct socket *`
+- NPF reads socket credentials from that tag and applies jail match.
+
+4.3 Inbound path
+- Inbound packets usually do not carry a service-owner socket tag.
+- NPF resolves local socket ownership for TCP/UDP via PCB lookup:
+  - IPv4 and IPv6 supported,
+  - first a full 4-tuple lookup,
+  - then bound/listening fallback.
+- If a local socket is found, NPF evaluates its credentials against the
+  configured jail selector (or host-only default when selector is absent).
+
+4.4 Decision integration point
+- Jail ownership matching is part of rule match evaluation and is applied
+  together with direction/interface/code checks.
+
+
+5) secmodel_jail Integration
+----------------------------
+- Exported reusable helper for credential ownership checks:
+  - `secmodel_jail_cred_matches(kauth_cred_t, const char *)`
+- Matching behavior:
+  - `name != NULL`: credential jail must exist and have matching jail name,
+  - `name == NULL`: credential must be host jail (id 0).
+
+
+6) End-to-End Policy Examples
+-----------------------------
+6.1 Outbound traffic restricted to a specific jail
+
+Example rule:
+
+    pass out final on wm0 proto tcp from any to any jail "proxy"
+
+Meaning:
+- Packet must be outbound.
+- Originating socket credentials must belong to jail `proxy`.
+- Host or other jails do not match this rule.
+
+6.2 Inbound service exposed only from jail `proxy`
+
+Example rule:
+
+    pass in final on wm0 proto tcp to 203.0.113.10 port 443 jail "proxy"
+
+Meaning:
+- NPF resolves local TCP socket owner for destination service.
+- Rule matches only if owner credentials are in jail `proxy`.
+- Host-owned TLS service on same address/port shape does not match.
+
+6.3 Inbound host-only default when `jail` is omitted
+
+Example rule:
+
+    pass in final on wm0 proto tcp to 203.0.113.10 port 22
+
+Meaning:
+- If local socket owner is found, it must be host jail (id 0).
+- Jail-owned sshd does not match this rule.
+
+6.4 Mixed explicit policy for host + jail services
+
+Example:
+
+    pass in final on wm0 proto tcp to 203.0.113.10 port 22
+    pass in final on wm0 proto tcp to 203.0.113.10 port 443 jail "proxy"
+
+Meaning:
+- SSH is explicitly host-owned.
+- HTTPS is explicitly jail-owned by `proxy`.
+- Reduces ambiguity and accidental cross-exposure.
+
+6.5 Transit/non-local inbound packets
+
+Example rule without `jail`:
+
+    pass in on wm0 from any to any
+
+Meaning:
+- If no local service-owner socket context exists, rule remains unrestricted by
+  jail ownership.
+- If `jail "name"` were added, such packet would not match unless owner context
+  can be resolved and matches.
+
+
+7) Security Intent
+------------------
+- Make service ownership in policy explicit.
+- Reduce misconfiguration risk when host and jail services can overlap on
+  addresses/ports.
+- Preserve backward-compatible behavior for traffic classes where local
+  service-owner context does not exist.
+
+
+8) Scope and Current Limits
+---------------------------
+- Inbound ownership checks are implemented for TCP/UDP service-bound traffic
+  via PCB lookup.
+- Non-socket traffic classes are not ownership-matched through this mechanism.
+- Name-based jail matching depends on secmodel_jail state and credential data.
+
+
+9) Documentation Alignment
+--------------------------
+- `npf.conf.5` documents:
+  - `jail` qualifier syntax,
+  - outbound socket-owner semantics,
+  - inbound socket-owner semantics,
+  - host-only default semantics for inbound rules without `jail`.
+
+
+10) Architectural Intent and Rationale
+--------------------------------------
+- The architecture deliberately keeps `secmodel_jail` focused on process
+  isolation and credential-domain enforcement.
+- A virtual per-jail network stack or network namespaces are intentionally not
+  part of the current design because they would significantly increase system
+  and operational complexity, which conflicts with the goal of a pragmatic and
+  understandable implementation.
+- Earlier experiments with kauth-based bind restrictions (for example alias-IP
+  pinning or strict per-port bind policies) exposed practical limits in real
+  scenarios (for example DNS) and often required brittle workarounds.
+- The NPF-based approach does not prevent jailed processes from binding
+  arbitrary local ports.  Instead, it ensures that external exposure of those
+  ports can be made explicit and intentional through firewall policy
+  (`jail <name>` + direction/protocol/address/port constraints).
+- This separation keeps secmodel_jail simple and predictable while using NPF
+  for the network-exposure boundary where that control naturally belongs.

--- a/doc/jail-stack-specification.txt
+++ b/doc/jail-stack-specification.txt
@@ -12,6 +12,8 @@ This document describes the behavior implemented by the current tree for:
 
 The scope is intentionally pragmatic: process isolation first, host networking
 by design (not virtualized), and simple operational workflows.
+Network virtualization (per-jail stacks/namespaces) is intentionally out of
+scope due to complexity and maintainability costs.
 
 
 1. Design Goals
@@ -26,8 +28,8 @@ by design (not virtualized), and simple operational workflows.
 - The solution deliberately reuses the host network stack.
 - There is no attempt to virtualize per-jail network namespaces, interfaces,
   routing tables, or independent TCP/IP stacks.
-- Optional per-jail bind-port allow-lists are enforced as an authorization
-  layer, not as network virtualization.
+- This is a conscious architecture decision: secmodel_jail focuses on process
+  isolation and credential-based membership, not network stack virtualization.
 
 1.3 Operational Simplicity and Low Overhead
 - Favor lightweight primitives already present in NetBSD:
@@ -40,8 +42,9 @@ by design (not virtualized), and simple operational workflows.
 
 1.4 Security Improvements at Obvious Control Points
 - Restrict inter-jail process signaling and process discovery.
-- Optionally restrict bind() to host-approved non-zero ports.
-- Optionally apply CPU and memory limits per jail.
+- Apply CPU and memory limits per jail (optional).
+- Integrate with NPF jail-aware filtering to make external service exposure
+  explicit at firewall policy level.
 
 1.5 Out-of-Scope / Non-Goals
 - No full-system virtualization semantics.
@@ -87,7 +90,6 @@ by design (not virtualized), and simple operational workflows.
   - root path (metadata for userland workflows)
   - optional CPU limit
   - optional memory limit
-  - optional allowed bind ports
 - Jail destroy is refused while any process (including zombies) still has that
   jail ID.
 
@@ -110,14 +112,17 @@ by design (not virtualized), and simple operational workflows.
 - New credentials initialize with jail id 0.
 - Credential copies preserve jail id.
 
-3.5 Network Bind Authorization
-- Hook point: KAUTH_NETWORK_BIND.
-- Applies when jail has an allowed-port list.
-- Supports AF_INET and AF_INET6 bind checks.
-- Port 0 (ephemeral bind request) is not blocked by allow-list logic.
-- Non-zero ports not present in configured allow-list are denied.
-- This is authorization-only; it does not rewrite addresses or virtualize
-  networking.
+3.5 Network Scope and Exposure Control
+- secmodel_jail does not currently implement per-jail network namespaces or a
+  virtual TCP/IP stack.
+- Processes in jails may bind to host addresses/ports subject to normal host
+  networking rules.
+- This is intentional: prior experiments with kauth-based bind restrictions
+  (e.g., alias-IP-only binding or strict per-port policies) showed limitations
+  in real workloads (for example DNS) and required brittle workarounds.
+- Instead, network exposure is controlled explicitly at packet-filter policy
+  level via NPF jail-aware rules (`jail <name>`), which keeps architecture and
+  operations simpler while making external exposure intentional.
 
 3.6 Resource Enforcement
 
@@ -168,7 +173,7 @@ by design (not virtualized), and simple operational workflows.
 -------------------------------------------------
 
 4.1 Command Surface
-- create [-c cpu-ms] [-m bytes] [-p ports] -n name <root>
+- create [-c cpu-ms] [-m bytes] -n name <root>
 - supervise [-p priority] [-t tag] <jail-id|name> <command...>
 - destroy <jail-id|name>
 - exec <jail-id|name> [command...]
@@ -184,7 +189,6 @@ by design (not virtualized), and simple operational workflows.
 - Optional policies:
   - CPU limit in milliseconds
   - memory limit in bytes
-  - comma-separated allowed bind ports
 
 4.4 Exec Behavior
 - chdir(root), chroot("."), chdir("/")
@@ -222,7 +226,6 @@ by design (not virtualized), and simple operational workflows.
 - Global config: /etc/jailmgr.conf (or JAILMGR_CONF override).
 - Per-jail config: ${JAIL_DATA_DIR}/<name>/jail.conf.
 - Supports global and per-jail supervised command selection.
-- Supports per-jail JAIL_PORTS passed through to jailctl create -p.
 
 5.4 Commands
 - bootstrap:
@@ -235,7 +238,7 @@ by design (not virtualized), and simple operational workflows.
   - generate jail.conf metadata
 - start <name>|--all:
   - mount composed root
-  - create jail (with optional bind-port policy)
+  - create jail
   - run jailctl supervise with configured service command
 - stop <name>|--all:
   - stop supervise process
@@ -255,7 +258,8 @@ by design (not virtualized), and simple operational workflows.
 6.1 What This Stack Is Good At
 - Efficient service isolation and management on one host.
 - Lightweight container-like operations with low conceptual overhead.
-- Clear host-centric control over process interaction and bind permissions.
+- Clear host-centric control over process interaction and explicit network
+  exposure policy when combined with NPF jail-aware filtering.
 
 6.2 What This Stack Does Not Attempt
 - It does not emulate full VM isolation characteristics.
@@ -270,7 +274,8 @@ by design (not virtualized), and simple operational workflows.
 ------------------------------------
 - resource_mode switching affects future checks only.
 - Existing process RLIMIT values are not rewritten on mode switch.
-- Port policy is deny-by-default only when a list is configured.
 - Process isolation behavior depends on jail ID assignment in credentials;
   host-root control plane remains intentionally global.
+- Network exposure control is delegated to firewall policy (NPF), not bind-time
+  namespace/stack virtualization in secmodel_jail.
 

--- a/lib/libnpf/libnpf.3
+++ b/lib/libnpf/libnpf.3
@@ -69,6 +69,7 @@
 .Fn npf_rule_setprio "nl_rule_t *rl" "int pri"
 .Ft int
 .Fn npf_rule_setproc "nl_rule_t *rl" "const char *name"
+.Fn npf_rule_setjailname "nl_rule_t *rl" "const char *name"
 .Ft int
 .Fn npf_rule_insert "nl_config_t *ncf" "nl_rule_t *parent" "nl_rule_t *rl"
 .Ft bool
@@ -271,6 +272,9 @@ assigned and will share this level in the ordered way.
 .\" ---
 .It Fn npf_rule_setproc "rl" "name"
 Set a procedure for the specified rule.
+." ---
+.It Fn npf_rule_setjailname "rl" "name"
+Set a jail selector name for the specified rule.
 .\" ---
 .It Fn npf_rule_insert "ncf" "parent" "rl"
 Insert the rule into the set of the parent rule specified by

--- a/lib/libnpf/npf.c
+++ b/lib/libnpf/npf.c
@@ -735,6 +735,13 @@ npf_rule_setproc(nl_rule_t *rl, const char *name)
 	return nvlist_error(rl->rule_dict);
 }
 
+int
+npf_rule_setjailname(nl_rule_t *rl, const char *name)
+{
+	nvlist_add_string(rl->rule_dict, "jail-name", name);
+	return nvlist_error(rl->rule_dict);
+}
+
 void *
 npf_rule_export(nl_rule_t *rl, size_t *length)
 {

--- a/lib/libnpf/npf.h
+++ b/lib/libnpf/npf.h
@@ -106,6 +106,7 @@ nl_rule_t *	npf_rule_create(const char *, uint32_t, const char *);
 int		npf_rule_setcode(nl_rule_t *, int, const void *, size_t);
 int		npf_rule_setprio(nl_rule_t *, int);
 int		npf_rule_setproc(nl_rule_t *, const char *);
+int		npf_rule_setjailname(nl_rule_t *, const char *);
 int		npf_rule_setkey(nl_rule_t *, const void *, size_t);
 int		npf_rule_setinfo(nl_rule_t *, const void *, size_t);
 const char *	npf_rule_getname(nl_rule_t *);

--- a/sys/net/npf/npf_ruleset.c
+++ b/sys/net/npf/npf_ruleset.c
@@ -44,6 +44,13 @@ __KERNEL_RCSID(0, "$NetBSD: npf_ruleset.c,v 1.51.20.1 2023/08/23 18:19:32 martin
 #include <sys/queue.h>
 #include <sys/mbuf.h>
 #include <sys/types.h>
+#include <sys/socketvar.h>
+
+#include <netinet/in_pcb.h>
+#include <netinet/tcp_var.h>
+#include <netinet/udp_var.h>
+
+#include <secmodel/jail/jail.h>
 
 #include <net/bpf.h>
 #include <net/bpfjit.h>
@@ -112,6 +119,7 @@ struct npf_rule {
 	/* Rule ID, name and the optional key. */
 	uint64_t		r_id;
 	char			r_name[NPF_RULE_MAXNAMELEN];
+	char			r_jailname[JAIL_NAME_MAX + 1];
 	uint8_t			r_key[NPF_RULE_MAXKEYLEN];
 
 	/* All-list entry and the auxiliary info. */
@@ -618,11 +626,22 @@ npf_rule_alloc(npf_t *npf, const nvlist_t *rule)
 	}
 	rl->r_natp = NULL;
 
-	/* Name (optional) */
+	/* Name (optional). */
 	if ((rname = dnvlist_get_string(rule, "name", NULL)) != NULL) {
 		strlcpy(rl->r_name, rname, NPF_RULE_MAXNAMELEN);
 	} else {
 		rl->r_name[0] = '\0';
+	}
+
+	/* Jail selector name (optional). */
+	if ((rname = dnvlist_get_string(rule, "jail-name", NULL)) != NULL) {
+		if (strlcpy(rl->r_jailname, rname, sizeof(rl->r_jailname)) >=
+		    sizeof(rl->r_jailname)) {
+			kmem_free(rl, sizeof(npf_rule_t));
+			return NULL;
+		}
+	} else {
+		rl->r_jailname[0] = '\0';
 	}
 
 	/* Attributes, priority and interface ID (optional). */
@@ -684,6 +703,9 @@ npf_rule_export(npf_t *npf, const npf_rule_t *rl)
 
 	if (rl->r_name[0]) {
 		nvlist_add_string(rule, "name", rl->r_name);
+	}
+	if (rl->r_jailname[0]) {
+		nvlist_add_string(rule, "jail-name", rl->r_jailname);
 	}
 	if (NPF_DYNAMIC_RULE_P(rl->r_attr)) {
 		nvlist_add_binary(rule, "key", rl->r_key, NPF_RULE_MAXKEYLEN);
@@ -798,13 +820,119 @@ npf_rule_setnat(npf_rule_t *rl, npf_natpolicy_t *np)
 	rl->r_natp = np;
 }
 
+
+#ifdef _KERNEL
+static struct socket *
+npf_rule_getsock_outbound(const npf_cache_t *npc)
+{
+	struct mbuf *m = nbuf_head_mbuf(npc->npc_nbuf);
+	struct m_tag *mt;
+
+	mt = m_tag_find(m, PACKET_TAG_SO);
+	if (mt == NULL) {
+		return NULL;
+	}
+	return *(struct socket **)(mt + 1);
+}
+
+static struct socket *
+npf_rule_getsock_inbound(const npf_cache_t *npc)
+{
+	struct inpcb *inp = NULL;
+	const in_port_t sport = npc->npc_l4.udp->uh_sport;
+	const in_port_t dport = npc->npc_l4.udp->uh_dport;
+
+#ifdef INET
+	if (npf_iscached(npc, NPC_IP4)) {
+		const struct in_addr saddr = { .s_addr = npc->npc_ips[NPF_SRC]->word32[0] };
+		const struct in_addr daddr = { .s_addr = npc->npc_ips[NPF_DST]->word32[0] };
+
+		if (npf_iscached(npc, NPC_TCP)) {
+			inp = inpcb_lookup(&tcbtable, saddr, sport, daddr, dport, NULL);
+			if (inp == NULL) {
+				inp = inpcb_lookup_bound(&tcbtable, daddr, dport);
+			}
+		} else if (npf_iscached(npc, NPC_UDP)) {
+			inp = inpcb_lookup(&udbtable, saddr, sport, daddr, dport, NULL);
+			if (inp == NULL) {
+				inp = inpcb_lookup_bound(&udbtable, daddr, dport);
+			}
+		}
+	}
+#endif
+#ifdef INET6
+	if (inp == NULL && npf_iscached(npc, NPC_IP6)) {
+		const struct in6_addr * const saddr =
+		    (const struct in6_addr *)npc->npc_ips[NPF_SRC];
+		const struct in6_addr * const daddr =
+		    (const struct in6_addr *)npc->npc_ips[NPF_DST];
+
+		if (npf_iscached(npc, NPC_TCP)) {
+			inp = in6pcb_lookup(&tcbtable, saddr, sport, daddr, dport, 0, NULL);
+			if (inp == NULL) {
+				inp = in6pcb_lookup_bound(&tcbtable, daddr, dport, 1);
+			}
+		} else if (npf_iscached(npc, NPC_UDP)) {
+			inp = in6pcb_lookup(&udbtable, saddr, sport, daddr, dport, 0, NULL);
+			if (inp == NULL) {
+				inp = in6pcb_lookup_bound(&udbtable, daddr, dport, 1);
+			}
+		}
+	}
+#endif
+
+	if (inp == NULL || inp->inp_socket == NULL) {
+		return NULL;
+	}
+	return inp->inp_socket;
+}
+
+static bool
+npf_rule_jail_match(const npf_rule_t *rl, const npf_cache_t *npc,
+    const int di_mask)
+{
+	const char *jail_name = rl->r_jailname[0] ? rl->r_jailname : NULL;
+	const bool inbound = di_mask == NPF_RULE_IN;
+	struct socket *so;
+
+	if (jail_name == NULL && !inbound) {
+		return true;
+	}
+
+	if (inbound && !npf_iscached(npc, NPC_TCP) && !npf_iscached(npc, NPC_UDP)) {
+		return true;
+	}
+
+	so = inbound ? npf_rule_getsock_inbound(npc) : npf_rule_getsock_outbound(npc);
+	if (so == NULL || so->so_cred == NULL) {
+		/*
+		 * Inbound ownership checks apply only when packet can be associated
+		 * with a local socket owner.  Keep legacy behaviour for non-local
+		 * traffic unless a jail qualifier was explicitly requested.
+		 */
+		return jail_name == NULL;
+	}
+	return secmodel_jail_cred_matches(so->so_cred, jail_name);
+}
+#else
+static bool
+npf_rule_jail_match(const npf_rule_t *rl, const npf_cache_t *npc,
+    const int di_mask)
+{
+	(void)rl;
+	(void)npc;
+	(void)di_mask;
+	return true;
+}
+#endif
+
 /*
  * npf_rule_inspect: match the interface, direction and run the filter code.
  * Returns true if rule matches and false otherwise.
  */
 static inline bool
-npf_rule_inspect(const npf_rule_t *rl, bpf_args_t *bc_args,
-    const int di_mask, const unsigned ifid)
+npf_rule_inspect(const npf_rule_t *rl, const npf_cache_t *npc,
+    bpf_args_t *bc_args, const int di_mask, const unsigned ifid)
 {
 	/* Match the interface. */
 	if (rl->r_ifid && rl->r_ifid != ifid) {
@@ -815,6 +943,10 @@ npf_rule_inspect(const npf_rule_t *rl, bpf_args_t *bc_args,
 	if ((rl->r_attr & NPF_RULE_DIMASK) != NPF_RULE_DIMASK) {
 		if ((rl->r_attr & di_mask) == 0)
 			return false;
+	}
+
+	if (!npf_rule_jail_match(rl, npc, di_mask)) {
+		return false;
 	}
 
 	/* Any code? */
@@ -831,8 +963,8 @@ npf_rule_inspect(const npf_rule_t *rl, bpf_args_t *bc_args,
  * This is only for the dynamic rules.  Subrules cannot have nested rules.
  */
 static inline npf_rule_t *
-npf_rule_reinspect(const npf_rule_t *rg, bpf_args_t *bc_args,
-    const int di_mask, const unsigned ifid)
+npf_rule_reinspect(const npf_rule_t *rg, const npf_cache_t *npc,
+    bpf_args_t *bc_args, const int di_mask, const unsigned ifid)
 {
 	npf_rule_t *final_rl = NULL, *rl;
 
@@ -841,7 +973,7 @@ npf_rule_reinspect(const npf_rule_t *rg, bpf_args_t *bc_args,
 	rl = atomic_load_relaxed(&rg->r_subset);
 	for (; rl; rl = atomic_load_relaxed(&rl->r_next)) {
 		KASSERT(!final_rl || rl->r_priority >= final_rl->r_priority);
-		if (!npf_rule_inspect(rl, bc_args, di_mask, ifid)) {
+		if (!npf_rule_inspect(rl, npc, bc_args, di_mask, ifid)) {
 			continue;
 		}
 		if (rl->r_attr & NPF_RULE_FINAL) {
@@ -896,7 +1028,7 @@ npf_ruleset_inspect(npf_cache_t *npc, const npf_ruleset_t *rlset,
 		}
 
 		/* Main inspection of the rule. */
-		if (!npf_rule_inspect(rl, &bc_args, di_mask, ifid)) {
+		if (!npf_rule_inspect(rl, npc, &bc_args, di_mask, ifid)) {
 			n = skip_to;
 			continue;
 		}
@@ -906,7 +1038,7 @@ npf_ruleset_inspect(npf_cache_t *npc, const npf_ruleset_t *rlset,
 			 * If this is a dynamic rule, re-inspect the subrules.
 			 * If it has any matching rule, then it is final.
 			 */
-			rl = npf_rule_reinspect(rl, &bc_args, di_mask, ifid);
+			rl = npf_rule_reinspect(rl, npc, &bc_args, di_mask, ifid);
 			if (rl != NULL) {
 				final_rl = rl;
 				break;

--- a/sys/netinet/ip_output.c
+++ b/sys/netinet/ip_output.c
@@ -158,6 +158,26 @@ extern pfil_head_t *inet_pfil_hook;			/* XXX */
 
 int ip_do_loopback_cksum = 0;
 
+
+static void
+ip_setsockettag(struct mbuf *m, struct inpcb *inp)
+{
+	struct m_tag *mtag;
+	struct socket **sotag;
+
+	if (inp == NULL || inp->inp_socket == NULL)
+		return;
+	if (m_tag_find(m, PACKET_TAG_SO) != NULL)
+		return;
+
+	mtag = m_tag_get(PACKET_TAG_SO, sizeof(*sotag), M_NOWAIT);
+	if (mtag == NULL)
+		return;
+	sotag = (struct socket **)(mtag + 1);
+	*sotag = inp->inp_socket;
+	m_tag_prepend(m, mtag);
+}
+
 static int
 ip_mark_mpls(struct ifnet * const ifp, struct mbuf * const m,
     const struct rtentry *rt)
@@ -643,6 +663,7 @@ sendit:
 		/*
 		 * Run through list of hooks for output packets.
 		 */
+		ip_setsockettag(m, inp);
 		error = pfil_run_hooks(inet_pfil_hook, &m, ifp, PFIL_OUT);
 		if (error || m == NULL) {
 			IP_STATINC(IP_STAT_PFILDROP_OUT);

--- a/sys/netinet6/ip6_output.c
+++ b/sys/netinet6/ip6_output.c
@@ -184,6 +184,25 @@ ip6_if_output(struct ifnet * const ifp, struct ifnet * const origifp,
 	return error;
 }
 
+static void
+ip6_setsockettag(struct mbuf *m, struct inpcb *inp)
+{
+	struct m_tag *mtag;
+	struct socket **sotag;
+
+	if (inp == NULL || inp->inp_socket == NULL)
+		return;
+	if (m_tag_find(m, PACKET_TAG_SO) != NULL)
+		return;
+
+	mtag = m_tag_get(PACKET_TAG_SO, sizeof(*sotag), M_NOWAIT);
+	if (mtag == NULL)
+		return;
+	sotag = (struct socket **)(mtag + 1);
+	*sotag = inp->inp_socket;
+	m_tag_prepend(m, mtag);
+}
+
 /*
  * IP6 output. The packet in mbuf chain m contains a skeletal IP6
  * header (with pri, len, nxt, hlim, src, dst).
@@ -770,6 +789,7 @@ ip6_output(
 	/*
 	 * Run through list of hooks for output packets.
 	 */
+	ip6_setsockettag(m, inp);
 	error = pfil_run_hooks(inet6_pfil_hook, &m, ifp, PFIL_OUT);
 	if (error != 0 || m == NULL) {
 		IP6_STATINC(IP6_STAT_PFILDROP_OUT);

--- a/sys/secmodel/jail/jail.h
+++ b/sys/secmodel/jail/jail.h
@@ -45,5 +45,7 @@ int secmodel_jail_process_cb(kauth_cred_t, kauth_action_t, void *,
 int secmodel_jail_cred_cb(kauth_cred_t, kauth_action_t, void *,
     void *, void *, void *, void *);
 
+bool secmodel_jail_cred_matches(kauth_cred_t, const char *);
+
 
 #endif /* !_SECMODEL_JAIL_JAIL_H_ */

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -110,6 +110,8 @@ static LIST_HEAD(, jail_entry) jail_list =
 static kmutex_t jail_lock;
 static jailid_t jail_next_id = 1;
 
+static struct jail_entry *secmodel_jail_lookup(jailid_t);
+
 struct jail_config {
 	bool jc_has_cpu_limit;
 	bool jc_has_mem_limit;
@@ -138,6 +140,31 @@ static void
 secmodel_jail_cred_setid(kauth_cred_t cred, jailid_t id)
 {
 	kauth_cred_setdata(cred, jail_key, (void *)(uintptr_t)id);
+}
+
+bool
+secmodel_jail_cred_matches(kauth_cred_t cred, const char *name)
+{
+	const struct jail_entry *entry;
+	jailid_t id;
+
+	id = secmodel_jail_cred_id(cred);
+	if (name == NULL) {
+		return id == JAILID_HOST;
+	}
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry == NULL) {
+		mutex_exit(&jail_lock);
+		return false;
+	}
+	if (strcmp(entry->je_name, name) != 0) {
+		mutex_exit(&jail_lock);
+		return false;
+	}
+	mutex_exit(&jail_lock);
+	return true;
 }
 
 /*

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -30,6 +30,7 @@
 #define _SYS_JAIL_H_
 
 #include <sys/types.h>
+#include <stdbool.h>
 
 typedef uint32_t jailid_t;
 

--- a/usr.sbin/npf/npfctl/npf.conf.5
+++ b/usr.sbin/npf/npfctl/npf.conf.5
@@ -288,6 +288,19 @@ understanding icmp-type.
 .Pp
 A rule can also instruct NPF to create an entry in the state table when
 passing the packet or to apply a procedure to the packet (e.g. "log").
+A rule can also include the
+.Cm jail
+qualifier (
+.Cm jail Ar name
+) to match socket ownership by jail name.
+For outbound traffic, the qualifier is evaluated against the jail of the
+originating socket credentials.
+For inbound TCP/UDP traffic, NPF resolves the local socket owner and evaluates
+its credentials against the configured jail name.
+If an inbound rule omits
+.Cm jail ,
+host-only semantics are applied for TCP/UDP traffic (jail id 0).
+
 .Pp
 A
 .Dq fully-featured
@@ -598,6 +611,7 @@ npf-filter	= [ "family" family-opt ] [ proto ] ( "all" | filt-opts )
 static-rule	= ( "block" [ block-opts ] | "pass" )
 		  [ "stateful" | "stateful-all" ]
 		  [ "in" | "out" ] [ "final" ] [ "on" interface ]
+		  [ "jail" name-string ]
 		  ( npf-filter | "pcap-filter" pcap-filter-expr )
 		  [ "apply" proc-name ]
 

--- a/usr.sbin/npf/npfctl/npf_build.c
+++ b/usr.sbin/npf/npfctl/npf_build.c
@@ -693,8 +693,8 @@ npfctl_build_group_end(void)
  * if any, and insert into the ruleset of current group, or set the rule.
  */
 void
-npfctl_build_rule(uint32_t attr, const char *ifname, sa_family_t family,
-    const npfvar_t *popts, const filt_opts_t *fopts,
+npfctl_build_rule(uint32_t attr, const char *ifname, const char *jail_name,
+    sa_family_t family, const npfvar_t *popts, const filt_opts_t *fopts,
     const char *pcap_filter, const char *rproc)
 {
 	nl_rule_t *rl;
@@ -710,6 +710,10 @@ npfctl_build_rule(uint32_t attr, const char *ifname, sa_family_t family,
 
 	if (rproc) {
 		npf_rule_setproc(rl, rproc);
+	}
+
+	if (jail_name) {
+		npf_rule_setjailname(rl, jail_name);
 	}
 
 	if (npf_conf) {

--- a/usr.sbin/npf/npfctl/npf_parse.y
+++ b/usr.sbin/npf/npfctl/npf_parse.y
@@ -130,6 +130,7 @@ yyerror(const char *fmt, ...)
 %token			INET4
 %token			INET6
 %token			INTERFACE
+%token			JAIL
 %token			INVALID
 %token			IPHASH
 %token			IPSET
@@ -183,7 +184,7 @@ yyerror(const char *fmt, ...)
 %token	<str>		VAR_ID
 
 %type	<str>		addr some_name table_store dynamic_ifaddrs
-%type	<str>		proc_param_val opt_apply ifname on_ifname ifref
+%type	<str>		proc_param_val opt_apply ifname on_ifname ifref opt_jail
 %type	<num>		port opt_final number afamily opt_family
 %type	<num>		block_or_pass rule_dir group_dir block_opts
 %type	<num>		maybe_not opt_stateful icmp_type table_type
@@ -547,17 +548,17 @@ rule_group
  */
 
 rule
-	: block_or_pass opt_stateful rule_dir opt_final on_ifname
+	: block_or_pass opt_stateful rule_dir opt_final on_ifname opt_jail
 	  opt_family opt_proto all_or_filt_opts opt_apply
 	{
-		npfctl_build_rule($1 | $2 | $3 | $4, $5,
-		    $6, $7, &$8, NULL, $9);
+		npfctl_build_rule($1 | $2 | $3 | $4, $5, $6,
+		    $7, $8, &$9, NULL, $10);
 	}
-	| block_or_pass opt_stateful rule_dir opt_final on_ifname
+	| block_or_pass opt_stateful rule_dir opt_final on_ifname opt_jail
 	  PCAP_FILTER STRING opt_apply
 	{
-		npfctl_build_rule($1 | $2 | $3 | $4, $5,
-		    AF_UNSPEC, NULL, NULL, $7, $8);
+		npfctl_build_rule($1 | $2 | $3 | $4, $5, $6,
+		    AF_UNSPEC, NULL, NULL, $8, $9);
 	}
 	;
 
@@ -579,6 +580,11 @@ opt_final
 
 on_ifname
 	: ON ifref		{ $$ = $2; }
+	|			{ $$ = NULL; }
+	;
+
+opt_jail
+	: JAIL STRING		{ $$ = $2; }
 	|			{ $$ = NULL; }
 	;
 

--- a/usr.sbin/npf/npfctl/npf_scan.l
+++ b/usr.sbin/npf/npfctl/npf_scan.l
@@ -142,6 +142,7 @@ in			return IN;
 out			return OUT;
 forw			return FORW;
 interface		return INTERFACE;
+jail			return JAIL;
 all			return ALL;
 block			return BLOCK;
 pass			return PASS;

--- a/usr.sbin/npf/npfctl/npfctl.h
+++ b/usr.sbin/npf/npfctl/npfctl.h
@@ -220,7 +220,7 @@ void		npfctl_build_alg(const char *);
 void		npfctl_build_rproc(const char *, npfvar_t *);
 void		npfctl_build_group(const char *, int, const char *, bool);
 void		npfctl_build_group_end(void);
-void		npfctl_build_rule(uint32_t, const char *, sa_family_t,
+void		npfctl_build_rule(uint32_t, const char *, const char *, sa_family_t,
 		    const npfvar_t *, const filt_opts_t *,
 		    const char *, const char *);
 void		npfctl_build_natseg(int, int, unsigned, const char *,


### PR DESCRIPTION
### Motivation
- Make network exposure by jails an explicit, firewall-level decision rather than embedding fragile bind-time restrictions in the kernel security model. 
- Keep `secmodel_jail` focused on process/credential-based isolation and lightweight operational workflows to avoid the complexity of per-jail network stacks or namespaces. 
- Provide an end-to-end mechanism in NPF to match rules against the owning jail of a socket so policy authors can say `jail "name"` for inbound/outbound semantics. 

### Description
- Implemented NPF `jail` qualifier end-to-end: parser changes (`npf_parse.y`, `npf_scan.l`), `npfctl` build plumbing (`npf_build.c`, `npfctl.h`), and libnpf API (`npf_rule_setjailname`) to carry a `jail-name` nvlist field. 
- Kernel-side NPF changes add an optional `r_jailname` to `npf_rule_t`, export/import of `jail-name`, and match logic `npf_rule_jail_match` which resolves socket ownership and checks jail membership during rule inspection. 
- Enabled socket-owner based matching by tagging outbound packets with a `PACKET_TAG_SO` containing the originating `struct socket *` in `ip_output.c` and `ip6_output.c`, and by performing PCB lookups for inbound TCP/UDP to find local service sockets. 
- Integrated with the jail security model by adding `secmodel_jail_cred_matches(kauth_cred_t, const char *)` and exposing it in `secmodel_jail` headers, so NPF can verify a socket's credentials against a rule's jail selector. 
- Documentation updates: added `doc/NPF-jail-qualifier-integration-spec.txt`, updated `doc/jail-stack-specification.txt` to emphasise process-isolation-first intent and NPF-based exposure control, and extended `npf.conf.5` to describe the `jail` qualifier. 

### Testing
- Ran `git diff --check` to validate whitespace/patch cleanliness and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991437ea350832ab35aeb3eeccf11a6)