### PR TITLE
jail: add per-jail reserved listening ports

### DIFF
--- a/doc/specs/netbsd-jails-specification.txt
+++ b/doc/specs/netbsd-jails-specification.txt
@@ -136,6 +136,7 @@ Key principle:
   - root path metadata
   - optional CPU limit
   - optional memory limit
+  - optional reserved listening-port set
 
 3.2 Privilege model
 - Host root means effective UID 0 and jail ID 0.
@@ -152,20 +153,32 @@ Key principle:
 - KAUTH_PROCESS_SIGNAL denies cross-jail signaling.
 - Host root bypasses these restrictions by design.
 
-3.4 Credential lifecycle behavior
+3.4 Network bind reservation semantics
+- secmodel_jail registers a KAUTH_SCOPE_NETWORK listener for bind decisions.
+- Jail create payload may include a set of reserved listening ports.
+- Port reservations are exclusive across jails (duplicate reservation fails
+  at create time).
+- For each bind attempt with a concrete TCP/UDP port:
+  - if the port is reserved by at least one jail, only a process in the jail
+    that reserved the port is allowed to bind it;
+  - if the port is not reserved by any jail, bind is allowed by this policy.
+- Port 0 (kernel-assigned ephemeral bind) is not restricted by reservation.
+
+3.5 Credential lifecycle behavior
 - Newly initialized credentials default to jail ID 0.
 - Credential copies preserve jail ID.
 
-3.5 Jail lifecycle constraints
+3.6 Jail lifecycle constraints
 - Destroy is refused while processes (including zombies) still reference the
   target jail ID.
 
-3.6 Sysctl control API (security.models.jail.*)
+3.7 Sysctl control API (security.models.jail.*)
 - id
   - read current process jail ID
   - write requests entering target jail ID
 - create
   - create a jail (legacy integer or structured create payload)
+  - structured payload may include reserved listening ports
 - destroy
   - destroy by ID (empty only)
 - list
@@ -173,7 +186,7 @@ Key principle:
 - resource_mode
   - choose RLIMIT or aggregate model
 
-3.7 Logging model
+3.8 Logging model
 - Module load/unload events.
 - Successful create/destroy operations.
 - Rate-limited resource-veto informational messages.
@@ -376,7 +389,7 @@ Inbound packet:
 - Thin operational interface over security.models.jail sysctls.
 
 8.2 Command surface
-- create [-c cpu-ms] [-m bytes] -n name <root>
+- create [-c cpu-ms] [-m bytes] [-r port[,port...]] -n name <root>
 - supervise [-p priority] [-t tag] <jail-id|name> <command...>
 - destroy <jail-id|name>
 - exec <jail-id|name> [command...]
@@ -422,6 +435,7 @@ List/resolve:
 - bootstrap: load/persist module, fetch/extract base artifacts, build shared
   base layer.
 - create [options] <name>: create/update per-jail structure and persist
+  resource settings (including reserved ports) and
   jail.conf metadata. During create, host /etc/resolv.conf is copied into
   per-jail data/etc/resolv.conf when present.
 - start <name>|--all: mount, create jail, launch supervise command.
@@ -431,6 +445,7 @@ List/resolve:
 - list: print configured jails with root/cmd/autostart information.
 
 9.4.1 Resource option semantics (jailmgr create)
+- -r port[,port...]: persist reserved listening ports forwarded to jailctl create.
 - -c <cpu-percent>
   - integer range: 0..100
   - converted internally to jailctl cpu-ms via:

--- a/share/man/man9/secmodel_jail.9
+++ b/share/man/man9/secmodel_jail.9
@@ -89,6 +89,12 @@ asynchronously signalled by aggregate CPU policy.
 .El
 .Pp
 The default is aggregate mode.
