### PR TITLE
npf: include prerequisite TCP/UDP header types

### DIFF
--- a/sys/net/npf/npf_ruleset.c
+++ b/sys/net/npf/npf_ruleset.c
@@ -49,7 +49,10 @@ __KERNEL_RCSID(0, "$NetBSD: npf_ruleset.c,v 1.51.20.1 2023/08/23 18:19:32 martin
 
 #if !defined(_RUMPKERNEL)
 #include <netinet/in_pcb.h>
+#include <netinet/ip_var.h>
+#include <netinet/tcp.h>
 #include <netinet/tcp_var.h>
+#include <netinet/udp.h>
 #include <netinet/udp_var.h>
 #endif
 


### PR DESCRIPTION
### Motivation
- A rump/libnpf build path compiled `npf_ruleset.c` with `tcp_var.h`/`udp_var.h` included but the prerequisite protocol types (`struct ipovly`, `struct tcphdr`, `struct udphdr`, and `tcp_seq`) were not visible, causing incomplete-type compile errors.

### Description
- Inserted `#include <netinet/ip_var.h>`, `#include <netinet/tcp.h>`, and `#include <netinet/udp.h>` into `sys/net/npf/npf_ruleset.c` before the existing `#include <netinet/tcp_var.h>`/`#include <netinet/udp_var.h>` inside the `#if !defined(_RUMPKERNEL)` block.
- This ensures the definitions required by `tcp_var.h` and `udp_var.h` are available when compiling the NPF ruleset module.

### Testing
- Ran `make -C sys/rump/net/lib/libnpf dependall`, which failed in this environment with `Makefile:33: *** missing separator.  Stop.`, indicating a local make/bootstrap issue rather than a failure of the header fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992d8f1cdbc832a8b9cd8248de0aa04)