### PR TITLE
Remove legacy JAIL_CREATE_MEMORY_BYTES handling in jailmgr

### DIFF
--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -81,6 +81,11 @@ In the current implementation these limits are applied as per-process
 .Bl -tag -width Ds
 .It Fl c Ar cpu-ms
 Set a CPU time limit (in milliseconds) for processes in the jail.
+The configured value is translated to
+.Dv RLIMIT_CPU
+when a process enters the jail, rounded up to whole seconds, and then enforced
+as per-process consumed CPU time (not wall clock time).
+It is therefore a lifetime budget per process.
 .It Fl m Ar bytes
 Set a virtual memory limit (in bytes) for processes in the jail.
 .It Fl p Ar profile

--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -11,7 +11,7 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
 - `create -a <name>` does the same and initializes `JAIL_AUTOSTART=YES`.
 - `create -s '<cmd ...>' <name>` initializes `JAIL_SUPERVISE_CMD` in `jail.conf`.
 - `create -c <cpu-percent>` sets CPU limits for `jailctl create` (0-100; internally 1% = 10ms/s).
-- `create -m <memory-mb>` sets memory limits for `jailctl create` (internally converted to bytes).
+- `create -m <memory-mb>` stores the memory limit in `jail.conf` (MB) and converts it to bytes only when starting the jail (`jailctl create -m`).
 - CPU and memory limits are enforced through per-process `RLIMIT` values when entering the jail.
 - `create -r <port[,port...]>` reserves one or more listening ports for the jail (`jailctl create -r`).
 - `create -f <facility> -o <stdout-level> -e <stderr-level> -t <tag>` initializes logging options for `jailctl supervise`.

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -352,7 +352,7 @@ load_jail_conf() {
 	JAIL_NAME=
 	JAIL_SUPERVISE_CMD=
 	JAIL_CREATE_CPU_MS=
-	JAIL_CREATE_MEMORY_BYTES=
+	JAIL_CREATE_MEMORY_MB=
 	JAIL_CREATE_PROFILE=
 	JAIL_CREATE_RESERVED_PORTS=
 	JAIL_SUPERVISE_FACILITY=
@@ -472,7 +472,7 @@ create_jail() {
 	autostart=${2:-NO}
 	supervise_cmd=${3:-/bin/sleep 60}
 	create_cpu_ms=${4:-}
-	create_memory_bytes=${5:-}
+	create_memory_mb=${5:-}
 	create_profile=${6:-}
 	create_reserved_ports=${7:-}
 	supervise_facility=${8:-}
@@ -501,7 +501,7 @@ JAIL_ARCH=${MACHINE_ARCH}
 JAIL_AUTOSTART=${autostart}
 # Optional jailctl create(8) resource controls:
 JAIL_CREATE_CPU_MS="${create_cpu_ms}"
-JAIL_CREATE_MEMORY_BYTES="${create_memory_bytes}"
+JAIL_CREATE_MEMORY_MB="${create_memory_mb}"
 JAIL_CREATE_PROFILE="${escaped_create_profile}"
 JAIL_CREATE_RESERVED_PORTS="${escaped_create_reserved_ports}"
 # Optional jailctl supervise(8) logging controls:
@@ -558,8 +558,8 @@ start_jail_internal() {
 		if [ -n "${JAIL_CREATE_CPU_MS:-}" ]; then
 			set -- "$@" -c "${JAIL_CREATE_CPU_MS}"
 		fi
-		if [ -n "${JAIL_CREATE_MEMORY_BYTES:-}" ]; then
-			set -- "$@" -m "${JAIL_CREATE_MEMORY_BYTES}"
+		if [ -n "${JAIL_CREATE_MEMORY_MB:-}" ]; then
+			set -- "$@" -m "$(memory_mb_to_bytes "${JAIL_CREATE_MEMORY_MB}")"
 		fi
 		if [ -n "${JAIL_CREATE_PROFILE:-}" ]; then
 			set -- "$@" -p "${JAIL_CREATE_PROFILE}"
@@ -840,7 +840,7 @@ case "${cmd}" in
 		autostart=NO
 		supervise_cmd="/bin/sleep 60"
 		create_cpu_ms=
-		create_memory_bytes=
+		create_memory_mb=
 		create_profile=
 		create_reserved_ports=
 		supervise_facility=
@@ -870,11 +870,12 @@ case "${cmd}" in
 				;;
 			-m)
 				[ $# -ge 2 ] || { usage; exit 1; }
-				[ -z "${create_memory_bytes}" ] || {
+				[ -z "${create_memory_mb}" ] || {
 					echo "memory limit (-m) may be provided only once" >&2
 					exit 1
 				}
-				create_memory_bytes=$(memory_mb_to_bytes "$2")
+				memory_mb_to_bytes "$2" >/dev/null
+				create_memory_mb=$2
 				shift 2
 				;;
 			-p)
@@ -922,7 +923,7 @@ case "${cmd}" in
 		fi
 		name=$1
 		create_jail "${name}" "${autostart}" "${supervise_cmd}" \
-		    "${create_cpu_ms}" "${create_memory_bytes}" \
+		    "${create_cpu_ms}" "${create_memory_mb}" \
 		    "${create_profile}" "${create_reserved_ports}" \
 		    "${supervise_facility}" "${supervise_stdout_level}" \
 		    "${supervise_stderr_level}" "${supervise_tag}"

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -144,16 +144,26 @@ the generated
 stores the corresponding create-time CPU limit used by
 .Xr jailctl 8
 .Pq internally converted to milliseconds per second; 1% = 10ms/s .
+The resulting create-time value is translated by
+.Xr secmodel_jail 9
+to
+.Dv RLIMIT_CPU
+when a process enters the jail,
+rounded up to whole seconds and enforced as per-process consumed CPU time
+(lifetime budget, not wall clock time).
 When
 .Fl m
 .Pq megabytes
 is provided,
 the generated
 .Pa jail.conf
-stores the corresponding create-time
+stores the corresponding create-time memory value in megabytes in
+.Pa jail.conf .
+.Nm
+converts this value to bytes when invoking
 .Xr jailctl 8
-resource limits
-.Pq internally converted to bytes .
+.Cm create Fl m
+at start time .
 When
 .Fl p
 is provided,
@@ -357,8 +367,11 @@ must be configured to emit to stderr if those logs should be captured by
 Optional value forwarded to
 .Xr jailctl 8
 .Cm create Fl c .
-.It Ev JAIL_CREATE_MEMORY_BYTES
-Optional value forwarded to
+.It Ev JAIL_CREATE_MEMORY_MB
+Optional memory limit in megabytes persisted in
+.Pa jail.conf .
+.Nm
+converts this value to bytes before invoking
 .Xr jailctl 8
 .Cm create Fl m .
 .It Ev JAIL_CREATE_PROFILE


### PR DESCRIPTION
### Motivation
- Simplify persisted memory-limit semantics by storing only megabytes in `jail.conf` and removing the legacy bytes-based compatibility path.
- Avoid maintaining dual state (`JAIL_CREATE_MEMORY_MB` vs `JAIL_CREATE_MEMORY_BYTES`) and convert MB to bytes only at jail start time via `memory_mb_to_bytes`.

### Description
- Removed `JAIL_CREATE_MEMORY_BYTES` initialization from `load_jail_conf()` so only `JAIL_CREATE_MEMORY_MB` is populated.
- Modified `create_jail()` to persist `JAIL_CREATE_MEMORY_MB` into `jail.conf` instead of the old bytes variable.
- Updated the `create` command handling to validate the `-m` argument with `memory_mb_to_bytes` and store the original MB value in `create_memory_mb`.
- Simplified `start_jail_internal()` to only accept `JAIL_CREATE_MEMORY_MB` and call `memory_mb_to_bytes` when building the `jailctl create -m` argument, removing the legacy fallback.
- Updated documentation (`jailmgr.8`, `jailctl.8`, and `examples/README`) to describe MB persistence and start-time conversion.

### Testing
- Ran a shell syntax check with `sh -n usr.sbin/jailmgr/jailmgr` which completed successfully.
- Searched for remaining legacy references with `rg -n "JAIL_CREATE_MEMORY_BYTES|backward|legacy" usr.sbin/jailmgr/jailmgr` and found none.
- Verified the modified file diff and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9f34d3c0832a905239aebacdcedc)