### PR TITLE
jailmgr.8: update example web root to /var/www/mysite

### DIFF
--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -395,10 +395,10 @@ Operational notes and quick-start guidance.
 Bring a host to operational readiness and deploy one web jail:
 .Bd -literal -offset indent
 # jailmgr bootstrap
-# jailmgr create -a -s '/usr/libexec/httpd -I 8080 -X -f -s /srv/www' -c 25 -m 512 -p medium -r 8080 -f local3 -o info -e err -t jail-web web
+# jailmgr create -a -s '/usr/libexec/httpd -I 8080 -X -f -s /var/www/mysite' -c 25 -m 512 -p medium -r 8080 -f local3 -o info -e err -t jail-web web
 # jailmgr apply --ephemeral web <<'APPLY'
-mkdir -p /srv/www
-echo "<html>Hello NetBSD!</html>" > /srv/www/index.html
+mkdir -p /var/www/mysite
+echo "<html>Hello NetBSD!</html>" > /var/www/mysite/index.html
 APPLY
 # jailmgr config web
 # jailmgr start --all


### PR DESCRIPTION
### Motivation
- Update the `jailmgr(8)` EXAMPLES to use the preferred document root `/var/www/mysite` instead of `/srv/www` so the sample matches the intended site layout.

### Description
- Change occurrences of `/srv/www` to `/var/www/mysite` in `usr.sbin/jailmgr/jailmgr.8`, including the `jailmgr create` supervise command and the example `mkdir`/`echo` lines.

### Testing
- Ran `rg -n "/var/www/mysite|/srv/www" usr.sbin/jailmgr/jailmgr.8` which shows only `/var/www/mysite` occurrences and no `/srv/www`, confirming the replacement succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999711840d4832aa389fef1106d97ef)