### PR TITLE
jailmgr: extract MAKEDEV directly from etc set

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -393,15 +393,15 @@ setup_local_dev() {
 	fi
 
 	if [ ! -f "${ROOT_DIR}/dev/MAKEDEV" ]; then
-		if [ ! -f "${DATA_DEV_DIR}/MAKEDEV" ]; then
-			echo "warning: ${DATA_DEV_DIR}/MAKEDEV not found; skipping /dev node creation" >&2
+		[ -f "${ETC_SET}" ] || {
+			echo "warning: ${ETC_SET} not found; skipping /dev node creation" >&2
 			return
-		fi
+		}
 
-		cp "${DATA_DEV_DIR}/MAKEDEV" "${ROOT_DIR}/dev/MAKEDEV"
+		tar -xzp -f "${ETC_SET}" -C "${ROOT_DIR}" ./dev/MAKEDEV
 		chmod 555 "${ROOT_DIR}/dev/MAKEDEV"
-		if [ -f "${DATA_DEV_DIR}/MAKEDEV.local" ]; then
-			cp "${DATA_DEV_DIR}/MAKEDEV.local" "${ROOT_DIR}/dev/MAKEDEV.local"
+		if tar -tzp -f "${ETC_SET}" ./dev/MAKEDEV.local >/dev/null 2>&1; then
+			tar -xzp -f "${ETC_SET}" -C "${ROOT_DIR}" ./dev/MAKEDEV.local
 			chmod 444 "${ROOT_DIR}/dev/MAKEDEV.local"
 		fi
 	fi
@@ -428,7 +428,7 @@ setup_etc() {
 		# Extract those link targets too so tar does not abort with missing
 		# hard-link target errors while unpacking ./root.
 		tar -xzp -f "${ETC_SET}" -C "${DATA_DIR}" \
-			./.cshrc ./.profile ./etc ./root ./var ./dev
+			./.cshrc ./.profile ./etc ./root ./var
 	fi
 
 

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -100,17 +100,19 @@ is extracted for that jail, but only the
 .Pa ./etc ,
 .Pa ./root ,
 .Pa ./var
-and
-.Pa ./dev
 entries are unpacked into
 .Pa data/ .
 For local jail
 .Pa /dev
 setup,
-.Pa data/dev/MAKEDEV
-and
-.Pa data/dev/MAKEDEV.local
-are used.
+.Pa ./dev/MAKEDEV
+and optional
+.Pa ./dev/MAKEDEV.local
+are extracted directly from
+.Pa etc.tar.xz
+into the jail's mounted
+.Pa /dev
+tmpfs.
 If host
 .Pa /etc/resolv.conf
 exists,


### PR DESCRIPTION
### Motivation

- Avoid staging `MAKEDEV`/`MAKEDEV.local` through a previously extracted `data/dev` tree and instead place them directly into the final jail `/dev` mount to simplify flow and reduce intermediate copies.
- Ensure the files used to populate a jail-local `/dev` come straight from the `etc.tar.xz` set so the resulting `/dev` tmpfs contains the canonical scripts from the release archive.

### Description

- Change `setup_local_dev()` in `usr.sbin/jailmgr/jailmgr` to extract `./dev/MAKEDEV` from `${ETC_SET}` directly into the mounted `${ROOT_DIR}/dev` and to extract `./dev/MAKEDEV.local` only when present in the set archive, instead of copying from `${DATA_DEV_DIR}`.
- Add a presence check on `${ETC_SET}` and print a warning and skip `/dev` node creation when the etc set is unavailable.
- Simplify `setup_etc()` to stop extracting `./dev` into `${DATA_DIR}` since `/dev` helper files are now extracted directly into the jail `/dev` during `setup_local_dev()`.
- Update the manpage `usr.sbin/jailmgr/jailmgr.8` to document that `./dev/MAKEDEV` (and optional `./dev/MAKEDEV.local`) are extracted directly from `etc.tar.xz` into the jail's mounted `/dev` tmpfs.

### Testing

- Ran a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which completed successfully.
- No additional automated tests were added; the change is limited to extraction/copy behavior and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999aee6a27c832a98204ac3ed76dbc6)