### PR TITLE
jailmgr: remove JAIL_DEFAULT_USER handling and sshd auto-enable

### DIFF
--- a/etc/jailmgr.conf
+++ b/etc/jailmgr.conf
@@ -17,9 +17,6 @@ JAIL_RELEASE_DIR=/var/jailmgr/releases
 # Jail-specific settings are stored in ${JAIL_DATA_DIR}/<name>/jail.conf
 # and created/updated by: jailmgr create <name>
 
-# User to create inside each jail (if not already present in master.passwd)
-JAIL_DEFAULT_USER=user
-
 # Per-jail local /dev setup (tmpfs + MAKEDEV)
 JAIL_LOCAL_DEV=YES
 JAIL_DEV_SIZE=8m

--- a/usr.sbin/jailmgr/examples/jailmgr.conf.sample
+++ b/usr.sbin/jailmgr/examples/jailmgr.conf.sample
@@ -14,9 +14,6 @@ JAIL_RELEASE_DIR=/var/jailmgr/releases
 # Jail-specific settings are stored in ${JAIL_DATA_DIR}/<name>/jail.conf
 # and created/updated by: jailmgr create <name>
 
-# User to create inside each jail (if not already present in master.passwd)
-JAIL_DEFAULT_USER=user
-
 # Per-jail local /dev setup (tmpfs + MAKEDEV)
 JAIL_LOCAL_DEV=YES
 JAIL_DEV_SIZE=8m

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -51,7 +51,6 @@ NETBSD_MIRROR=
 JAIL_BASE_DIR=/var/jailmgr/base
 JAIL_DATA_DIR=/var/jailmgr/jails
 JAIL_RELEASE_DIR=/var/jailmgr/releases
-JAIL_DEFAULT_USER=user
 
 # Per-jail local /dev setup.
 JAIL_LOCAL_DEV=YES
@@ -304,25 +303,8 @@ setup_etc() {
 
 	mkdir -p "${ETC_DIR}/ssh"
 
-	grep -q '^sshd=YES' "${ETC_DIR}/rc.conf" 2>/dev/null ||
-		echo 'sshd=YES' >> "${ETC_DIR}/rc.conf"
-
 	grep -q '^hostname=' "${ETC_DIR}/rc.conf" 2>/dev/null ||
 		echo "hostname=${name}" >> "${ETC_DIR}/rc.conf"
-
-	if [ ! -f "${ETC_DIR}/master.passwd" ]; then
-		echo "warning: ${ETC_DIR}/master.passwd not found; user provisioning skipped" >&2
-		return
-	fi
-
-	if [ -z "${JAIL_DEFAULT_USER}" ]; then
-		return
-	fi
-
-	if ! awk -F: -v u="${JAIL_DEFAULT_USER}" '$1==u{found=1} END{exit !found}' "${ETC_DIR}/master.passwd"; then
-		echo "${JAIL_DEFAULT_USER}:*:1000:1000::0:0:Jail User:/home/${JAIL_DEFAULT_USER}:/bin/ksh" >> "${ETC_DIR}/master.passwd"
-		pwd_mkdb -d "${JAIL_DIR}" "${ETC_DIR}/master.passwd"
-	fi
 }
 
 # Compose the final jail root by overlaying writable per-jail directories on
@@ -374,9 +356,6 @@ create_jail() {
 	jail_paths "${name}"
 	mkdir -p "${ROOT_DIR}" "${ETC_DIR}" "${VAR_DIR}" "${TMP_DIR}" "${HOME_DIR}" "${ROOT_HOME_DIR}" "${PKG_DIR}" \
 		"${DEV_DIR}" "${VAR_DIR}/run" "${VAR_DIR}/log"
-	if [ -n "${JAIL_DEFAULT_USER}" ]; then
-		mkdir -p "${HOME_DIR}/${JAIL_DEFAULT_USER}"
-	fi
 	chmod 1777 "${TMP_DIR}"
 	setup_etc
 

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -187,7 +187,7 @@ accepts shell-style variable assignments in
 .Ev JAILMGR_CONF ) .
 .Pp
 Important variables:
-.Bl -tag -width "JAIL_DEFAULT_USER"
+.Bl -tag -width "JAIL_RELEASE_DIR"
 .It Ev RELEASE
 NetBSD release used for set download paths.
 .It Ev MACHINE_ARCH
@@ -200,8 +200,6 @@ Directory containing extracted shared base layers.
 Directory containing per-jail writable state.
 .It Ev JAIL_RELEASE_DIR
 Directory containing downloaded set archives.
-.It Ev JAIL_DEFAULT_USER
-User account to ensure exists inside each created jail.
 .It Ev JAIL_LOCAL_DEV
 When set to
 .Dq YES


### PR DESCRIPTION
### Motivation
- The default per-jail user knob `JAIL_DEFAULT_USER` and its provisioning logic are being removed to simplify jail creation semantics and avoid implicit user management inside jails. 
- `sshd` should no longer be force-enabled inside created jails to avoid surprising service activation and to let the jail's own configuration decide whether to run SSH. 
- Documentation and example configuration should reflect the removal of the `JAIL_DEFAULT_USER` setting. 

### Description
- Deleted the `JAIL_DEFAULT_USER` default and all code that ensured a user entry was added to the jail `master.passwd` inside `usr.sbin/jailmgr/jailmgr`. 
- Stopped creating a default home directory for the removed user during `create_jail()` in `usr.sbin/jailmgr/jailmgr`. 
- Removed the automatic addition of `sshd=YES` to the jail-local `etc/rc.conf` in `setup_etc()` so SSH is not enabled implicitly. 
- Removed `JAIL_DEFAULT_USER` from the global config and example files (`etc/jailmgr.conf` and `usr.sbin/jailmgr/examples/jailmgr.conf.sample`) and removed the corresponding man-page entry in `usr.sbin/jailmgr/jailmgr.8`. 

### Testing
- Verified the script parses correctly with `sh -n usr.sbin/jailmgr/jailmgr` and the check returned successfully. 
- Searched the codebase to confirm removal with `rg -n "JAIL_DEFAULT_USER|sshd=YES|user provisioning skipped|master.passwd" usr.sbin/jailmgr etc/jailmgr.conf` and found no matches. 
- Changes committed and smoke-validated by inspecting diffs of `usr.sbin/jailmgr/jailmgr`, `etc/jailmgr.conf`, `usr.sbin/jailmgr/examples/jailmgr.conf.sample`, and `usr.sbin/jailmgr/jailmgr.8` which reflect the described removals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994683885c4832a8ea1cae61aebdef7)