### PR TITLE
npf: remove unnecessary tcp/udp var includes from ruleset

### DIFF
--- a/sys/net/npf/npf_ruleset.c
+++ b/sys/net/npf/npf_ruleset.c
@@ -47,8 +47,6 @@ __KERNEL_RCSID(0, "$NetBSD: npf_ruleset.c,v 1.51.20.1 2023/08/23 18:19:32 martin
 #include <sys/socketvar.h>
 
 #include <netinet/in_pcb.h>
-#include <netinet/tcp_var.h>
-#include <netinet/udp_var.h>
 
 #include <secmodel/jail/jail.h>
 


### PR DESCRIPTION
### Motivation
- Avoid pulling in TCP/UDP internal kernel headers into `sys/net/npf/npf_ruleset.c` which can cause compilation failures in rump/libnpf build contexts where those internals are not present.

### Description
- Remove the unused `#include <netinet/tcp_var.h>` and `#include <netinet/udp_var.h>` from `sys/net/npf/npf_ruleset.c`, keeping only `#include <netinet/in_pcb.h>` for the required symbols.

### Testing
- Attempted to build `sys/rump/net/lib/libnpf` using `make -j4` which failed with `missing separator`, and `bmake -j4` could not be run because `bmake` is not installed in this environment, so a full rebuild could not be validated automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b65b6394832aa55331c0fb1058a9)