### PR TITLE
jailmgr: require set-provided MAKEDEV for local /dev

### DIFF
--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -52,6 +52,10 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
 
    Then set at least `JAIL_SUPERVISE_CMD` and `JAIL_AUTOSTART` in each
    jail-local `jail.conf`.
+   During creation, `jailmgr` unpacks `./etc`, `./root`, `./var`, and
+   `./dev` from `etc.tar.xz` into the jail's writable `data/` tree.
+   For local `/dev` setup it uses `data/dev/MAKEDEV*` from that set.
+
 
    Real-world example for jail `www`:
 

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -335,6 +335,7 @@ jail_paths() {
 	DATA_HOME_DIR="${DATA_DIR}/home"
 	DATA_ROOT_DIR="${DATA_DIR}/root"
 	DATA_PKG_DIR="${DATA_DIR}/usr/pkg"
+	DATA_DEV_DIR="${DATA_DIR}/dev"
 	DEV_DIR="${JAIL_DIR}/dev"
 	JAIL_CONF="${JAIL_DIR}/jail.conf"
 }
@@ -388,14 +389,18 @@ setup_local_dev() {
 		mount_tmpfs -s "${JAIL_DEV_SIZE}" tmpfs "${ROOT_DIR}/dev"
 	fi
 
-	if [ -f "${ROOT_DIR}/dev/MAKEDEV" ]; then
-		:
-	elif [ -f /dev/MAKEDEV ]; then
-		cp /dev/MAKEDEV "${ROOT_DIR}/dev/MAKEDEV"
+	if [ ! -f "${ROOT_DIR}/dev/MAKEDEV" ]; then
+		if [ ! -f "${DATA_DEV_DIR}/MAKEDEV" ]; then
+			echo "warning: ${DATA_DEV_DIR}/MAKEDEV not found; skipping /dev node creation" >&2
+			return
+		fi
+
+		cp "${DATA_DEV_DIR}/MAKEDEV" "${ROOT_DIR}/dev/MAKEDEV"
 		chmod 555 "${ROOT_DIR}/dev/MAKEDEV"
-	else
-		echo "warning: MAKEDEV not found; skipping /dev node creation" >&2
-		return
+		if [ -f "${DATA_DEV_DIR}/MAKEDEV.local" ]; then
+			cp "${DATA_DEV_DIR}/MAKEDEV.local" "${ROOT_DIR}/dev/MAKEDEV.local"
+			chmod 444 "${ROOT_DIR}/dev/MAKEDEV.local"
+		fi
 	fi
 
 	# shellcheck disable=SC2086
@@ -416,9 +421,7 @@ setup_etc() {
 	}
 
 	if [ ! -f "${DATA_ETC_DIR}/rc.conf" ]; then
-		tar -xzp -f "${ETC_SET}" -C "${JAIL_DIR}"
-		rm -rf "${DATA_ETC_DIR}"
-		mv "${JAIL_DIR}/etc" "${DATA_ETC_DIR}"
+		tar -xzp -f "${ETC_SET}" -C "${DATA_DIR}" ./etc ./root ./var ./dev
 	fi
 
 

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -96,9 +96,21 @@ and
 .Pa dev .
 If necessary,
 .Pa etc.tar.xz
-is extracted into
-.Pa data/etc
-for that jail.
+is extracted for that jail, but only the
+.Pa ./etc ,
+.Pa ./root ,
+.Pa ./var
+and
+.Pa ./dev
+entries are unpacked into
+.Pa data/ .
+For local jail
+.Pa /dev
+setup,
+.Pa data/dev/MAKEDEV
+and
+.Pa data/dev/MAKEDEV.local
+are used.
 If host
 .Pa /etc/resolv.conf
 exists,


### PR DESCRIPTION
### Motivation

- Ensure jail-local `/dev` population is derived only from the distribution-provided set files and not from host `/dev` files, so per-jail device setup is reproducible and contained.

### Description

- `setup_local_dev()` was changed to require and copy `data/dev/MAKEDEV` (and optionally `data/dev/MAKEDEV.local`) from the extracted `etc.tar.xz` and to skip `/dev` node creation with a warning if that file is absent, removing any fallback to host `/dev/MAKEDEV*`.
- Added `DATA_DEV_DIR` to `jail_paths()` so the extracted `data/dev` location is referenced via `DATA_DEV_DIR`.
- `setup_etc()` extraction was updated to unpack `./etc`, `./root`, `./var`, and `./dev` into the jail `data/` tree with `tar -xzp -f "${ETC_SET}" -C "${DATA_DIR}" ./etc ./root ./var ./dev`.
- Documentation updates: `usr.sbin/jailmgr/jailmgr.8` and `usr.sbin/jailmgr/examples/README` were edited to state that `data/dev/MAKEDEV*` from the set is used for local `/dev` setup.

### Testing

- Performed a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699988e4df90832a903eb929d51bd462)