### PR TITLE
jailmgr: `jailctl exec` statt `jexec` im Apply-Pfad verwenden

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -635,7 +635,7 @@ jail_jid_by_name() {
 }
 
 require_apply_tools() {
-	for t in jexec mktemp cp; do
+	for t in jailctl mktemp cp; do
 		command -v "${t}" >/dev/null 2>&1 || {
 			echo "missing required tool: ${t}" >&2
 			exit 1
@@ -746,7 +746,7 @@ apply_jail_script() {
 	fi
 	chmod 700 "${host_script}"
 
-	set -- jexec "${jail_jid}" /bin/sh "${jail_script}" "$@"
+	set -- jailctl exec "${jail_jid}" /bin/sh "${jail_script}" "$@"
 	if "$@"; then
 		apply_rc=0
 	else


### PR DESCRIPTION
### Motivation
- Behebt die falsche Verwendung von `jexec` im Apply-Workflow und nutzt stattdessen die vorgesehene Schnittstelle `jailctl exec`, damit Skripte zuverlässig im Ziel-Jail ausgeführt werden.

### Description
- In `usr.sbin/jailmgr/jailmgr` wird in `require_apply_tools()` `jailctl` anstelle von `jexec` geprüft, und die Ausführung des Apply-Skripts erfolgt über `jailctl exec "${jail_jid}" /bin/sh "${jail_script}" ...` anstelle von `jexec`.

### Testing
- Syntaxprüfung `sh -n usr.sbin/jailmgr/jailmgr` wurde ausgeführt und lieferte keine Fehler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69996d5ce1dc832a95ffc922f6b8a124)