### PR TITLE
man: add AUTHORS sections and align jail history notes

### DIFF
--- a/share/man/man9/secmodel_jail.9
+++ b/share/man/man9/secmodel_jail.9
@@ -158,5 +158,10 @@ resource-management actions during incident analysis without excessive noise.
 .Xr secmodel_securelevel 9 ,
 .Xr secmodel_suser 9 ,
 .Xr sysctl 7
+.Sh HISTORY
+The
+.Nm
+security model first appeared as a prototype patch for
+.Nx 10.1 .
 .Sh AUTHORS
-.An The NetBSD Foundation, Inc.
+.An Matthias Petermann Aq Mt mp@petermann-digital.de

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -183,4 +183,7 @@ List active jail ids, process counts, configured jail names, and roots.
 .Sh HISTORY
 The
 .Nm
-utility first appeared in NetBSD 10.0.
+utility first appeared as a prototype patch for
+.Nx 10.1 .
+.Sh AUTHORS
+.An Matthias Petermann Aq Mt mp@petermann-digital.de

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -373,10 +373,12 @@ Prepare and start all configured jails:
 .Sh HISTORY
 The
 .Nm
-script appeared in
-.Nx 10.0 .
+script first appeared as a prototype patch for
+.Nx 10.1 .
 This manual page was expanded when
 .Nm
 was moved to its own
 .Pa usr.sbin/jailmgr
 subdirectory.
+.Sh AUTHORS
+.An Matthias Petermann Aq Mt mp@petermann-digital.de


### PR DESCRIPTION
### Motivation
- Provide consistent author attribution and history notes for the jail-related manpages and ensure the manual pages include an `AUTHORS` section naming the author of the prototype work.

### Description
- Updated `share/man/man9/secmodel_jail.9` to add a `HISTORY` stanza stating the model "first appeared as a prototype patch for NetBSD 10.1" and added an `AUTHORS` entry for `Matthias Petermann <mp@petermann-digital.de>`.
- Updated `usr.sbin/jailctl/jailctl.8` to normalize the `HISTORY` wording to the same NetBSD 10.1 prototype text and added an `AUTHORS` entry for `Matthias Petermann <mp@petermann-digital.de>`.
- Updated `usr.sbin/jailmgr/jailmgr.8` to normalize the `HISTORY` wording to the same NetBSD 10.1 prototype text and added an `AUTHORS` entry for `Matthias Petermann <mp@petermann-digital.de>`.

### Testing
- Attempted to run `mandoc -Tlint` on the updated manpages, but `mandoc` is not available in this environment so linting could not be performed (failed); no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979801e30c832a90a3a834ba23f737)