### PR TITLE
npf: fix rump build for jail-aware rule matching

### DIFF
--- a/sys/net/npf/npf_ruleset.c
+++ b/sys/net/npf/npf_ruleset.c
@@ -45,8 +45,11 @@ __KERNEL_RCSID(0, "$NetBSD: npf_ruleset.c,v 1.51.20.1 2023/08/23 18:19:32 martin
 #include <sys/mbuf.h>
 #include <sys/types.h>
 #include <sys/socketvar.h>
+#include <sys/jail.h>
 
+#if !defined(_RUMPKERNEL)
 #include <netinet/in_pcb.h>
+#endif
 
 #include <secmodel/jail/jail.h>
 
@@ -819,7 +822,7 @@ npf_rule_setnat(npf_rule_t *rl, npf_natpolicy_t *np)
 }
 
 
-#ifdef _KERNEL
+#if defined(_KERNEL) && !defined(_RUMPKERNEL)
 static struct socket *
 npf_rule_getsock_outbound(const npf_cache_t *npc)
 {


### PR DESCRIPTION
### Motivation
- Rump builds of the NPF code failed due to missing `JAIL_NAME_MAX` and missing PCB table symbols when including `in_pcb` headers, so the ruleset code must avoid pulling kernel-only PCB lookups into rump builds while keeping jail-name support for full-kernel builds.
- The change aims to make the jail-aware socket ownership checks compile under regular kernel builds while allowing rump builds to use the existing fallback matcher.

### Description
- Added `#include <sys/jail.h>` so `JAIL_NAME_MAX` is defined for the `r_jailname` field in `npf_rule`.
- Wrapped `#include <netinet/in_pcb.h>` in `#if !defined(_RUMPKERNEL)` to avoid introducing PCB table symbols into rump builds.
- Narrowed the kernel-only implementation guard from `#ifdef _KERNEL` to `#if defined(_KERNEL) && !defined(_RUMPKERNEL)` so the socket/jail-aware matcher is compiled only for non-rump kernel builds and the existing rump fallback matcher remains in the `#else` block.

### Testing
- Ran `git diff --check` which reported no whitespace or patch-format issues and succeeded.
- Attempted `cd sys/rump/net/lib/libnpf && bmake -j4 dependall`, but the build invocation failed because `bmake` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992c4b0fdb0832aad906ef8b5b2004e)