### PR TITLE
jailmgr: default supervise command -> /bin/sleep 60; add httpd example

### DIFF
--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -45,12 +45,18 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
    ```sh
    /usr/sbin/jailmgr create jail1
    /usr/sbin/jailmgr create -a jail2
-   /usr/sbin/jailmgr create -a -s '/bin/sh /etc/rc' \
+   /usr/sbin/jailmgr create -a -s '/bin/sleep 60' \
        -c 25 -m 512 -r 80,443 -f local3 -o info -e err -t jail-web jail3
    ```
 
    Then set at least `JAIL_SUPERVISE_CMD` and `JAIL_AUTOSTART` in each
    jail-local `jail.conf`.
+
+   Real-world example for jail `www`:
+
+   ```sh
+   JAIL_SUPERVISE_CMD="/usr/libexec/httpd -I 8080 -X -s -f /srv/www"
+   ```
 
 5. Start jails:
 

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -409,7 +409,7 @@ create_jail() {
 	require_tools
 	name=$1
 	autostart=${2:-NO}
-	supervise_cmd=${3:-/bin/sh /etc/rc}
+	supervise_cmd=${3:-/bin/sleep 60}
 	create_cpu_ms=${4:-}
 	create_memory_bytes=${5:-}
 	create_profile=${6:-}
@@ -449,7 +449,7 @@ JAIL_SUPERVISE_STDOUT_LEVEL="${escaped_supervise_stdout_level}"
 JAIL_SUPERVISE_STDERR_LEVEL="${escaped_supervise_stderr_level}"
 JAIL_SUPERVISE_TAG="${escaped_supervise_tag}"
 # Required command (with optional args) to supervise in this jail.
-# Example starts the normal NetBSD in-jail boot sequence:
+# Example placeholder that keeps the jail alive until a real service command is configured:
 JAIL_SUPERVISE_CMD="${escaped_supervise_cmd}"
 CONF
 
@@ -471,7 +471,7 @@ start_jail() {
 	load_jail_conf "${name}"
 	effective_supervise_cmd=${JAIL_SUPERVISE_CMD:-}
 	if [ -z "${effective_supervise_cmd}" ]; then
-		echo "JAIL_SUPERVISE_CMD must be set in ${JAIL_CONF} (example: /bin/sh /etc/rc)" >&2
+		echo "JAIL_SUPERVISE_CMD must be set in ${JAIL_CONF} (example: /bin/sleep 60)" >&2
 		exit 1
 	fi
 
@@ -616,7 +616,7 @@ case "${cmd}" in
 		;;
 	create)
 		autostart=NO
-		supervise_cmd="/bin/sh /etc/rc"
+		supervise_cmd="/bin/sleep 60"
 		create_cpu_ms=
 		create_memory_bytes=
 		create_profile=

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -348,7 +348,7 @@ Prepare and start all configured jails:
 # vi /etc/jailmgr.conf
 # jailmgr bootstrap
 # jailmgr create jail1
-# jailmgr create -a -s '/bin/sh /etc/rc' -c 25 -m 512 -p medium -r 80,443 -f local3 -o info -e err -t jail-web jail2
+# jailmgr create -a -s '/bin/sleep 60' -c 25 -m 512 -p medium -r 80,443 -f local3 -o info -e err -t jail-web jail2
 # vi /var/jailmgr/jails/jail1/jail.conf
 # vi /var/jailmgr/jails/jail2/jail.conf
 # jailmgr start --all


### PR DESCRIPTION
### Motivation
- Avoid running the in-jail boot sequence by default and provide a harmless placeholder supervise command that keeps the jail alive until a real service is configured. 
- Make documentation examples consistent with the new default and provide a concrete real-world example for an HTTP server jail. 

### Description
- Change default supervise command from `/bin/sh /etc/rc` to `/bin/sleep 60` for both the `create` CLI default and the `create_jail` fallback in `usr.sbin/jailmgr/jailmgr`.
- Update the runtime validation hint when `JAIL_SUPERVISE_CMD` is missing to reference `/bin/sleep 60`.
- Update examples in `usr.sbin/jailmgr/examples/README` and sync the `jailmgr(8)` example to use `/bin/sleep 60`.
- Add a real-world supervise example to the README: `JAIL_SUPERVISE_CMD="/usr/libexec/httpd -I 8080 -X -s -f /srv/www"` for jail `www`.

### Testing
- Ran shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded.
- Verified the presence of updated literals with ripgrep: searches for `/bin/sleep 60` and the `httpd` example completed and matched the expected files.
- No regressions reported by these automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f53bf9a8832abe3e67450a600f82)