### PR TITLE
sys/jail.h: include <sys/stdbool.h> instead of <stdbool.h>

### DIFF
--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -30,7 +30,7 @@
 #define _SYS_JAIL_H_
 
 #include <sys/types.h>
-#include <stdbool.h>
+#include <sys/stdbool.h>
 
 typedef uint32_t jailid_t;
 


### PR DESCRIPTION
### Motivation
- Avoid depending on the host C library header during early build steps by using the tree-local bool definitions, which prevents failures when `<stdbool.h>` is not available (observed during `dependall` in rump builds).

### Description
- Replace `#include <stdbool.h>` with `#include <sys/stdbool.h>` in `sys/sys/jail.h` so the kernel tree supplies the `bool`/`true`/`false` definitions.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted `make -C sys/rump/net/lib/libnpf dependall`, which could not complete in this environment because NetBSD makefiles require `bmake` (not available here).
- Performed a minimal host `cc -I/workspace/netbsd-src/sys` compile including `sys/jail.h`, which failed early due to missing target `machine/types.h` include paths in a host-only compile, so the local build validation is limited in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992cb5b74dc832aa349cd489d3d6041)