### PR TITLE
jailmgr: symlink /.cshrc and /.profile into writable .data in base layer

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -299,12 +299,15 @@ ensure_base_writable_links() {
 
 	mkdir -p "${BASE_LAYER}/.data" "${BASE_LAYER}/usr"
 	rm -rf "${BASE_LAYER}/etc" "${BASE_LAYER}/var" "${BASE_LAYER}/tmp" \
-		"${BASE_LAYER}/home" "${BASE_LAYER}/root" "${BASE_LAYER}/usr/pkg"
+		"${BASE_LAYER}/home" "${BASE_LAYER}/root" "${BASE_LAYER}/usr/pkg" \
+		"${BASE_LAYER}/.cshrc" "${BASE_LAYER}/.profile"
 	ln -s ".data/etc" "${BASE_LAYER}/etc"
 	ln -s ".data/var" "${BASE_LAYER}/var"
 	ln -s ".data/tmp" "${BASE_LAYER}/tmp"
 	ln -s ".data/home" "${BASE_LAYER}/home"
 	ln -s ".data/root" "${BASE_LAYER}/root"
+	ln -s ".data/.cshrc" "${BASE_LAYER}/.cshrc"
+	ln -s ".data/.profile" "${BASE_LAYER}/.profile"
 	ln -s "../.data/usr/pkg" "${BASE_LAYER}/usr/pkg"
 }
 


### PR DESCRIPTION
### Motivation
- Make the shared read-only base layer prepared for extraction of `etc.tar.xz` which stores root dotfiles as hardlinks to `./.cshrc` and `./.profile` by ensuring those dotfiles are provided as symlinks into the per-jail writable `.data` tree.

### Description
- Update `ensure_base_writable_links()` in `usr.sbin/jailmgr/jailmgr` to remove top-level `/.cshrc` and `/.profile` from the base and create `ln -s ".data/.cshrc" "${BASE_LAYER}/.cshrc"` and `ln -s ".data/.profile" "${BASE_LAYER}/.profile"` alongside the existing writable-path symlinks.

### Testing
- Ran `sh -n usr.sbin/jailmgr/jailmgr` to validate shell syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ac1c50b0832a802ca6f938fc5f4b)