### PR TITLE
jailmgr: suppress duplicate jailctl startup lines

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -483,7 +483,9 @@ start_jail() {
 		set -- "$@" -p "${JAIL_CREATE_PROFILE}"
 	fi
 	set -- "$@" "${ROOT_DIR}"
-	"$@"
+	# jailctl create/supervise print "jail <jid>" on stdout; keep jailmgr
+	# output concise and only show the high-level status line below.
+	"$@" >/dev/null
 
 	set -- jailctl supervise
 	if [ -n "${JAIL_SUPERVISE_PRI:-}" ]; then
@@ -497,7 +499,7 @@ start_jail() {
 	set -f
 	set -- "$@" ${effective_supervise_cmd}
 	set +f
-	"$@"
+	"$@" >/dev/null
 	echo "Started jail ${name}"
 }
 


### PR DESCRIPTION
### Motivation
- `jailctl` prints `jail <jid>` during `create` and `supervise`, which makes `jailmgr start` output noisy and duplicate an already-present high-level status line, so the stdout noise should be suppressed for clarity.

### Description
- Redirect stdout of the `jailctl create` and `jailctl supervise` invocations in `start_jail()` to `/dev/null` while leaving `stderr` unchanged and preserving the final `Started jail <name>` status line, and add a short comment explaining the change.

### Testing
- Performed a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996b3a5d83c832a92ef9956cf4ecc66)