### PR TITLE
npf: include TCP/UDP PCB table declarations in npf_ruleset.c

### DIFF
--- a/sys/net/npf/npf_ruleset.c
+++ b/sys/net/npf/npf_ruleset.c
@@ -49,6 +49,8 @@ __KERNEL_RCSID(0, "$NetBSD: npf_ruleset.c,v 1.51.20.1 2023/08/23 18:19:32 martin
 
 #if !defined(_RUMPKERNEL)
 #include <netinet/in_pcb.h>
+#include <netinet/tcp_var.h>
+#include <netinet/udp_var.h>
 #endif
 
 #include <secmodel/jail/jail.h>


### PR DESCRIPTION
### Motivation
- Rump/net builds of `sys/net/npf/npf_ruleset.c` could fail with `tcbtable`/`udbtable` undeclared because those PCB table symbols were not guaranteed to be pulled in via indirect headers.
- The change makes the required PCB table declarations explicit in the non-rump-kernel build path so `npf_rule_getsock_inbound()` can use `inpcb_lookup*` calls reliably.

### Description
- Added `#include <netinet/tcp_var.h>` and `#include <netinet/udp_var.h>` inside the existing `#if !defined(_RUMPKERNEL)` block in `sys/net/npf/npf_ruleset.c` to expose `tcbtable` and `udbtable` declarations.
- No functional logic was changed; this is an include-cleanup to fix a build-time implicit dependency.

### Testing
- Attempted an automated targeted build with `cd sys/rump/net/lib/libnpf && bmake npf_ruleset.o`, but the environment lacks `bmake` so the compile could not be performed locally (failed due to `bmake: command not found`).
- No automated unit tests were run in this environment after the change due to the missing build toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992d19fa980832aa1750e002035a009)