### PR TITLE
jailctl: add supervise -f facility and make -o/-e level-only; update jailmgr and docs

### DIFF
--- a/doc/specs/netbsd-jails-specification.txt
+++ b/doc/specs/netbsd-jails-specification.txt
@@ -390,7 +390,7 @@ Inbound packet:
 
 8.2 Command surface
 - create [-c cpu-ms] [-m bytes] [-r port[,port...]] -n name <root>
-- supervise [-p priority] [-t tag] <jail-id|name> <command...>
+- supervise [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <jail-id|name> <command...>
 - destroy <jail-id|name>
 - exec <jail-id|name> [command...]
 - list
@@ -408,6 +408,7 @@ Exec:
 Supervise:
 - detached monitor + child workload model
 - streams child stdout/stderr to syslog with jail context
+- logging options: -f selects facility, -o/-e select only levels
 - on stop signal: SIGTERM process group, then SIGKILL after timeout
 
 List/resolve:

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -25,7 +25,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"-
-.Dd September 24, 2025
+.Dd February 19, 2026
 .Dt JAILCTL 8
 .Os
 .Sh NAME
@@ -42,8 +42,9 @@
 .Ar root
 .Nm
 .Cm supervise
-.Op Fl o Ar stdout-pri
-.Op Fl e Ar stderr-pri
+.Op Fl f Ar facility
+.Op Fl o Ar stdout-level
+.Op Fl e Ar stderr-level
 .Op Fl t Ar tag
 .Ar jail-id | name
 .Ar command
@@ -104,7 +105,7 @@ When at least one jail reserves a given port, bind attempts for that port are
 allowed only from processes in the jail that reserved it.
 Ports not reserved by any jail remain unrestricted.
 .El
-.It Cm supervise Op Fl o Ar stdout-pri Op Fl e Ar stderr-pri Op Fl t Ar tag Ar jail-id | name Ar command Op Ar args ...
+.It Cm supervise Op Fl f Ar facility Op Fl o Ar stdout-level Op Fl e Ar stderr-level Op Fl t Ar tag Ar jail-id | name Ar command Op Ar args ...
 Start a command in an existing jail selected by
 .Ar jail-id
 or
@@ -121,20 +122,33 @@ and restarts it with an exponential backoff delay (capped at 10 seconds).
 .Pp
 The optional flags control supervisor logging:
 .Bl -tag -width Ds
-.It Fl o Ar stdout-pri
-Set the syslog priority used for forwarded standard output lines.
-Accepts the same syntax as
-.Xr logger 1
-.Pq numeric or Dq facility.level .
+.It Fl f Ar facility
+Set the syslog facility used by the supervisor and for forwarded
+standard-output and standard-error lines.
 The default is
-.Dq daemon.notice .
-.It Fl e Ar stderr-pri
-Set the syslog priority used for forwarded standard error lines.
-Accepts the same syntax as
-.Xr logger 1
-.Pq numeric or Dq facility.level .
+.Dq daemon .
+.It Fl o Ar stdout-level
+Set the syslog level used for forwarded standard output lines.
+The level may be specified as one of
+.Dq emerg ,
+.Dq alert ,
+.Dq crit ,
+.Dq err ,
+.Dq warning ,
+.Dq notice ,
+.Dq info ,
+or
+.Dq debug ,
+or as a numeric level from 0 to 7.
 The default is
-.Dq daemon.err .
+.Dq notice .
+.It Fl e Ar stderr-level
+Set the syslog level used for forwarded standard error lines.
+The same values as
+.Fl o
+are accepted.
+The default is
+.Dq err .
 .It Fl t Ar tag
 Set the syslog tag used for forwarded jailed-command output.
 If omitted,

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -69,7 +69,7 @@ static void	jail_spawn_detached(jailid_t, const char *, const char *,
 			    const char *, char *[], int, int, int);
 static int	parse_log_facility(const char *);
 static int	parse_log_level(const char *);
-static int	parse_log_priority(const char *);
+static int	parse_log_level_arg(const char *);
 static uint32_t	parse_profile(const char *);
 static void	parse_port_list(struct jail_create *, const char *);
 static void	sanitize_field(const char *, char *, size_t);
@@ -718,31 +718,20 @@ parse_log_level(const char *name)
 }
 
 static int