+A structured
+.Vt struct jail_create
+request can include an optional set of reserved listening ports.
+Reserved ports are exclusive per jail and are enforced during
+.Dv KAUTH_NETWORK_BIND
+authorization.
 .Sh MODE TRANSITIONS
 Changing
 .Va resource_mode

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -61,6 +61,7 @@ MODULE(MODULE_CLASS_SECMODEL, secmodel_jail, NULL);
 static kauth_listener_t l_process;
 static kauth_listener_t l_cred;
 static kauth_listener_t l_system;
+static kauth_listener_t l_network;
 
 static secmodel_t jail_sm;
 static kauth_key_t jail_key;
@@ -94,6 +95,11 @@ static void	secmodel_jail_log_veto(const char *, jailid_t,
 		    const struct jail_config *, uint64_t, uint64_t);
 static int	secmodel_jail_system_cb(kauth_cred_t, kauth_action_t, void *,
 		    void *, void *, void *, void *);
+static int	secmodel_jail_network_cb(kauth_cred_t, kauth_action_t, void *,
+		    void *, void *, void *, void *);
+static bool	secmodel_jail_port_reserved_by_id(jailid_t, in_port_t);
+static bool	secmodel_jail_port_reserved_any(in_port_t);
+static bool	secmodel_jail_addr_port(const struct sockaddr *, in_port_t *);
 
 static struct timeval secmodel_jail_veto_log_last;
 static const struct timeval secmodel_jail_veto_log_interval = { 5, 0 };
@@ -112,6 +118,8 @@ struct jail_entry {
 	rlim_t je_cpu_limit;
 	rlim_t je_mem_limit;
 	enum jail_policy_profile je_profile;
+	uint16_t je_nports;
+	uint16_t je_ports[JAIL_PORTS_MAX];
 	LIST_ENTRY(jail_entry) je_entry;
 };
 
@@ -287,6 +295,22 @@ secmodel_jail_create(const struct jail_create *create,
 		return EEXIST;
 	}
 
