### PR TITLE
jailmgr: drop remaining unused DEV_DIR path setup

### DIFF
--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -338,8 +338,6 @@ jail_paths() {
 	DATA_HOME_DIR="${DATA_DIR}/home"
 	DATA_ROOT_DIR="${DATA_DIR}/root"
 	DATA_PKG_DIR="${DATA_DIR}/usr/pkg"
-	DATA_DEV_DIR="${DATA_DIR}/dev"
-	DEV_DIR="${JAIL_DIR}/dev"
 	JAIL_CONF="${JAIL_DIR}/jail.conf"
 }
 
@@ -491,7 +489,7 @@ create_jail() {
 
 	jail_paths "${name}"
 	mkdir -p "${ROOT_DIR}" "${DATA_VAR_DIR}" "${DATA_TMP_DIR}" "${DATA_HOME_DIR}" \
-		"${DATA_ROOT_DIR}" "${DATA_PKG_DIR}" "${DEV_DIR}" "${DATA_VAR_DIR}/run" "${DATA_VAR_DIR}/log"
+		"${DATA_ROOT_DIR}" "${DATA_PKG_DIR}" "${DATA_VAR_DIR}/run" "${DATA_VAR_DIR}/log"
 	chmod 1777 "${DATA_TMP_DIR}"
 	setup_etc
 
@@ -511,8 +509,7 @@ JAIL_SUPERVISE_FACILITY="${escaped_supervise_facility}"
 JAIL_SUPERVISE_STDOUT_LEVEL="${escaped_supervise_stdout_level}"
 JAIL_SUPERVISE_STDERR_LEVEL="${escaped_supervise_stderr_level}"
 JAIL_SUPERVISE_TAG="${escaped_supervise_tag}"
-# Required command (with optional args) to supervise in this jail.
-# Example placeholder that keeps the jail alive until a real service command is configured:
+# Required command (with optional args) to supervise in this jail:
 JAIL_SUPERVISE_CMD="${escaped_supervise_cmd}"
 CONF
 


### PR DESCRIPTION
### Motivation

- Remove dead path state so `jailmgr` does not advertise or create a per-jail `${JAIL_DIR}/dev` that is never used. 
- Keep the generated `jail.conf` supervise comment as the single-line phrasing already applied earlier.

### Description

- Remove the `DEV_DIR` assignment from `jail_paths()` in `usr.sbin/jailmgr/jailmgr` so `${JAIL_DIR}/dev` is no longer tracked.
- Stop creating `${DEV_DIR}` in `create_jail()` and only create the actual required directories (`${ROOT_DIR}`, `${DATA_VAR_DIR}`, `${DATA_TMP_DIR}`, `${DATA_HOME_DIR}`, `${DATA_ROOT_DIR}`, `${DATA_PKG_DIR}`, `${DATA_VAR_DIR}/run`, `${DATA_VAR_DIR}/log`).
- Keep the one-line `# Required command (with optional args) to supervise in this jail:` comment and `JAIL_SUPERVISE_CMD` entry in the generated `jail.conf`.

### Testing

- Ran `bash -n usr.sbin/jailmgr/jailmgr` to verify the script has no syntax errors, which succeeded.
- Searched the modified file with `rg -n "DEV_DIR|DATA_DEV_DIR" usr.sbin/jailmgr/jailmgr` to confirm the removed symbols no longer appear, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999b2ac3180832a9aed98527500fd61)