### PR TITLE
secmodel_jail: block unload while jails exist

### DIFF
--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -82,6 +82,7 @@ static int	secmodel_jail_network_cb(kauth_cred_t, kauth_action_t, void *,
 static bool	secmodel_jail_port_reserved_by_id(jailid_t, in_port_t);
 static bool	secmodel_jail_port_reserved_any(in_port_t);
 static bool	secmodel_jail_addr_port(const struct sockaddr *, in_port_t *);
+static bool	secmodel_jail_has_entries(void);
 
 /*
  * Each jail is tracked by an entry in a global list. The entry only stores the
@@ -379,6 +380,21 @@ secmodel_jail_addr_port(const struct sockaddr *sa, in_port_t *port)
 	default:
 		return false;
 	}
+}
+
+/*
+ * Check whether any jail ids still exist.
+ */
+static bool
+secmodel_jail_has_entries(void)
+{
+	bool has_entries;
+
+	mutex_enter(&jail_lock);
+	has_entries = LIST_FIRST(&jail_list) != NULL;
+	mutex_exit(&jail_lock);
+
+	return has_entries;
 }
 
 /*
@@ -1177,6 +1193,9 @@ secmodel_jail_modcmd(modcmd_t cmd, void *arg)
 		break;
 
 	case MODULE_CMD_FINI:
+		if (secmodel_jail_has_entries())
+			return EBUSY;
+
 		log(LOG_INFO, "secmodel_jail: unloading\n");
 		secmodel_jail_stop();
 


### PR DESCRIPTION
### Motivation

- Ensure the secmodel_jail module cannot be unloaded while there are still active jail IDs, preventing leftover process/jail state from remaining after an unload.

### Description

- Add helper `secmodel_jail_has_entries()` that checks under `jail_lock` whether `LIST_FIRST(&jail_list) != NULL` to detect any existing jail entries.
- Declare the new helper and use it in the module command handler to return `EBUSY` from `MODULE_CMD_FINI` when any jail entries exist, preventing unload until all jails are destroyed.
- Keep existing teardown (`secmodel_jail_stop()`) and deregistration behavior unchanged when no jails remain.

### Testing

- Ran `git diff --check` to validate whitespace and patch sanity, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa2a82060832a85bb1d9d0c62f503)