+	if (create != NULL &&
+	    (create->jc_flags & JAIL_CREATE_PORTS) != 0) {
+		size_t i;
+
+		for (i = 0; i < create->jc_nports; i++) {
+			if (create->jc_ports[i] == 0) {
+				mutex_exit(&jail_lock);
+				return EINVAL;
+			}
+			if (secmodel_jail_port_reserved_any(htons(create->jc_ports[i]))) {
+				mutex_exit(&jail_lock);
+				return EEXIST;
+			}
+		}
+	}
+
 	if (jail_next_id == 0) {
 		mutex_exit(&jail_lock);
 		return EOVERFLOW;
@@ -299,6 +323,11 @@ secmodel_jail_create(const struct jail_create *create,
 	if (create != NULL) {
 		strlcpy(entry->je_name, create->jc_name, sizeof(entry->je_name));
 		strlcpy(entry->je_root, create->jc_root, sizeof(entry->je_root));
+		if ((create->jc_flags & JAIL_CREATE_PORTS) != 0) {
+			entry->je_nports = create->jc_nports;
+			memcpy(entry->je_ports, create->jc_ports,
+			    sizeof(create->jc_ports));
+		}
 	}
 	if (config != NULL) {
 		entry->je_has_cpu_limit = config->jc_has_cpu_limit;
@@ -314,6 +343,63 @@ secmodel_jail_create(const struct jail_create *create,
 
 	*idp = id;
 	return 0;
+}
+
+static bool
+secmodel_jail_port_reserved_by_id(jailid_t id, in_port_t lport)
+{
+	struct jail_entry *entry;
+	size_t i;
+
+	entry = secmodel_jail_lookup(id);
+	if (entry == NULL)
+		return false;
+
+	for (i = 0; i < entry->je_nports; i++) {
+		if (htons(entry->je_ports[i]) == lport)
+			return true;
+	}
+
+	return false;
+}
+
+static bool
+secmodel_jail_port_reserved_any(in_port_t lport)
+{
+	struct jail_entry *entry;
+	size_t i;
+
+	LIST_FOREACH(entry, &jail_list, je_entry) {
+		for (i = 0; i < entry->je_nports; i++) {
+			if (htons(entry->je_ports[i]) == lport)
+				return true;
+		}
+	}
+
+	return false;
+}
+
+static bool
+secmodel_jail_addr_port(const struct sockaddr *sa, in_port_t *port)
+{
+	const struct sockaddr_in *sin;
+	const struct sockaddr_in6 *sin6;
+
+	if (sa == NULL || port == NULL)
+		return false;
+
+	switch (sa->sa_family) {
+	case AF_INET:
+		sin = (const struct sockaddr_in *)sa;
+		*port = sin->sin_port;
+		return true;
+	case AF_INET6:
+		sin6 = (const struct sockaddr_in6 *)sa;
+		*port = sin6->sin6_port;
+		return true;
+	default:
+		return false;
+	}
 }
 
 /*
@@ -673,8 +759,25 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 		flags = create.jc_flags;
 		if ((flags & ~(JAIL_CREATE_MEMLIMIT |
 		    JAIL_CREATE_CPULIMIT |
-		    JAIL_CREATE_PROFILE)) != 0)
+		    JAIL_CREATE_PROFILE |
+		    JAIL_CREATE_PORTS)) != 0)
 			return EINVAL;
+		if ((flags & JAIL_CREATE_PORTS) != 0) {
+			size_t i, j;
+
+			if (create.jc_nports == 0 || create.jc_nports > JAIL_PORTS_MAX)
+				return EINVAL;
+			for (i = 0; i < create.jc_nports; i++) {
+				if (create.jc_ports[i] == 0)
+					return EINVAL;
+				for (j = i + 1; j < create.jc_nports; j++) {
+					if (create.jc_ports[i] == create.jc_ports[j])
+						return EINVAL;
+				}
+			}
+		} else if (create.jc_nports != 0) {
+			return EINVAL;
+		}
 
 		memset(&config, 0, sizeof(config));
 		config.jc_profile = JAIL_PROFILE_POLICY_HIGH;
@@ -1040,6 +1143,8 @@ secmodel_jail_start(void)
 	    secmodel_jail_cred_cb, NULL);
 	l_system = kauth_listen_scope(KAUTH_SCOPE_SYSTEM,
 	    secmodel_jail_system_cb, NULL);
+	l_network = kauth_listen_scope(KAUTH_SCOPE_NETWORK,
+	    secmodel_jail_network_cb, NULL);
 	/*
 	 * Publish the UVM integration hook. UVM checks this pointer before calling,
 	 * so the model can be cleanly loaded/unloaded without hard linker coupling.
@@ -1062,6 +1167,7 @@ secmodel_jail_stop(void)
 	kauth_unlisten_scope(l_process);
 	kauth_unlisten_scope(l_cred);
 	kauth_unlisten_scope(l_system);
+	kauth_unlisten_scope(l_network);
 	kauth_deregister_key(jail_key);
 
 	mutex_enter(&jail_lock);
@@ -1071,6 +1177,47 @@ secmodel_jail_stop(void)
 	}
 	mutex_exit(&jail_lock);
 	mutex_destroy(&jail_lock);
+}
+
+static int
+secmodel_jail_network_cb(kauth_cred_t cred, kauth_action_t action,
+    void *cookie, void *arg0, void *arg1, void *arg2, void *arg3)
+{
+	enum kauth_network_req req;
+	in_port_t lport;
+	jailid_t id;
+
+	(void)cookie;
+	(void)arg1;
+	(void)arg3;
+
+	if (action != KAUTH_NETWORK_BIND)
+		return KAUTH_RESULT_DEFER;
+
+	req = (enum kauth_network_req)(uintptr_t)arg0;
+	if (req != KAUTH_REQ_NETWORK_BIND_PORT &&
+	    req != KAUTH_REQ_NETWORK_BIND_PRIVPORT)
+		return KAUTH_RESULT_DEFER;
+
+	if (!secmodel_jail_addr_port((const struct sockaddr *)arg2, &lport))
+		return KAUTH_RESULT_DEFER;
+	if (lport == 0)
+		return KAUTH_RESULT_DEFER;
+
+	id = secmodel_jail_cred_id(cred);
+
+	mutex_enter(&jail_lock);
+	if (!secmodel_jail_port_reserved_any(lport)) {
+		mutex_exit(&jail_lock);
+		return KAUTH_RESULT_DEFER;
+	}
+	if (secmodel_jail_port_reserved_by_id(id, lport)) {
+		mutex_exit(&jail_lock);
+		return KAUTH_RESULT_ALLOW;
+	}
+	mutex_exit(&jail_lock);
+
+	return KAUTH_RESULT_DENY;
 }
 
 /*

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -45,6 +45,9 @@ typedef uint32_t jailid_t;
 #define JAIL_CREATE_MEMLIMIT	0x00000001
 #define JAIL_CREATE_CPULIMIT	0x00000002
 #define JAIL_CREATE_PROFILE	0x00000004
+#define JAIL_CREATE_PORTS	0x00000008
+
+#define JAIL_PORTS_MAX	32
 
 #define JAIL_PROFILE_LOW	0
 #define JAIL_PROFILE_MEDIUM	1
@@ -56,6 +59,8 @@ struct jail_create {
 	uint32_t jc_profile;
 	uint64_t jc_mem_limit;
 	uint64_t jc_cpu_limit;
+	uint16_t jc_nports;
+	uint16_t jc_ports[JAIL_PORTS_MAX];
 	char jc_name[JAIL_NAME_MAX + 1];
 	char jc_root[JAIL_ROOT_MAX + 1];
 };

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -37,6 +37,7 @@
 .Op Fl c Ar cpu-ms
 .Op Fl m Ar bytes
 .Op Fl p Ar profile
+.Op Fl r Ar port[,port...]
 .Fl n Ar name
 .Ar root
 .Nm
@@ -66,7 +67,7 @@ jail id, while the host root user (jail id 0) can access all processes.
 .Pp
 The commands are as follows:
 .Bl -tag -width Ds
-.It Cm create Op Fl c Ar cpu-ms Op Fl m Ar bytes Op Fl p Ar profile Fl n Ar name Ar root
+.It Cm create Op Fl c Ar cpu-ms Op Fl m Ar bytes Op Fl p Ar profile Op Fl r Ar port[,port...] Fl n Ar name Ar root
 Create a new jail id, assign it the unique
 .Ar name ,
 and store jail name and root metadata in the kernel jail model.
@@ -95,6 +96,12 @@ keeps hardening but defers SysV IPC administrative checks,
 and
 .Dq high
 enforces full system-scope hardening.
+.It Fl r Ar port[,port...]
+Reserve one or more listening ports for this jail.
+The option may be repeated and accepts comma-separated lists.
+When at least one jail reserves a given port, bind attempts for that port are
+allowed only from processes in the jail that reserved it.
+Ports not reserved by any jail remain unrestricted.
 .El
 .It Cm supervise Op Fl p Ar pri Op Fl t Ar tag Ar jail-id | name Ar command Op Ar args ...
 Start a command in an existing jail selected by

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -71,6 +71,7 @@ static int	parse_log_facility(const char *);
 static int	parse_log_level(const char *);
 static int	parse_log_priority(const char *);
 static uint32_t	parse_profile(const char *);
+static void	parse_port_list(struct jail_create *, const char *);
 static void	sanitize_field(const char *, char *, size_t);
 static bool	jail_lookup_by_name(const char *, struct jail_info *);
 static bool	jail_lookup_by_id(jailid_t, struct jail_info *);
@@ -758,6 +759,46 @@ parse_profile(const char *arg)
 	return JAIL_PROFILE_HIGH;
 }
 
+static void
+parse_port_list(struct jail_create *create, const char *arg)
+{
+	char *list, *tok, *sp;
+	unsigned long port;
+
+	list = strdup(arg);
+	if (list == NULL)
+		err(1, "strdup");
+
+	for (tok = strtok_r(list, ",", &sp); tok != NULL;
+	    tok = strtok_r(NULL, ",", &sp)) {
+		char *endp;
+		size_t i;
+
+		errno = 0;
+		port = strtoul(tok, &endp, 10);
+		if (errno != 0 || *tok == '\0' || *endp != '\0' ||
+		    port == 0 || port > UINT16_MAX) {
+			free(list);
+			errx(1, "invalid reserved port: %s", tok);
+		}
+		for (i = 0; i < create->jc_nports; i++) {
+			if (create->jc_ports[i] == (uint16_t)port) {
+				free(list);
+				errx(1, "duplicate reserved port: %lu", port);
+			}
+		}
+		if (create->jc_nports >= JAIL_PORTS_MAX) {
+			free(list);
+			errx(1, "too many reserved ports (max %u)", JAIL_PORTS_MAX);
+		}
+		create->jc_ports[create->jc_nports++] = (uint16_t)port;
+	}
+
+	free(list);
+	if (create->jc_nports > 0)
+		create->jc_flags |= JAIL_CREATE_PORTS;
+}
+
 static int
 getnum(const char *str, uintmax_t *num)
 {
@@ -815,7 +856,7 @@ main(int argc, char *argv[])
 		name = NULL;
 		create.jc_profile = JAIL_PROFILE_HIGH;
 		optind = 2;
-		while ((ch = getopt(argc, argv, "c:m:n:p:")) != -1) {
+		while ((ch = getopt(argc, argv, "c:m:n:p:r:")) != -1) {
 			switch (ch) {
 			case 'c':
 				errno = 0;
@@ -839,6 +880,9 @@ main(int argc, char *argv[])
 			case 'p':
 				create.jc_flags |= JAIL_CREATE_PROFILE;
 				create.jc_profile = parse_profile(optarg);
+				break;
+			case 'r':
+				parse_port_list(&create, optarg);
 				break;
 			default:
 				usage();
@@ -931,7 +975,7 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s create [-c cpu-ms] [-m bytes] [-p low|medium|high] -n name <root>\n"
+	    "usage: %s create [-c cpu-ms] [-m bytes] [-p low|medium|high] [-r port[,port...]] -n name <root>\n"
 	    "       %s supervise [-p pri] [-t tag] <jail-id|name> <command [args...]>\n"
 	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id|name>\n"

--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -12,6 +12,7 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
 - `create -s '<cmd ...>' <name>` initializes `JAIL_SUPERVISE_CMD` in `jail.conf`.
 - `create -c <cpu-percent>` sets CPU limits for `jailctl create` (0-100; internally 1% = 10ms/s).
 - `create -m <memory-mb>` sets memory limits for `jailctl create` (internally converted to bytes).
+- `create -r <port[,port...]>` reserves one or more listening ports for the jail (`jailctl create -r`).
 - `create -p <pri> -t <tag>` initializes logging options for `jailctl supervise`.
 - `start <name>` and `restart <name>` use per-jail settings from `${JAIL_DATA_DIR}/<name>/jail.conf`.
 - `start --all` / `stop --all` / `restart --all` work only on jails with `JAIL_AUTOSTART=YES`.
@@ -45,7 +46,7 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
    /usr/sbin/jailmgr create jail1
    /usr/sbin/jailmgr create -a jail2
    /usr/sbin/jailmgr create -a -s '/bin/sh /etc/rc' \
-       -c 25 -m 512 -p local3.info -t jail-web jail3
+       -c 25 -m 512 -r 80,443 -p local3.info -t jail-web jail3
    ```
 
    Then set at least `JAIL_SUPERVISE_CMD` and `JAIL_AUTOSTART` in each

--- a/usr.sbin/jailmgr/examples/jailmgr.conf.sample
+++ b/usr.sbin/jailmgr/examples/jailmgr.conf.sample
@@ -19,3 +19,6 @@ JAIL_LOCAL_DEV=YES
 JAIL_DEV_SIZE=8m
 JAIL_DEVICES="std ptm"
 JAIL_PTYFS=YES
+
+# Per-jail create-time options are stored in each jail.conf, including
+# JAIL_CREATE_RESERVED_PORTS for exclusive listening-port reservations.

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -78,7 +78,7 @@ Usage: $0 <command> [args]
 
 Commands:
   bootstrap                   Download sets and build shared base layer
-  create [-a] [-s cmd] [-c cpu-percent] [-m memory-mb] [-P profile] [-p pri] [-t tag] <name>
+  create [-a] [-s cmd] [-c cpu-percent] [-m memory-mb] [-P profile] [-r port[,port...]] [-p pri] [-t tag] <name>
                               Create jail instance directories and persist jail.conf
   start <name>                Mount jail root and supervise jail via jailctl
   start --all                 Start all configured jails
@@ -297,6 +297,7 @@ load_jail_conf() {
 	JAIL_CREATE_CPU_MS=
 	JAIL_CREATE_MEMORY_BYTES=
 	JAIL_CREATE_PROFILE=
+	JAIL_CREATE_RESERVED_PORTS=
 	JAIL_SUPERVISE_PRI=
 	JAIL_SUPERVISE_TAG=
 	JAIL_AUTOSTART=NO
@@ -410,9 +411,11 @@ create_jail() {
 	create_cpu_ms=${4:-}
 	create_memory_bytes=${5:-}
 	create_profile=${6:-}
-	supervise_pri=${7:-}
-	supervise_tag=${8:-}
+	create_reserved_ports=${7:-}
+	supervise_pri=${8:-}
+	supervise_tag=${9:-}
 	escaped_create_profile=$(escape_dq "${create_profile}")
+	escaped_create_reserved_ports=$(escape_dq "${create_reserved_ports}")
 	escaped_supervise_cmd=$(escape_dq "${supervise_cmd}")
 	escaped_supervise_pri=$(escape_dq "${supervise_pri}")
 	escaped_supervise_tag=$(escape_dq "${supervise_tag}")
@@ -433,6 +436,7 @@ JAIL_AUTOSTART=${autostart}
 JAIL_CREATE_CPU_MS="${create_cpu_ms}"
 JAIL_CREATE_MEMORY_BYTES="${create_memory_bytes}"
 JAIL_CREATE_PROFILE="${escaped_create_profile}"
+JAIL_CREATE_RESERVED_PORTS="${escaped_create_reserved_ports}"
 # Optional jailctl supervise(8) logging controls:
 JAIL_SUPERVISE_PRI="${escaped_supervise_pri}"
 JAIL_SUPERVISE_TAG="${escaped_supervise_tag}"
@@ -481,6 +485,9 @@ start_jail() {
 	fi
 	if [ -n "${JAIL_CREATE_PROFILE:-}" ]; then
 		set -- "$@" -p "${JAIL_CREATE_PROFILE}"
+	fi
+	if [ -n "${JAIL_CREATE_RESERVED_PORTS:-}" ]; then
+		set -- "$@" -r "${JAIL_CREATE_RESERVED_PORTS}"
 	fi
 	set -- "$@" "${ROOT_DIR}"
 	# jailctl create/supervise print "jail <jid>" on stdout; keep jailmgr
@@ -599,6 +606,7 @@ case "${cmd}" in
 		create_cpu_ms=
 		create_memory_bytes=
 		create_profile=
+		create_reserved_ports=
 		supervise_pri=
 		supervise_tag=
 		shift
@@ -634,6 +642,11 @@ case "${cmd}" in
 			-P)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				create_profile=$2
+				shift 2
+				;;
+			-r)
+				[ $# -ge 2 ] || { usage; exit 1; }
+				create_reserved_ports=$2
 				shift 2
 				;;
 			-p)

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -79,7 +79,7 @@ Then
 extract
 .Pa base.tar.xz
 into the configured shared base layer directory.
-.It Cm create Op Fl a Op Fl s Ar cmd Op Fl c Ar cpu-percent Op Fl m Ar memory-mb Op Fl P Ar profile Op Fl p Ar pri Op Fl t Ar tag Ar name
+.It Cm create Op Fl a Op Fl s Ar cmd Op Fl c Ar cpu-percent Op Fl m Ar memory-mb Op Fl P Ar profile Op Fl r Ar port[,port...] Op Fl p Ar pri Op Fl t Ar tag Ar name
 Create directories and metadata for one jail:
 .Pa root ,
 .Pa data ,
@@ -143,6 +143,15 @@ create profile
 .Dq medium ,
 or
 .Dq high .
+When
+.Fl r
+is provided,
+the generated
+.Pa jail.conf
+stores the corresponding
+.Xr jailctl 8
+create-time reserved listening ports
+.Pq comma-separated list forwarded to Cm create Fl r .
 When
 .Fl p
 or
@@ -282,6 +291,11 @@ Optional value forwarded to
 .Dq medium ,
 or
 .Dq high .
+.It Ev JAIL_CREATE_RESERVED_PORTS
+Optional value forwarded to
+.Xr jailctl 8
+.Cm create Fl r
+.Pq comma-separated TCP/UDP port list .
 .It Ev JAIL_SUPERVISE_PRI
 Optional value forwarded to
 .Xr jailctl 8
@@ -317,7 +331,7 @@ Prepare and start all configured jails:
 # vi /etc/jailmgr.conf
 # jailmgr bootstrap
 # jailmgr create jail1
-# jailmgr create -a -s '/bin/sh /etc/rc' -c 25 -m 512 -P medium -p local3.info -t jail-web jail2
+# jailmgr create -a -s '/bin/sh /etc/rc' -c 25 -m 512 -P medium -r 80,443 -p local3.info -t jail-web jail2
 # vi /var/jailmgr/jails/jail1/jail.conf
 # vi /var/jailmgr/jails/jail2/jail.conf
 # jailmgr start --all


### PR DESCRIPTION
### Motivation
- Provide a mechanism to exclusively reserve one or more listening ports for a jail so bind attempts can be restricted to the owning jail while leaving unreserved ports unrestricted.

### Description
- Extend the jail creation ABI by adding `JAIL_CREATE_PORTS`, `jc_nports` and `jc_ports[]` to `struct jail_create` in `sys/sys/jail.h` and define `JAIL_PORTS_MAX`.
- Implement kernel enforcement in `secmodel_jail`: store per-jail reserved ports, reject conflicting reservations at create time, and register a `KAUTH_SCOPE_NETWORK` listener that allows a bind only when the calling process's jail reserved that port (ports reserved by no jail are unchanged; ephemeral `0` stays unrestricted). (`sys/secmodel/jail/secmodel_jail.c`)
- Add `jailctl create -r port[,port...]` with comma-separated parsing, duplicate/limit checks and integration into the structured create payload. (`usr.sbin/jailctl/jailctl.c`, `usr.sbin/jailctl/jailctl.8`)
- Integrate persistence and forwarding in `jailmgr`: persist `JAIL_CREATE_RESERVED_PORTS` to per-jail `jail.conf` and forward to `jailctl create -r` during `start`. Update `jailmgr` CLI and examples accordingly. (`usr.sbin/jailmgr/*`)
- Update documentation and specification texts to describe the reserved-port semantics and new CLI options: `secmodel_jail(9)`, `jailctl(8)`, `jailmgr(8)`, the jails spec (`doc/specs/netbsd-jails-specification.txt`), and example README/config samples.

### Testing
- Ran a shell syntax check on `usr.sbin/jailmgr/jailmgr` with `sh -n`, which succeeded (`OK`).
- Attempted to build `usr.sbin/jailctl` in this environment; `make -C usr.sbin/jailctl` failed due to a missing/broken make invocation in this containerized environment, and `bmake` is not present here, so a full build could not be completed.
- No kernel-level runtime tests were executed in this environment; the kernel integration and kauth listener behavior should be validated on a NetBSD system with `bmake`/kernel build and runtime verification (create conflicting reservations, verify `bind(2)` allow/deny semantics, and check `jailctl`/`jailmgr` persistence).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996b64419c0832abd600a290acd5e26)