-parse_log_priority(const char *arg)
+parse_log_level_arg(const char *arg)
 {
-	char pri[64], *dot;
 	long num;
 	char *endp;
 
-	/* Accept either a raw numeric priority or facility.level syntax. */
-	if (strlen(arg) >= sizeof(pri))
-		errx(1, "priority too long: %s", arg);
-	strlcpy(pri, arg, sizeof(pri));
-
 	errno = 0;
-	num = strtol(pri, &endp, 0);
-	if (errno == 0 && *pri != '\0' && *endp == '\0') {
-		if (num < 0 || num > (LOG_FACMASK | LOG_PRIMASK))
-			errx(1, "priority out of range: %s", arg);
+	num = strtol(arg, &endp, 0);
+	if (errno == 0 && *arg != '\0' && *endp == '\0') {
+		if (num < LOG_EMERG || num > LOG_DEBUG)
+			errx(1, "log level out of range: %s", arg);
 		return (int)num;
 	}
 
-	dot = strchr(pri, '.');
-	if (dot == NULL || dot == pri || dot[1] == '\0')
-		errx(1, "invalid priority: %s (expected facility.level)", arg);
-	*dot++ = '\0';
-
-	return parse_log_facility(pri) | parse_log_level(dot);
+	return parse_log_level(arg);
 }
 
 static uint32_t
@@ -908,20 +897,24 @@ main(int argc, char *argv[])
 	if (strcmp(argv[1], "supervise") == 0) {
 		char **cmd;
 		int ch;
-		int stdout_priority, stderr_priority;
+		int facility, stdout_level, stderr_level;
 		char logtag[JAILCTL_TAG_MAX + 1];
 
-		stdout_priority = LOG_DAEMON | LOG_NOTICE;
-		stderr_priority = LOG_DAEMON | LOG_ERR;
+		facility = LOG_DAEMON;
+		stdout_level = LOG_NOTICE;
+		stderr_level = LOG_ERR;
 		strlcpy(logtag, "jailctl", sizeof(logtag));
 		optind = 2;
-		while ((ch = getopt(argc, argv, "t:o:e:")) != -1) {
+		while ((ch = getopt(argc, argv, "f:t:o:e:")) != -1) {
 			switch (ch) {
+			case 'f':
+				facility = parse_log_facility(optarg);
+				break;
 			case 'o':
-				stdout_priority = parse_log_priority(optarg);
+				stdout_level = parse_log_level_arg(optarg);
 				break;
 			case 'e':
-				stderr_priority = parse_log_priority(optarg);
+				stderr_level = parse_log_level_arg(optarg);
 				break;
 			case 't':
 				sanitize_field(optarg, logtag, sizeof(logtag));
@@ -942,7 +935,7 @@ main(int argc, char *argv[])
 		cmd = &argv[optind];
 
 		jail_spawn_detached(id, ji.ji_root, ji.ji_name, logtag, cmd,
-		    LOG_DAEMON, stdout_priority, stderr_priority);
+		    facility, facility | stdout_level, facility | stderr_level);
 		return 0;
 	}
 
@@ -981,7 +974,7 @@ usage(void)
 {
 	fprintf(stderr,
 	    "usage: %s create [-c cpu-ms] [-m bytes] [-p low|medium|high] [-r port[,port...]] -n name <root>\n"
-	    "       %s supervise [-o stdout-pri] [-e stderr-pri] [-t tag] <jail-id|name> <command [args...]>\n"
+	    "       %s supervise [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <jail-id|name> <command [args...]>\n"
 	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id|name>\n"
 	    "       %s list\n",

--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -13,7 +13,7 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
 - `create -c <cpu-percent>` sets CPU limits for `jailctl create` (0-100; internally 1% = 10ms/s).
 - `create -m <memory-mb>` sets memory limits for `jailctl create` (internally converted to bytes).
 - `create -r <port[,port...]>` reserves one or more listening ports for the jail (`jailctl create -r`).
-- `create -o <stdout-pri> -e <stderr-pri> -t <tag>` initializes logging options for `jailctl supervise`.
+- `create -f <facility> -o <stdout-level> -e <stderr-level> -t <tag>` initializes logging options for `jailctl supervise`.
 - `start <name>` and `restart <name>` use per-jail settings from `${JAIL_DATA_DIR}/<name>/jail.conf`.
 - `start --all` / `stop --all` / `restart --all` work only on jails with `JAIL_AUTOSTART=YES`.
 
@@ -46,7 +46,7 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
    /usr/sbin/jailmgr create jail1
    /usr/sbin/jailmgr create -a jail2
    /usr/sbin/jailmgr create -a -s '/bin/sh /etc/rc' \
-       -c 25 -m 512 -r 80,443 -o local3.info -e local3.err -t jail-web jail3
+       -c 25 -m 512 -r 80,443 -f local3 -o info -e err -t jail-web jail3
    ```
 
    Then set at least `JAIL_SUPERVISE_CMD` and `JAIL_AUTOSTART` in each

--- a/usr.sbin/jailmgr/examples/jailmgr.conf.sample
+++ b/usr.sbin/jailmgr/examples/jailmgr.conf.sample
@@ -22,3 +22,8 @@ JAIL_PTYFS=YES
 
 # Per-jail create-time options are stored in each jail.conf, including
 # JAIL_CREATE_RESERVED_PORTS for exclusive listening-port reservations.
+
+# Per-jail supervise logging settings are stored in each jail.conf:
+#   JAIL_SUPERVISE_FACILITY (facility name, e.g. daemon/local0)
+#   JAIL_SUPERVISE_STDOUT_LEVEL (emerg..debug or 0..7)
+#   JAIL_SUPERVISE_STDERR_LEVEL (emerg..debug or 0..7)

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -78,7 +78,7 @@ Usage: $0 <command> [args]
 
 Commands:
   bootstrap                   Download sets and build shared base layer
-  create [-a] [-s cmd] [-c cpu-percent] [-m memory-mb] [-p profile] [-r port[,port...]] [-o stdout-pri] [-e stderr-pri] [-t tag] <name>
+  create [-a] [-s cmd] [-c cpu-percent] [-m memory-mb] [-p profile] [-r port[,port...]] [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <name>
                               Create jail instance directories and persist jail.conf
   start <name>                Mount jail root and supervise jail via jailctl
   start --all                 Start all configured jails
@@ -298,8 +298,9 @@ load_jail_conf() {
 	JAIL_CREATE_MEMORY_BYTES=
 	JAIL_CREATE_PROFILE=
 	JAIL_CREATE_RESERVED_PORTS=
-	JAIL_SUPERVISE_STDOUT_PRI=
-	JAIL_SUPERVISE_STDERR_PRI=
+	JAIL_SUPERVISE_FACILITY=
+	JAIL_SUPERVISE_STDOUT_LEVEL=
+	JAIL_SUPERVISE_STDERR_LEVEL=
 	JAIL_SUPERVISE_TAG=
 	JAIL_AUTOSTART=NO
 	# shellcheck disable=SC1090
@@ -413,14 +414,16 @@ create_jail() {
 	create_memory_bytes=${5:-}
 	create_profile=${6:-}
 	create_reserved_ports=${7:-}
-	supervise_stdout_pri=${8:-}
-	supervise_stderr_pri=${9:-}
-	supervise_tag=${10:-}
+	supervise_facility=${8:-}
+	supervise_stdout_level=${9:-}
+	supervise_stderr_level=${10:-}
+	supervise_tag=${11:-}
 	escaped_create_profile=$(escape_dq "${create_profile}")
 	escaped_create_reserved_ports=$(escape_dq "${create_reserved_ports}")
 	escaped_supervise_cmd=$(escape_dq "${supervise_cmd}")
-	escaped_supervise_stdout_pri=$(escape_dq "${supervise_stdout_pri}")
-	escaped_supervise_stderr_pri=$(escape_dq "${supervise_stderr_pri}")
+	escaped_supervise_facility=$(escape_dq "${supervise_facility}")
+	escaped_supervise_stdout_level=$(escape_dq "${supervise_stdout_level}")
+	escaped_supervise_stderr_level=$(escape_dq "${supervise_stderr_level}")
 	escaped_supervise_tag=$(escape_dq "${supervise_tag}")
 
 	jail_paths "${name}"
@@ -441,8 +444,9 @@ JAIL_CREATE_MEMORY_BYTES="${create_memory_bytes}"
 JAIL_CREATE_PROFILE="${escaped_create_profile}"
 JAIL_CREATE_RESERVED_PORTS="${escaped_create_reserved_ports}"
 # Optional jailctl supervise(8) logging controls:
-JAIL_SUPERVISE_STDOUT_PRI="${escaped_supervise_stdout_pri}"
-JAIL_SUPERVISE_STDERR_PRI="${escaped_supervise_stderr_pri}"
+JAIL_SUPERVISE_FACILITY="${escaped_supervise_facility}"
+JAIL_SUPERVISE_STDOUT_LEVEL="${escaped_supervise_stdout_level}"
+JAIL_SUPERVISE_STDERR_LEVEL="${escaped_supervise_stderr_level}"
 JAIL_SUPERVISE_TAG="${escaped_supervise_tag}"
 # Required command (with optional args) to supervise in this jail.
 # Example starts the normal NetBSD in-jail boot sequence:
@@ -499,11 +503,14 @@ start_jail() {
 	"$@" >/dev/null
 
 	set -- jailctl supervise
-	if [ -n "${JAIL_SUPERVISE_STDOUT_PRI:-}" ]; then
-		set -- "$@" -o "${JAIL_SUPERVISE_STDOUT_PRI}"
+	if [ -n "${JAIL_SUPERVISE_FACILITY:-}" ]; then
+		set -- "$@" -f "${JAIL_SUPERVISE_FACILITY}"
 	fi
-	if [ -n "${JAIL_SUPERVISE_STDERR_PRI:-}" ]; then
-		set -- "$@" -e "${JAIL_SUPERVISE_STDERR_PRI}"
+	if [ -n "${JAIL_SUPERVISE_STDOUT_LEVEL:-}" ]; then
+		set -- "$@" -o "${JAIL_SUPERVISE_STDOUT_LEVEL}"
+	fi
+	if [ -n "${JAIL_SUPERVISE_STDERR_LEVEL:-}" ]; then
+		set -- "$@" -e "${JAIL_SUPERVISE_STDERR_LEVEL}"
 	fi
 	if [ -n "${JAIL_SUPERVISE_TAG:-}" ]; then
 		set -- "$@" -t "${JAIL_SUPERVISE_TAG}"
@@ -614,8 +621,9 @@ case "${cmd}" in
 		create_memory_bytes=
 		create_profile=
 		create_reserved_ports=
-		supervise_stdout_pri=
-		supervise_stderr_pri=
+		supervise_facility=
+		supervise_stdout_level=
+		supervise_stderr_level=
 		supervise_tag=
 		shift
 		while [ $# -gt 0 ]; do
@@ -657,14 +665,19 @@ case "${cmd}" in
 				create_reserved_ports=$2
 				shift 2
 				;;
+			-f)
+				[ $# -ge 2 ] || { usage; exit 1; }
+				supervise_facility=$2
+				shift 2
+				;;
 			-o)
 				[ $# -ge 2 ] || { usage; exit 1; }
-				supervise_stdout_pri=$2
+				supervise_stdout_level=$2
 				shift 2
 				;;
 			-e)
 				[ $# -ge 2 ] || { usage; exit 1; }
-				supervise_stderr_pri=$2
+				supervise_stderr_level=$2
 				shift 2
 				;;
 			-t)
@@ -689,8 +702,8 @@ case "${cmd}" in
 		create_jail "${name}" "${autostart}" "${supervise_cmd}" \
 		    "${create_cpu_ms}" "${create_memory_bytes}" \
 		    "${create_profile}" "${create_reserved_ports}" \
-		    "${supervise_stdout_pri}" "${supervise_stderr_pri}" \
-		    "${supervise_tag}"
+		    "${supervise_facility}" "${supervise_stdout_level}" \
+		    "${supervise_stderr_level}" "${supervise_tag}"
 		;;
 	start)
 		if [ $# -eq 2 ] && [ "$2" = "--all" ]; then

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -79,7 +79,7 @@ Then
 extract
 .Pa base.tar.xz
 into the configured shared base layer directory.
-.It Cm create Op Fl a Op Fl s Ar cmd Op Fl c Ar cpu-percent Op Fl m Ar memory-mb Op Fl p Ar profile Op Fl r Ar port[,port...] Op Fl o Ar stdout-pri Op Fl e Ar stderr-pri Op Fl t Ar tag Ar name
+.It Cm create Op Fl a Op Fl s Ar cmd Op Fl c Ar cpu-percent Op Fl m Ar memory-mb Op Fl p Ar profile Op Fl r Ar port[,port...] Op Fl f Ar facility Op Fl o Ar stdout-level Op Fl e Ar stderr-level Op Fl t Ar tag Ar name
 Create directories and metadata for one jail:
 .Pa root ,
 .Pa data ,
@@ -153,6 +153,7 @@ stores the corresponding
 create-time reserved listening ports
 .Pq comma-separated list forwarded to Cm create Fl r .
 When
+.Fl f ,
 .Fl o ,
 .Fl e ,
 or
@@ -297,11 +298,15 @@ Optional value forwarded to
 .Xr jailctl 8
 .Cm create Fl r
 .Pq comma-separated TCP/UDP port list .
-.It Ev JAIL_SUPERVISE_STDOUT_PRI
+.It Ev JAIL_SUPERVISE_FACILITY
+Optional value forwarded to
+.Xr jailctl 8
+.Cm supervise Fl f .
+.It Ev JAIL_SUPERVISE_STDOUT_LEVEL
 Optional value forwarded to
 .Xr jailctl 8
 .Cm supervise Fl o .
-.It Ev JAIL_SUPERVISE_STDERR_PRI
+.It Ev JAIL_SUPERVISE_STDERR_LEVEL
 Optional value forwarded to
 .Xr jailctl 8
 .Cm supervise Fl e .
@@ -336,7 +341,7 @@ Prepare and start all configured jails:
 # vi /etc/jailmgr.conf
 # jailmgr bootstrap
 # jailmgr create jail1
-# jailmgr create -a -s '/bin/sh /etc/rc' -c 25 -m 512 -p medium -r 80,443 -o local3.info -e local3.err -t jail-web jail2
+# jailmgr create -a -s '/bin/sh /etc/rc' -c 25 -m 512 -p medium -r 80,443 -f local3 -o info -e err -t jail-web jail2
 # vi /var/jailmgr/jails/jail1/jail.conf
 # vi /var/jailmgr/jails/jail2/jail.conf
 # jailmgr start --all


### PR DESCRIPTION
### Motivation
- Allow callers to explicitly select the syslog facility used by `jailctl supervise` rather than embedding facility in a combined priority string. 
- Make `-o` and `-e` only specify the syslog level (name or numeric 0..7) and compose the final priority as `facility | level`. 
- Propagate the new logging model into `jailmgr` so per-jail settings can persist and be forwarded to `jailctl` and update docs to match the new, non-backward-compatible interface.

### Description
- Replace combined priority parsing in `jailctl` with a `parse_log_level_arg()` helper and add a `-f <facility>` flag, compose stream priorities as `facility | level`, and update `getopt` usage in `usr.sbin/jailctl/jailctl.c` (new defaults: facility `LOG_DAEMON`, stdout `NOTICE`, stderr `ERR`).
- Update the `jailctl(8)` manpage in `usr.sbin/jailctl/jailctl.8` to document `-f facility`, `-o stdout-level`, and `-e stderr-level` semantics and defaults.
- Update `jailmgr` to persist new per-jail variables `JAIL_SUPERVISE_FACILITY`, `JAIL_SUPERVISE_STDOUT_LEVEL`, and `JAIL_SUPERVISE_STDERR_LEVEL`, parse `-f`/`-o`/`-e` on `create`, and forward them to `jailctl supervise` (files changed: `usr.sbin/jailmgr/jailmgr`, `usr.sbin/jailmgr/jailmgr.8`, `usr.sbin/jailmgr/examples/README`, `usr.sbin/jailmgr/examples/jailmgr.conf.sample`).
- Update the jails specification in `doc/specs/netbsd-jails-specification.txt` to reflect the facility+level split and update examples to use the new flags.

### Testing
- Ran a shell syntax check `sh -n usr.sbin/jailmgr/jailmgr` which succeeded. 
- Attempted to build `jailctl` with `make -C usr.sbin/jailctl` but GNU `make` in this environment fails on BSD-style makefiles (`missing separator`).
- Attempted `bmake -C usr.sbin/jailctl` but `bmake` is not installed in this environment, so an actual compile/test run was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996d0f74bc0832ab3cdd1cf479d9209)