### PR TITLE
secmodel_jail: expose per-jail profiles to jailmgr/jailctl and document them

### DIFF
--- a/sys/secmodel/jail/jail.h
+++ b/sys/secmodel/jail/jail.h
@@ -35,8 +35,9 @@
 #include <secmodel/secmodel.h>
 
 /*
- * secmodel_jail enforces process visibility and signal delivery based on a
- * jail id stored in credentials. Host root (jail id 0) bypasses these checks.
+ * secmodel_jail enforces process visibility/signal delivery and
+ * jail-safe system authorization restrictions based on a jail id stored in
+ * credentials. Host root (jail id 0) bypasses these checks.
  */
 #define SECMODEL_JAIL_ID   "org.netbsd.secmodel.jail"
 #define SECMODEL_JAIL_NAME "NetBSD Jail"

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -60,11 +60,18 @@ MODULE(MODULE_CLASS_SECMODEL, secmodel_jail, NULL);
 
 static kauth_listener_t l_process;
 static kauth_listener_t l_cred;
+static kauth_listener_t l_system;
 
 static secmodel_t jail_sm;
 static kauth_key_t jail_key;
 
 struct jail_config;
+
+enum jail_policy_profile {
+	JAIL_PROFILE_POLICY_LOW = JAIL_PROFILE_LOW,
+	JAIL_PROFILE_POLICY_MEDIUM = JAIL_PROFILE_MEDIUM,
+	JAIL_PROFILE_POLICY_HIGH = JAIL_PROFILE_HIGH,
+};
 
 enum jail_resource_mode {
 	JAIL_RESOURCE_RLIMIT = 0,
@@ -85,6 +92,8 @@ static bool	secmodel_jail_over_limit(jailid_t, const struct jail_config *,
 static int	secmodel_jail_enforce_memlimit(struct proc *, size_t);
 static void	secmodel_jail_log_veto(const char *, jailid_t,
 		    const struct jail_config *, uint64_t, uint64_t);
+static int	secmodel_jail_system_cb(kauth_cred_t, kauth_action_t, void *,
+		    void *, void *, void *, void *);
 
 static struct timeval secmodel_jail_veto_log_last;
 static const struct timeval secmodel_jail_veto_log_interval = { 5, 0 };
@@ -102,6 +111,7 @@ struct jail_entry {
 	bool je_has_mem_limit;
 	rlim_t je_cpu_limit;
 	rlim_t je_mem_limit;
+	enum jail_policy_profile je_profile;
 	LIST_ENTRY(jail_entry) je_entry;
 };
 
@@ -117,6 +127,7 @@ struct jail_config {
 	bool jc_has_mem_limit;
 	rlim_t jc_cpu_limit;
 	rlim_t jc_mem_limit;
+	enum jail_policy_profile jc_profile;
 };
 
 /*
@@ -252,6 +263,7 @@ secmodel_jail_get_config(jailid_t id, struct jail_config *config)
 	config->jc_has_mem_limit = entry->je_has_mem_limit;
 	config->jc_cpu_limit = entry->je_cpu_limit;
 	config->jc_mem_limit = entry->je_mem_limit;
+	config->jc_profile = entry->je_profile;
 	mutex_exit(&jail_lock);
 
 	return true;
@@ -293,6 +305,9 @@ secmodel_jail_create(const struct jail_create *create,
 		entry->je_has_mem_limit = config->jc_has_mem_limit;
 		entry->je_cpu_limit = config->jc_cpu_limit;
 		entry->je_mem_limit = config->jc_mem_limit;
+		entry->je_profile = config->jc_profile;
+	} else {
+		entry->je_profile = JAIL_PROFILE_POLICY_HIGH;
 	}
 	LIST_INSERT_HEAD(&jail_list, entry, je_entry);
 	mutex_exit(&jail_lock);
@@ -657,10 +672,27 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 
 		flags = create.jc_flags;
 		if ((flags & ~(JAIL_CREATE_MEMLIMIT |
-		    JAIL_CREATE_CPULIMIT)) != 0)
+		    JAIL_CREATE_CPULIMIT |
+		    JAIL_CREATE_PROFILE)) != 0)
 			return EINVAL;
 
 		memset(&config, 0, sizeof(config));
+		config.jc_profile = JAIL_PROFILE_POLICY_HIGH;
+		if ((flags & JAIL_CREATE_PROFILE) != 0) {
+			switch (create.jc_profile) {
+			case JAIL_PROFILE_LOW:
+				config.jc_profile = JAIL_PROFILE_POLICY_LOW;
+				break;
+			case JAIL_PROFILE_MEDIUM:
+				config.jc_profile = JAIL_PROFILE_POLICY_MEDIUM;
+				break;
+			case JAIL_PROFILE_HIGH:
+				config.jc_profile = JAIL_PROFILE_POLICY_HIGH;
+				break;
+			default:
+				return EINVAL;
+			}
+		}
 		if ((flags & JAIL_CREATE_MEMLIMIT) != 0) {
 			if (create.jc_mem_limit == 0)
 				return EINVAL;
@@ -694,8 +726,9 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 
 	if (newlen == sizeof(create)) {
 		log(LOG_INFO,
-		    "secmodel_jail: created jail id=%u name=\"%s\" root=\"%s\" by pid=%d euid=%u\n",
-		    id, create.jc_name, create.jc_root, l->l_proc->p_pid,
+		    "secmodel_jail: created jail id=%u name=\"%s\" root=\"%s\" profile=%u by pid=%d euid=%u\n",
+		    id, create.jc_name, create.jc_root,
+		    (unsigned)configp->jc_profile, l->l_proc->p_pid,
 		    kauth_cred_geteuid(l->l_cred));
 		create.jc_id = id;
 		if (oldp == NULL) {
@@ -1005,6 +1038,8 @@ secmodel_jail_start(void)
 	    secmodel_jail_process_cb, NULL);
 	l_cred = kauth_listen_scope(KAUTH_SCOPE_CRED,
 	    secmodel_jail_cred_cb, NULL);
+	l_system = kauth_listen_scope(KAUTH_SCOPE_SYSTEM,
+	    secmodel_jail_system_cb, NULL);
 	/*
 	 * Publish the UVM integration hook. UVM checks this pointer before calling,
 	 * so the model can be cleanly loaded/unloaded without hard linker coupling.
@@ -1026,6 +1061,7 @@ secmodel_jail_stop(void)
 
 	kauth_unlisten_scope(l_process);
 	kauth_unlisten_scope(l_cred);
+	kauth_unlisten_scope(l_system);
 	kauth_deregister_key(jail_key);
 
 	mutex_enter(&jail_lock);
@@ -1035,6 +1071,89 @@ secmodel_jail_stop(void)
 	}
 	mutex_exit(&jail_lock);
 	mutex_destroy(&jail_lock);
+}
+
+/*
+ * kauth(9) listener for system scope.
+ *
+ * Denies host-level administrative actions for jailed credentials while
+ * deferring host credentials and host root to other security models.
+ */
+static int
+secmodel_jail_system_cb(kauth_cred_t cred, kauth_action_t action,
+    void *cookie, void *arg0, void *arg1, void *arg2, void *arg3)
+{
+	enum kauth_system_req req;
+	struct jail_config config;
+
+	(void)cookie;
+	(void)arg1;
+	(void)arg2;
+	(void)arg3;
+
+	if (secmodel_jail_is_host_root(cred))
+		return KAUTH_RESULT_DEFER;
+
+	if (secmodel_jail_cred_id(cred) == JAILID_HOST)
+		return KAUTH_RESULT_DEFER;
+
+	if (!secmodel_jail_get_config(secmodel_jail_cred_id(cred), &config))
+		return KAUTH_RESULT_DEFER;
+
+	if (config.jc_profile == JAIL_PROFILE_POLICY_LOW)
+		return KAUTH_RESULT_DEFER;
+
+	req = (enum kauth_system_req)(uintptr_t)arg0;
+
+	switch (action) {
+	case KAUTH_SYSTEM_MOUNT: /* Deny mounting/unmounting or mount reconfiguration inside jail. */
+		switch (req) {
+		case KAUTH_REQ_SYSTEM_MOUNT_DEVICE: /* Block use of raw block devices as mount sources. */
+		case KAUTH_REQ_SYSTEM_MOUNT_NEW: /* Block creation of new mounts. */
+		case KAUTH_REQ_SYSTEM_MOUNT_UNMOUNT: /* Block unmounting existing filesystems. */
+		case KAUTH_REQ_SYSTEM_MOUNT_UPDATE: /* Block remount/update flag changes. */
+		case KAUTH_REQ_SYSTEM_MOUNT_UMAP: /* Block uid/gid remapping mount operations. */
+			return KAUTH_RESULT_DENY;
+		default:
+			return KAUTH_RESULT_DEFER;
+		}
+
+	case KAUTH_SYSTEM_MODULE: /* Block loading/unloading kernel modules from jail context. */
+	case KAUTH_SYSTEM_MKNOD: /* Block creation of device special files. */
+	case KAUTH_SYSTEM_FILEHANDLE: /* Block generation/use of kernel file handles. */
+	case KAUTH_SYSTEM_CHROOT: /* Block nested chroot/fchroot privilege operations. */
+	case KAUTH_SYSTEM_REBOOT: /* Block reboot or halt style host control actions. */
+	case KAUTH_SYSTEM_SWAPCTL: /* Block swap device/table administration. */
+	case KAUTH_SYSTEM_ACCOUNTING: /* Block kernel process accounting configuration. */
+	case KAUTH_SYSTEM_CPU: /* Block global CPU administrative state changes. */
+	case KAUTH_SYSTEM_PSET: /* Block processor-set management and binding controls. */
+	case KAUTH_SYSTEM_TIME: /* Block host clock/ntp/timecounter administration. */
+	case KAUTH_SYSTEM_SEMAPHORE: /* Block global kernel semaphore administration. */
+	case KAUTH_SYSTEM_MQUEUE: /* Block POSIX message queue subsystem administration. */
+	case KAUTH_SYSTEM_DEVMAPPER: /* Block device-mapper table/control operations. */
+	case KAUTH_SYSTEM_INTR: /* Block interrupt affinity and routing controls. */
+	case KAUTH_SYSTEM_KERNADDR: /* Block privileged kernel address disclosure access. */
+		return KAUTH_RESULT_DENY;
+
+	case KAUTH_SYSTEM_SYSVIPC: /* Block SysV IPC administrative bypass/override controls. */
+		if (config.jc_profile == JAIL_PROFILE_POLICY_MEDIUM)
+			return KAUTH_RESULT_DEFER;
+		return KAUTH_RESULT_DENY;
+
+	case KAUTH_SYSTEM_SYSCTL: /* Constrain jail writes to global kernel sysctl tree. */
+		switch (req) {
+		case KAUTH_REQ_SYSTEM_SYSCTL_ADD: /* Block runtime creation of sysctl nodes. */
+		case KAUTH_REQ_SYSTEM_SYSCTL_DELETE: /* Block runtime deletion of sysctl nodes. */
+		case KAUTH_REQ_SYSTEM_SYSCTL_MODIFY: /* Block writes to privileged sysctl values. */
+		case KAUTH_REQ_SYSTEM_SYSCTL_PRVT: /* Block reads of private/protected sysctls. */
+			return KAUTH_RESULT_DENY;
+		default:
+			return KAUTH_RESULT_DEFER;
+		}
+
+	default:
+		return KAUTH_RESULT_DEFER;
+	}
 }
 
 /*

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -44,9 +44,16 @@ typedef uint32_t jailid_t;
 
 #define JAIL_CREATE_MEMLIMIT	0x00000001
 #define JAIL_CREATE_CPULIMIT	0x00000002
+#define JAIL_CREATE_PROFILE	0x00000004
+
+#define JAIL_PROFILE_LOW	0
+#define JAIL_PROFILE_MEDIUM	1
+#define JAIL_PROFILE_HIGH	2
+
 struct jail_create {
 	uint32_t jc_flags;
 	uint32_t jc_id;
+	uint32_t jc_profile;
 	uint64_t jc_mem_limit;
 	uint64_t jc_cpu_limit;
 	char jc_name[JAIL_NAME_MAX + 1];

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -36,6 +36,7 @@
 .Cm create
 .Op Fl c Ar cpu-ms
 .Op Fl m Ar bytes
+.Op Fl p Ar profile
 .Fl n Ar name
 .Ar root
 .Nm
@@ -65,7 +66,7 @@ jail id, while the host root user (jail id 0) can access all processes.
 .Pp
 The commands are as follows:
 .Bl -tag -width Ds
-.It Cm create Op Fl c Ar cpu-ms Op Fl m Ar bytes Fl n Ar name Ar root
+.It Cm create Op Fl c Ar cpu-ms Op Fl m Ar bytes Op Fl p Ar profile Fl n Ar name Ar root
 Create a new jail id, assign it the unique
 .Ar name ,
 and store jail name and root metadata in the kernel jail model.
@@ -77,6 +78,23 @@ The optional flags set per-jail resource limits at creation time:
 Set a CPU time limit (in milliseconds) for processes in the jail.
 .It Fl m Ar bytes
 Set a virtual memory limit (in bytes) for processes in the jail.
+.It Fl p Ar profile
+Select the jail security profile.
+Valid values are
+.Dq low ,
+.Dq medium ,
+and
+.Dq high .
+The default is
+.Dq high .
+The
+.Dq low
+profile keeps only process visibility/signal isolation,
+.Dq medium
+keeps hardening but defers SysV IPC administrative checks,
+and
+.Dq high
+enforces full system-scope hardening.
 .El
 .It Cm supervise Op Fl p Ar pri Op Fl t Ar tag Ar jail-id | name Ar command Op Ar args ...
 Start a command in an existing jail selected by

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -68,6 +68,7 @@ static void	jail_spawn_detached(jailid_t, const char *, const char *,
 static int	parse_log_facility(const char *);
 static int	parse_log_level(const char *);
 static int	parse_log_priority(const char *);
+static uint32_t	parse_profile(const char *);
 static void	sanitize_field(const char *, char *, size_t);
 static bool	jail_lookup_by_name(const char *, struct jail_info *);
 static bool	jail_lookup_by_id(jailid_t, struct jail_info *);
@@ -632,6 +633,20 @@ parse_log_priority(const char *arg)
 	return parse_log_facility(pri) | parse_log_level(dot);
 }
 
+static uint32_t
+parse_profile(const char *arg)
+{
+	if (strcmp(arg, "low") == 0)
+		return JAIL_PROFILE_LOW;
+	if (strcmp(arg, "medium") == 0)
+		return JAIL_PROFILE_MEDIUM;
+	if (strcmp(arg, "high") == 0)
+		return JAIL_PROFILE_HIGH;
+
+	errx(1, "invalid profile '%s' (expected low|medium|high)", arg);
+	return JAIL_PROFILE_HIGH;
+}
+
 static int
 getnum(const char *str, uintmax_t *num)
 {
@@ -687,8 +702,9 @@ main(int argc, char *argv[])
 
 		memset(&create, 0, sizeof(create));
 		name = NULL;
+		create.jc_profile = JAIL_PROFILE_HIGH;
 		optind = 2;
-		while ((ch = getopt(argc, argv, "c:m:n:")) != -1) {
+		while ((ch = getopt(argc, argv, "c:m:n:p:")) != -1) {
 			switch (ch) {
 			case 'c':
 				errno = 0;
@@ -708,6 +724,10 @@ main(int argc, char *argv[])
 				break;
 			case 'n':
 				name = optarg;
+				break;
+			case 'p':
+				create.jc_flags |= JAIL_CREATE_PROFILE;
+				create.jc_profile = parse_profile(optarg);
 				break;
 			default:
 				usage();
@@ -800,7 +820,7 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s create [-c cpu-ms] [-m bytes] -n name <root>\n"
+	    "usage: %s create [-c cpu-ms] [-m bytes] [-p low|medium|high] -n name <root>\n"
 	    "       %s supervise [-p pri] [-t tag] <jail-id|name> <command [args...]>\n"
 	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id|name>\n"

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -78,7 +78,7 @@ Usage: $0 <command> [args]
 
 Commands:
   bootstrap                   Download sets and build shared base layer
-  create [-a] [-s cmd] [-c cpu-ms] [-m bytes] [-p pri] [-t tag] <name>
+  create [-a] [-s cmd] [-c cpu-ms] [-m bytes] [-P profile] [-p pri] [-t tag] <name>
                               Create jail instance directories and persist jail.conf
   start <name>                Mount jail root and supervise jail via jailctl
   start --all                 Start all configured jails
@@ -259,6 +259,7 @@ load_jail_conf() {
 	JAIL_SUPERVISE_CMD=
 	JAIL_CREATE_CPU_MS=
 	JAIL_CREATE_MEMORY_BYTES=
+	JAIL_CREATE_PROFILE=
 	JAIL_SUPERVISE_PRI=
 	JAIL_SUPERVISE_TAG=
 	JAIL_AUTOSTART=NO
@@ -365,8 +366,10 @@ create_jail() {
 	supervise_cmd=${3:-/bin/sh /etc/rc}
 	create_cpu_ms=${4:-}
 	create_memory_bytes=${5:-}
-	supervise_pri=${6:-}
-	supervise_tag=${7:-}
+	create_profile=${6:-}
+	supervise_pri=${7:-}
+	supervise_tag=${8:-}
+	escaped_create_profile=$(escape_dq "${create_profile}")
 	escaped_supervise_cmd=$(escape_dq "${supervise_cmd}")
 	escaped_supervise_pri=$(escape_dq "${supervise_pri}")
 	escaped_supervise_tag=$(escape_dq "${supervise_tag}")
@@ -386,6 +389,7 @@ JAIL_AUTOSTART=${autostart}
 # Optional jailctl create(8) resource controls:
 JAIL_CREATE_CPU_MS="${create_cpu_ms}"
 JAIL_CREATE_MEMORY_BYTES="${create_memory_bytes}"
+JAIL_CREATE_PROFILE="${escaped_create_profile}"
 # Optional jailctl supervise(8) logging controls:
 JAIL_SUPERVISE_PRI="${escaped_supervise_pri}"
 JAIL_SUPERVISE_TAG="${escaped_supervise_tag}"
@@ -431,6 +435,9 @@ start_jail() {
 	fi
 	if [ -n "${JAIL_CREATE_MEMORY_BYTES:-}" ]; then
 		set -- "$@" -m "${JAIL_CREATE_MEMORY_BYTES}"
+	fi
+	if [ -n "${JAIL_CREATE_PROFILE:-}" ]; then
+		set -- "$@" -p "${JAIL_CREATE_PROFILE}"
 	fi
 	set -- "$@" "${ROOT_DIR}"
 	"$@"
@@ -550,6 +557,7 @@ case "${cmd}" in
 		supervise_cmd="/bin/sh /etc/rc"
 		create_cpu_ms=
 		create_memory_bytes=
+		create_profile=
 		supervise_pri=
 		supervise_tag=
 		shift
@@ -572,6 +580,11 @@ case "${cmd}" in
 			-m)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				create_memory_bytes=$2
+				shift 2
+				;;
+			-P)
+				[ $# -ge 2 ] || { usage; exit 1; }
+				create_profile=$2
 				shift 2
 				;;
 			-p)
@@ -600,7 +613,7 @@ case "${cmd}" in
 		name=$1
 		create_jail "${name}" "${autostart}" "${supervise_cmd}" \
 		    "${create_cpu_ms}" "${create_memory_bytes}" \
-		    "${supervise_pri}" "${supervise_tag}"
+		    "${create_profile}" "${supervise_pri}" "${supervise_tag}"
 		;;
 	start)
 		if [ $# -eq 2 ] && [ "$2" = "--all" ]; then

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -79,7 +79,7 @@ Then
 extract
 .Pa base.tar.xz
 into the configured shared base layer directory.
-.It Cm create Op Fl a Op Fl s Ar cmd Op Fl c Ar cpu-ms Op Fl m Ar bytes Op Fl p Ar pri Op Fl t Ar tag Ar name
+.It Cm create Op Fl a Op Fl s Ar cmd Op Fl c Ar cpu-ms Op Fl m Ar bytes Op Fl P Ar profile Op Fl p Ar pri Op Fl t Ar tag Ar name
 Create directories and metadata for one jail:
 .Pa root ,
 .Pa data ,
@@ -116,6 +116,18 @@ the generated
 stores the corresponding create-time
 .Xr jailctl 8
 resource limits.
+When
+.Fl P
+is provided,
+the generated
+.Pa jail.conf
+stores the corresponding
+.Xr jailctl 8
+create profile
+.Pq Dq low ,
+.Dq medium ,
+or
+.Dq high .
 When
 .Fl p
 or
@@ -246,6 +258,15 @@ Optional value forwarded to
 Optional value forwarded to
 .Xr jailctl 8
 .Cm create Fl m .
+.It Ev JAIL_CREATE_PROFILE
+Optional value forwarded to
+.Xr jailctl 8
+.Cm create Fl p
+.Pq one of
+.Dq low ,
+.Dq medium ,
+or
+.Dq high .
 .It Ev JAIL_SUPERVISE_PRI
 Optional value forwarded to
 .Xr jailctl 8
@@ -281,7 +302,7 @@ Prepare and start all configured jails:
 # vi /etc/jailmgr.conf
 # jailmgr bootstrap
 # jailmgr create jail1
-# jailmgr create -a -s '/bin/sh /etc/rc' -c 250 -m 536870912 -p local3.info -t jail-web jail2
+# jailmgr create -a -s '/bin/sh /etc/rc' -c 250 -m 536870912 -P medium -p local3.info -t jail-web jail2
 # vi /var/jailmgr/jails/jail1/jail.conf
 # vi /var/jailmgr/jails/jail2/jail.conf
 # jailmgr start --all


### PR DESCRIPTION
### Motivation
- Make the new per-jail security profile feature usable from admin tooling and documented in manpages so operators can select and persist `low|medium|high` isolation for jails. 
- Keep existing `-p` supervise/priority behaviour unchanged in `jailmgr` while adding a distinct `-P`/`-p` separation for profile vs syslog priority.

### Description
- Kernel/API: added `JAIL_CREATE_PROFILE`, `JAIL_PROFILE_{LOW,MEDIUM,HIGH}` and `jc_profile` to `struct jail_create` in `sys/sys/jail.h` and persist `je_profile`/`jc_profile` in `secmodel_jail` entries/configs with a `high` default. 
- Security model: added a `KAUTH_SCOPE_SYSTEM` listener in `secmodel_jail` that enforces deny/defer semantics based on the per-jail profile and documents the intent of denied cases inline; `low` defers system checks, `medium` defers `SYSVIPC`, and `high` enforces full hardening. 
- jailctl: added `create -p <profile>` support, `parse_profile()` and wiring to set `create.jc_profile` so profile can be set at creation time, and updated `usage()`/manpage text describing `low|medium|high` and the default. 
- jailmgr: added `create -P <profile>` CLI flag, persisted `JAIL_CREATE_PROFILE` into generated `jail.conf`, and forward `JAIL_CREATE_PROFILE` to `jailctl create -p` on `start`; manpage `jailmgr(8)` updated with `-P` and `JAIL_CREATE_PROFILE` docs and example. 

### Testing
- Ran a syntax check `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded. 
- Ran `git diff --check` to ensure no whitespace errors, which passed. 
- Verified working tree status and inspected modified files; no automated build or kernel integration tests were run in this environment and runtime behavior should be validated on a NetBSD buildbot or a local system image before deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f47c57cc832a97836c661261573b)