### PR TITLE
jailmgr: don't launch supervisor when apply starts a jail

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -517,15 +517,17 @@ jail_exists() {
 }
 
 # Start sequence: load config, mount root overlays, allocate kernel jail ID
-# through jailctl create, then launch supervised workload with jailctl supervise.
-start_jail() {
+# through jailctl create, then optionally launch supervised workload with
+# jailctl supervise.
+start_jail_internal() {
 	need_root
 	require_tools
 	name=$1
+	supervise=${2:-YES}
 
 	load_jail_conf "${name}"
 	effective_supervise_cmd=${JAIL_SUPERVISE_CMD:-}
-	if [ -z "${effective_supervise_cmd}" ]; then
+	if [ "${supervise}" = "YES" ] && [ -z "${effective_supervise_cmd}" ]; then
 		echo "JAIL_SUPERVISE_CMD must be set in ${JAIL_CONF} (example: /bin/sleep 60)" >&2
 		exit 1
 	fi
@@ -557,26 +559,32 @@ start_jail() {
 	# output concise and only show the high-level status line below.
 	"$@" >/dev/null
 
-	set -- jailctl supervise
-	if [ -n "${JAIL_SUPERVISE_FACILITY:-}" ]; then
-		set -- "$@" -f "${JAIL_SUPERVISE_FACILITY}"
+	if [ "${supervise}" = "YES" ]; then
+		set -- jailctl supervise
+		if [ -n "${JAIL_SUPERVISE_FACILITY:-}" ]; then
+			set -- "$@" -f "${JAIL_SUPERVISE_FACILITY}"
+		fi
+		if [ -n "${JAIL_SUPERVISE_STDOUT_LEVEL:-}" ]; then
+			set -- "$@" -o "${JAIL_SUPERVISE_STDOUT_LEVEL}"
+		fi
+		if [ -n "${JAIL_SUPERVISE_STDERR_LEVEL:-}" ]; then
+			set -- "$@" -e "${JAIL_SUPERVISE_STDERR_LEVEL}"
+		fi
+		if [ -n "${JAIL_SUPERVISE_TAG:-}" ]; then
+			set -- "$@" -t "${JAIL_SUPERVISE_TAG}"
+		fi
+		set -- "$@" "${name}"
+		# shellcheck disable=SC2086
+		set -f
+		set -- "$@" ${effective_supervise_cmd}
+		set +f
+		"$@" >/dev/null
 	fi
-	if [ -n "${JAIL_SUPERVISE_STDOUT_LEVEL:-}" ]; then
-		set -- "$@" -o "${JAIL_SUPERVISE_STDOUT_LEVEL}"
-	fi
-	if [ -n "${JAIL_SUPERVISE_STDERR_LEVEL:-}" ]; then
-		set -- "$@" -e "${JAIL_SUPERVISE_STDERR_LEVEL}"
-	fi
-	if [ -n "${JAIL_SUPERVISE_TAG:-}" ]; then
-		set -- "$@" -t "${JAIL_SUPERVISE_TAG}"
-	fi
-	set -- "$@" "${name}"
-	# shellcheck disable=SC2086
-	set -f
-	set -- "$@" ${effective_supervise_cmd}
-	set +f
-	"$@" >/dev/null
 	echo "Started jail ${name}"
+}
+
+start_jail() {
+	start_jail_internal "$1" "YES"
 }
 
 # Stop sequence mirrors startup in reverse: stop supervisor, destroy kernel
@@ -704,7 +712,7 @@ apply_jail_script() {
 
 	started_by_apply=NO
 	if ! jail_exists "${name}"; then
-		start_jail "${name}"
+		start_jail_internal "${name}" "NO"
 		started_by_apply=YES
 	fi
 

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -222,6 +222,12 @@ using
 and
 .Pa /bin/sh .
 If the jail is not running, it is started first.
+When started by
+.Cm apply ,
+only the jail runtime is created;
+the configured
+.Cm jailctl supervise
+process is not launched.
 The script can be provided as a filesystem path, as
 .Cm -
 to read from standard input, or omitted when standard input is not a terminal


### PR DESCRIPTION
### Motivation
- `apply` should be able to start a jail runtime to run a one-off script without side-effecting the host by launching the configured `jailctl supervise` process.
- Avoid launching the supervise process when `apply` brings a jail up temporarily (e.g. for ephemeral script execution).

### Description
- Refactored the startup logic into `start_jail_internal(name, supervise)` and added a `supervise` flag to control whether `jailctl supervise` is launched. 
- Kept `jailmgr start` behavior unchanged by implementing `start_jail()` to call `start_jail_internal <name> YES`.
- Changed `apply` to start non-running jails with `start_jail_internal <name> NO`, so the supervisor is not started just for `apply` runs.
- Updated `jailmgr(8)` to document that `apply` only creates runtime state and does not launch the configured `jailctl supervise` process.

### Testing
- Verified shell syntax with `sh -n usr.sbin/jailmgr/jailmgr`, which completed without errors. 
- Attempted manual manpage lint with `mandoc -Tlint -Wwarning usr.sbin/jailmgr/jailmgr.8`, but `mandoc` was not available in the environment so lint could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699986d4ea68832ab9079f210acba9e4)