### PR TITLE
Implement jail-native resource limits and remove RLIMIT fallback

### DIFF
--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -97,6 +97,8 @@ __KERNEL_RCSID(0, "$NetBSD: kern_descrip.c,v 1.251.10.3 2024/11/17 13:26:13 mart
 #include <sys/sysctl.h>
 #include <sys/ktrace.h>
 
+#include <secmodel/jail/jail.h>
+
 /*
  * A list (head) of open files, counter, and lock protecting them.
  */
@@ -889,6 +891,7 @@ fd_alloc(proc_t *p, int want, int *result)
 	int i, lim, last, error, hi;
 	u_int off;
 	fdtab_t *dt;
+	uint64_t fd_current;
 
 	KASSERT(p == curproc || p == &proc0);
 
@@ -899,6 +902,15 @@ fd_alloc(proc_t *p, int want, int *result)
 	mutex_enter(&fdp->fd_lock);
 	fd_checkmaps(fdp);
 	dt = fdp->fd_dt;
+	fd_current = 0;
+	for (i = 0; i < dt->dt_nfiles; i++) {
+		if (dt->dt_ff[i] != NULL && dt->dt_ff[i]->ff_file != NULL)
+			fd_current++;
+	}
+	if (!secmodel_jail_fd_admit(p->p_cred, fd_current, 1)) {
+		mutex_exit(&fdp->fd_lock);
+		return EMFILE;
+	}
 	KASSERT(dt->dt_ff[0] == (fdfile_t *)fdp->fd_dfdfile[0]);
 	lim = uimin((int)p->p_rlimit[RLIMIT_NOFILE].rlim_cur, maxfiles);
 	last = uimin(dt->dt_nfiles, lim);
@@ -937,6 +949,7 @@ fd_alloc(proc_t *p, int want, int *result)
 		KASSERT(i >= NDFDFILE ||
 		    dt->dt_ff[i] == (fdfile_t *)fdp->fd_dfdfile[i]);
 		fd_checkmaps(fdp);
+		secmodel_jail_fd_set_current(p->p_cred, fd_current + 1);
 		mutex_exit(&fdp->fd_lock);
 		return 0;
 	}

--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -97,6 +97,7 @@ __KERNEL_RCSID(0, "$NetBSD: kern_descrip.c,v 1.251.10.3 2024/11/17 13:26:13 mart
 #include <sys/sysctl.h>
 #include <sys/ktrace.h>
 
+#include <secmodel/secmodel.h>
 #include <secmodel/jail/jail.h>
 
 /*
@@ -907,9 +908,18 @@ fd_alloc(proc_t *p, int want, int *result)
 		if (dt->dt_ff[i] != NULL && dt->dt_ff[i]->ff_file != NULL)
 			fd_current++;
 	}
-	if (!secmodel_jail_fd_admit(p->p_cred, fd_current, 1)) {
-		mutex_exit(&fdp->fd_lock);
-		return EMFILE;
+	{
+		struct secmodel_jail_eval_admit_args aa;
+		bool ok;
+
+		aa.cred = p->p_cred;
+		aa.current = fd_current;
+		aa.delta = 1;
+		if (secmodel_eval(SECMODEL_JAIL_ID, SECMODEL_JAIL_EVAL_FD_ADMIT,
+		    &aa, &ok) == 0 && !ok) {
+			mutex_exit(&fdp->fd_lock);
+			return EMFILE;
+		}
 	}
 	KASSERT(dt->dt_ff[0] == (fdfile_t *)fdp->fd_dfdfile[0]);
 	lim = uimin((int)p->p_rlimit[RLIMIT_NOFILE].rlim_cur, maxfiles);
@@ -949,7 +959,13 @@ fd_alloc(proc_t *p, int want, int *result)
 		KASSERT(i >= NDFDFILE ||
 		    dt->dt_ff[i] == (fdfile_t *)fdp->fd_dfdfile[i]);
 		fd_checkmaps(fdp);
-		secmodel_jail_fd_set_current(p->p_cred, fd_current + 1);
+		{
+			struct secmodel_jail_eval_set_current_args sca;
+			sca.cred = p->p_cred;
+			sca.current = fd_current + 1;
+			(void)secmodel_eval(SECMODEL_JAIL_ID,
+			    SECMODEL_JAIL_EVAL_FD_SET_CURRENT, &sca, NULL);
+		}
 		mutex_exit(&fdp->fd_lock);
 		return 0;
 	}

--- a/sys/kern/uipc_socket2.c
+++ b/sys/kern/uipc_socket2.c
@@ -87,6 +87,7 @@ __KERNEL_RCSID(0, "$NetBSD: uipc_socket2.c,v 1.142 2022/10/26 23:38:09 riastradh
 #include <sys/filedesc.h>
 #include <ddb/db_active.h>
 
+#include <secmodel/secmodel.h>
 #include <secmodel/jail/jail.h>
 #endif
 
@@ -714,20 +715,37 @@ sbreserve(struct sockbuf *sb, u_long cc, struct socket *so)
 	if (cc == 0 || cc > sb_max_adj)
 		return (0);
 	oldcc = sb->sb_hiwat;
-	if (cc > oldcc && so->so_cred != NULL &&
-	    !secmodel_jail_sockbuf_charge(so->so_cred, cc - oldcc))
-		return 0;
+	if (cc > oldcc && so->so_cred != NULL) {
+		struct secmodel_jail_eval_sockbuf_charge_args sba;
+		bool ok;
+
+		sba.cred = so->so_cred;
+		sba.bytes = cc - oldcc;
+		if (secmodel_eval(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_EVAL_SOCKBUF_CHARGE, &sba, &ok) == 0 && !ok)
+			return 0;
+	}
 
 	maxcc = l->l_proc->p_rlimit[RLIMIT_SBSIZE].rlim_cur;
 
 	uidinfo = so->so_uidinfo;
 	if (!chgsbsize(uidinfo, &sb->sb_hiwat, cc, maxcc)) {
-		if (cc > oldcc && so->so_cred != NULL)
-			secmodel_jail_sockbuf_uncharge(so->so_cred, cc - oldcc);
+		if (cc > oldcc && so->so_cred != NULL) {
+			struct secmodel_jail_eval_sockbuf_charge_args sba;
+			sba.cred = so->so_cred;
+			sba.bytes = cc - oldcc;
+			(void)secmodel_eval(SECMODEL_JAIL_ID,
+			    SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE, &sba, NULL);
+		}
 		return 0;
 	}
-	if (oldcc > cc && so->so_cred != NULL)
-		secmodel_jail_sockbuf_uncharge(so->so_cred, oldcc - cc);
+	if (oldcc > cc && so->so_cred != NULL) {
+		struct secmodel_jail_eval_sockbuf_charge_args sba;
+		sba.cred = so->so_cred;
+		sba.bytes = oldcc - cc;
+		(void)secmodel_eval(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE, &sba, NULL);
+	}
 	sb->sb_mbmax = uimin(cc * 2, sb_max);
 	if (sb->sb_lowat > sb->sb_hiwat)
 		sb->sb_lowat = sb->sb_hiwat;
@@ -749,8 +767,13 @@ sbrelease(struct sockbuf *sb, struct socket *so)
 
 	sbflush(sb);
 	(void)chgsbsize(so->so_uidinfo, &sb->sb_hiwat, 0, RLIM_INFINITY);
-	if (oldcc != 0 && so->so_cred != NULL)
-		secmodel_jail_sockbuf_uncharge(so->so_cred, oldcc);
+	if (oldcc != 0 && so->so_cred != NULL) {
+		struct secmodel_jail_eval_sockbuf_charge_args sba;
+		sba.cred = so->so_cred;
+		sba.bytes = oldcc;
+		(void)secmodel_eval(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE, &sba, NULL);
+	}
 	sb->sb_mbmax = 0;
 }
 

--- a/sys/kern/uipc_socket2.c
+++ b/sys/kern/uipc_socket2.c
@@ -86,6 +86,8 @@ __KERNEL_RCSID(0, "$NetBSD: uipc_socket2.c,v 1.142 2022/10/26 23:38:09 riastradh
 #ifdef DDB
 #include <sys/filedesc.h>
 #include <ddb/db_active.h>
+
+#include <secmodel/jail/jail.h>
 #endif
 
 /*
@@ -703,6 +705,7 @@ sbreserve(struct sockbuf *sb, u_long cc, struct socket *so)
 	struct lwp *l = curlwp; /* XXX */
 	rlim_t maxcc;
 	struct uidinfo *uidinfo;
+	u_long oldcc;
 
 	KASSERT(so->so_pcb == NULL || solocked(so));
 	KASSERT(sb->sb_so == so);
@@ -710,12 +713,21 @@ sbreserve(struct sockbuf *sb, u_long cc, struct socket *so)
 
 	if (cc == 0 || cc > sb_max_adj)
 		return (0);
+	oldcc = sb->sb_hiwat;
+	if (cc > oldcc && so->so_cred != NULL &&
+	    !secmodel_jail_sockbuf_charge(so->so_cred, cc - oldcc))
+		return 0;
 
 	maxcc = l->l_proc->p_rlimit[RLIMIT_SBSIZE].rlim_cur;
 
 	uidinfo = so->so_uidinfo;
-	if (!chgsbsize(uidinfo, &sb->sb_hiwat, cc, maxcc))
+	if (!chgsbsize(uidinfo, &sb->sb_hiwat, cc, maxcc)) {
+		if (cc > oldcc && so->so_cred != NULL)
+			secmodel_jail_sockbuf_uncharge(so->so_cred, cc - oldcc);
 		return 0;
+	}
+	if (oldcc > cc && so->so_cred != NULL)
+		secmodel_jail_sockbuf_uncharge(so->so_cred, oldcc - cc);
 	sb->sb_mbmax = uimin(cc * 2, sb_max);
 	if (sb->sb_lowat > sb->sb_hiwat)
 		sb->sb_lowat = sb->sb_hiwat;
@@ -730,11 +742,15 @@ sbreserve(struct sockbuf *sb, u_long cc, struct socket *so)
 void
 sbrelease(struct sockbuf *sb, struct socket *so)
 {
+	u_long oldcc;
 
 	KASSERT(sb->sb_so == so);
+	oldcc = sb->sb_hiwat;
 
 	sbflush(sb);
 	(void)chgsbsize(so->so_uidinfo, &sb->sb_hiwat, 0, RLIM_INFINITY);
+	if (oldcc != 0 && so->so_cred != NULL)
+		secmodel_jail_sockbuf_uncharge(so->so_cred, oldcc);
 	sb->sb_mbmax = 0;
 }
 

--- a/sys/secmodel/jail/jail.h
+++ b/sys/secmodel/jail/jail.h
@@ -55,20 +55,33 @@ int secmodel_jail_cred_cb(kauth_cred_t, kauth_action_t, void *,
 
 bool secmodel_jail_cred_matches(kauth_cred_t, const char *);
 
-bool secmodel_jail_memory_admit(kauth_cred_t, uint64_t, uint64_t);
-void secmodel_jail_memory_set_current(kauth_cred_t, uint64_t);
-
-bool secmodel_jail_fd_admit(kauth_cred_t, uint64_t, uint64_t);
-void secmodel_jail_fd_set_current(kauth_cred_t, uint64_t);
-
-bool secmodel_jail_sockbuf_charge(kauth_cred_t, uint64_t);
-void secmodel_jail_sockbuf_uncharge(kauth_cred_t, uint64_t);
-
 #define SECMODEL_JAIL_EVAL_CRED_MATCHES "cred-matches"
+#define SECMODEL_JAIL_EVAL_MEMORY_ADMIT "memory-admit"
+#define SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT "memory-set-current"
+#define SECMODEL_JAIL_EVAL_FD_ADMIT "fd-admit"
+#define SECMODEL_JAIL_EVAL_FD_SET_CURRENT "fd-set-current"
+#define SECMODEL_JAIL_EVAL_SOCKBUF_CHARGE "sockbuf-charge"
+#define SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE "sockbuf-uncharge"
 
 struct secmodel_jail_eval_cred_matches_args {
 	kauth_cred_t cred;
 	const char *name;
+};
+
+struct secmodel_jail_eval_admit_args {
+	kauth_cred_t cred;
+	uint64_t current;
+	uint64_t delta;
+};
+
+struct secmodel_jail_eval_set_current_args {
+	kauth_cred_t cred;
+	uint64_t current;
+};
+
+struct secmodel_jail_eval_sockbuf_charge_args {
+	kauth_cred_t cred;
+	uint64_t bytes;
 };
 
 #endif /* !_SECMODEL_JAIL_JAIL_H_ */

--- a/sys/secmodel/jail/jail.h
+++ b/sys/secmodel/jail/jail.h
@@ -32,6 +32,8 @@
 #ifndef _SECMODEL_JAIL_JAIL_H_
 #define _SECMODEL_JAIL_JAIL_H_
 
+#include <sys/types.h>
+
 #include <secmodel/secmodel.h>
 
 /*
@@ -52,6 +54,15 @@ int secmodel_jail_cred_cb(kauth_cred_t, kauth_action_t, void *,
     void *, void *, void *, void *);
 
 bool secmodel_jail_cred_matches(kauth_cred_t, const char *);
+
+bool secmodel_jail_memory_admit(kauth_cred_t, uint64_t, uint64_t);
+void secmodel_jail_memory_set_current(kauth_cred_t, uint64_t);
+
+bool secmodel_jail_fd_admit(kauth_cred_t, uint64_t, uint64_t);
+void secmodel_jail_fd_set_current(kauth_cred_t, uint64_t);
+
+bool secmodel_jail_sockbuf_charge(kauth_cred_t, uint64_t);
+void secmodel_jail_sockbuf_uncharge(kauth_cred_t, uint64_t);
 
 #define SECMODEL_JAIL_EVAL_CRED_MATCHES "cred-matches"
 

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -42,12 +42,10 @@ __KERNEL_RCSID(0, "$NetBSD$");
 #include <sys/kmem.h>
 #include <sys/proc.h>
 #include <sys/queue.h>
-#include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/systm.h>
 #include <sys/syslog.h>
 #include <sys/jail.h>
-#include <sys/time.h>
 
 #include <netinet/in.h>
 
@@ -72,9 +70,6 @@ enum jail_policy_profile {
 	JAIL_PROFILE_POLICY_HIGH = JAIL_PROFILE_HIGH,
 };
 
-#define	JAIL_CPU_MS_PER_SEC	1000ULL
-
-static rlim_t	secmodel_jail_cpu_ms_to_rlimit(uint64_t);
 static int	secmodel_jail_system_cb(kauth_cred_t, kauth_action_t, void *,
 		    void *, void *, void *, void *);
 static int	secmodel_jail_network_cb(kauth_cred_t, kauth_action_t, void *,
@@ -93,11 +88,24 @@ struct jail_entry {
 	jailid_t je_id;
 	char je_name[JAIL_NAME_MAX + 1];
 	char je_root[JAIL_ROOT_MAX + 1];
-	bool je_has_cpu_limit;
-	bool je_has_mem_limit;
-	rlim_t je_cpu_limit;
-	rlim_t je_mem_limit;
+	uint64_t je_cpu_quota;
+	uint64_t je_cpu_period;
+	uint64_t je_cpu_weight;
+	uint64_t je_memory_max;
+	uint64_t je_proc_max;
+	uint64_t je_fd_max;
+	uint64_t je_sockbuf_max;
 	enum jail_policy_profile je_profile;
+	uint64_t je_proc_current;
+	uint64_t je_fd_current;
+	uint64_t je_sockbuf_current;
+	uint64_t je_memory_current;
+	uint64_t je_cpu_usage;
+	uint64_t je_deny_proc;
+	uint64_t je_deny_fd;
+	uint64_t je_deny_sockbuf;
+	uint64_t je_deny_memory;
+	uint64_t je_throttle_cpu;
 	uint16_t je_nports;
 	uint16_t je_ports[JAIL_PORTS_MAX];
 	LIST_ENTRY(jail_entry) je_entry;
@@ -111,10 +119,13 @@ static jailid_t jail_next_id = 1;
 static struct jail_entry *secmodel_jail_lookup(jailid_t);
 
 struct jail_config {
-	bool jc_has_cpu_limit;
-	bool jc_has_mem_limit;
-	rlim_t jc_cpu_limit;
-	rlim_t jc_mem_limit;
+	uint64_t jc_cpu_quota;
+	uint64_t jc_cpu_period;
+	uint64_t jc_cpu_weight;
+	uint64_t jc_memory_max;
+	uint64_t jc_proc_max;
+	uint64_t jc_fd_max;
+	uint64_t jc_sockbuf_max;
 	enum jail_policy_profile jc_profile;
 };
 
@@ -247,10 +258,13 @@ secmodel_jail_get_config(jailid_t id, struct jail_config *config)
 		mutex_exit(&jail_lock);
 		return false;
 	}
-	config->jc_has_cpu_limit = entry->je_has_cpu_limit;
-	config->jc_has_mem_limit = entry->je_has_mem_limit;
-	config->jc_cpu_limit = entry->je_cpu_limit;
-	config->jc_mem_limit = entry->je_mem_limit;
+	config->jc_cpu_quota = entry->je_cpu_quota;
+	config->jc_cpu_period = entry->je_cpu_period;
+	config->jc_cpu_weight = entry->je_cpu_weight;
+	config->jc_memory_max = entry->je_memory_max;
+	config->jc_proc_max = entry->je_proc_max;
+	config->jc_fd_max = entry->je_fd_max;
+	config->jc_sockbuf_max = entry->je_sockbuf_max;
 	config->jc_profile = entry->je_profile;
 	mutex_exit(&jail_lock);
 
@@ -310,10 +324,13 @@ secmodel_jail_create(const struct jail_create *create,
 		}
 	}
 	if (config != NULL) {
-		entry->je_has_cpu_limit = config->jc_has_cpu_limit;
-		entry->je_has_mem_limit = config->jc_has_mem_limit;
-		entry->je_cpu_limit = config->jc_cpu_limit;
-		entry->je_mem_limit = config->jc_mem_limit;
+		entry->je_cpu_quota = config->jc_cpu_quota;
+		entry->je_cpu_period = config->jc_cpu_period;
+		entry->je_cpu_weight = config->jc_cpu_weight;
+		entry->je_memory_max = config->jc_memory_max;
+		entry->je_proc_max = config->jc_proc_max;
+		entry->je_fd_max = config->jc_fd_max;
+		entry->je_sockbuf_max = config->jc_sockbuf_max;
 		entry->je_profile = config->jc_profile;
 	} else {
 		entry->je_profile = JAIL_PROFILE_POLICY_HIGH;
@@ -463,9 +480,6 @@ secmodel_jail_enter(struct lwp *l, jailid_t id)
 	struct proc *p;
 	kauth_cred_t cred, ncred;
 	jailid_t cur;
-	struct jail_config config;
-	int error;
-	bool has_config;
 
 	p = l->l_proc;
 	proc_crmod_enter();
@@ -492,27 +506,6 @@ secmodel_jail_enter(struct lwp *l, jailid_t id)
 		mutex_exit(&jail_lock);
 	}
 	proc_crmod_leave(cred, NULL, false);
-
-	has_config = secmodel_jail_get_config(id, &config);
-	if (has_config && (config.jc_has_cpu_limit || config.jc_has_mem_limit)) {
-		struct rlimit lim;
-
-		if (config.jc_has_cpu_limit) {
-			lim.rlim_cur =
-			    secmodel_jail_cpu_ms_to_rlimit(config.jc_cpu_limit);
-			lim.rlim_max = lim.rlim_cur;
-			error = dosetrlimit(l, p, RLIMIT_CPU, &lim);
-			if (error != 0)
-				return error;
-		}
-		if (config.jc_has_mem_limit) {
-			lim.rlim_cur = config.jc_mem_limit;
-			lim.rlim_max = config.jc_mem_limit;
-			error = dosetrlimit(l, p, RLIMIT_AS, &lim);
-			if (error != 0)
-				return error;
-		}
-	}
 
 	if (cur == id) {
 		return 0;
@@ -546,20 +539,6 @@ secmodel_jail_enter(struct lwp *l, jailid_t id)
 	return 0;
 }
 
-static rlim_t
-secmodel_jail_cpu_ms_to_rlimit(uint64_t cpu_ms)
-{
-	uint64_t secs;
-
-	if (cpu_ms == 0)
-		return 0;
-
-	secs = (cpu_ms + (JAIL_CPU_MS_PER_SEC - 1)) / JAIL_CPU_MS_PER_SEC;
-	if (secs > (uint64_t)RLIM_INFINITY)
-		return RLIM_INFINITY;
-
-	return (rlim_t)secs;
-}
 /*
  * sysctl handler for security.models.jail.create
  *
@@ -571,7 +550,6 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 {
 	uint32_t id;
 	int error;
-	uint32_t dummy;
 	struct jail_create create;
 	struct jail_config config;
 	struct jail_config *configp;
@@ -583,19 +561,19 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 	if (!secmodel_jail_is_host_root(l->l_cred))
 		return EPERM;
 
-	if (newlen == sizeof(dummy)) {
-		error = sysctl_copyin(l, newp, &dummy, sizeof(dummy));
-		if (error != 0)
-			return error;
-		configp = NULL;
-	} else if (newlen == sizeof(create)) {
+	if (newlen == sizeof(create)) {
 		error = sysctl_copyin(l, newp, &create, sizeof(create));
 		if (error != 0)
 			return error;
 
 		flags = create.jc_flags;
-		if ((flags & ~(JAIL_CREATE_MEMLIMIT |
-		    JAIL_CREATE_CPULIMIT |
+		if ((flags & ~(JAIL_CREATE_CPU_QUOTA |
+		    JAIL_CREATE_CPU_PERIOD |
+		    JAIL_CREATE_CPU_WEIGHT |
+		    JAIL_CREATE_MEMORY_MAX |
+		    JAIL_CREATE_PROC_MAX |
+		    JAIL_CREATE_FD_MAX |
+		    JAIL_CREATE_SOCKBUF_MAX |
 		    JAIL_CREATE_PROFILE |
 		    JAIL_CREATE_PORTS)) != 0)
 			return EINVAL;
@@ -633,68 +611,72 @@ secmodel_jail_sysctl_create(SYSCTLFN_ARGS)
 				return EINVAL;
 			}
 		}
-		if ((flags & JAIL_CREATE_MEMLIMIT) != 0) {
-			if (create.jc_mem_limit == 0)
+		if ((flags & JAIL_CREATE_CPU_QUOTA) != 0) {
+			if (create.jc_cpu_quota == 0)
 				return EINVAL;
-			config.jc_has_mem_limit = true;
-			config.jc_mem_limit = (rlim_t)create.jc_mem_limit;
+			config.jc_cpu_quota = create.jc_cpu_quota;
 		}
-		if ((flags & JAIL_CREATE_CPULIMIT) != 0) {
-			if (create.jc_cpu_limit == 0)
+		if ((flags & JAIL_CREATE_CPU_PERIOD) != 0) {
+			if (create.jc_cpu_period == 0)
 				return EINVAL;
-			config.jc_has_cpu_limit = true;
-			config.jc_cpu_limit = (rlim_t)create.jc_cpu_limit;
+			config.jc_cpu_period = create.jc_cpu_period;
 		}
+		if ((flags & JAIL_CREATE_CPU_WEIGHT) != 0)
+			config.jc_cpu_weight = create.jc_cpu_weight;
+		if ((flags & JAIL_CREATE_MEMORY_MAX) != 0) {
+			if (create.jc_memory_max == 0)
+				return EINVAL;
+			config.jc_memory_max = create.jc_memory_max;
+		}
+		if ((flags & JAIL_CREATE_PROC_MAX) != 0) {
+			if (create.jc_proc_max == 0)
+				return EINVAL;
+			config.jc_proc_max = create.jc_proc_max;
+		}
+		if ((flags & JAIL_CREATE_FD_MAX) != 0) {
+			if (create.jc_fd_max == 0)
+				return EINVAL;
+			config.jc_fd_max = create.jc_fd_max;
+		}
+		if ((flags & JAIL_CREATE_SOCKBUF_MAX) != 0) {
+			if (create.jc_sockbuf_max == 0)
+				return EINVAL;
+			config.jc_sockbuf_max = create.jc_sockbuf_max;
+		}
+		if ((config.jc_cpu_quota != 0 && config.jc_cpu_period == 0) ||
+		    (config.jc_cpu_quota == 0 && config.jc_cpu_period != 0))
+			return EINVAL;
 		configp = &config;
 	} else {
 		return EINVAL;
 	}
 
-	if (newlen == sizeof(create)) {
-		if (create.jc_name[0] == '\0' || create.jc_root[0] == '\0')
-			return EINVAL;
-		if (memchr(create.jc_name, '\n', sizeof(create.jc_name)) != NULL ||
-		    memchr(create.jc_root, '\n', sizeof(create.jc_root)) != NULL)
-			return EINVAL;
-		error = secmodel_jail_create(&create, configp, &id);
-	} else {
-		error = secmodel_jail_create(NULL, configp, &id);
-	}
+	if (create.jc_name[0] == '\0' || create.jc_root[0] == '\0')
+		return EINVAL;
+	if (memchr(create.jc_name, '\n', sizeof(create.jc_name)) != NULL ||
+	    memchr(create.jc_root, '\n', sizeof(create.jc_root)) != NULL)
+		return EINVAL;
+	error = secmodel_jail_create(&create, configp, &id);
 
 	if (error != 0)
 		return error;
 
-	if (newlen == sizeof(create)) {
-		log(LOG_INFO,
-		    "secmodel_jail: created jail id=%u name=\"%s\" root=\"%s\" profile=%u by pid=%d euid=%u\n",
-		    id, create.jc_name, create.jc_root,
-		    (unsigned)configp->jc_profile, l->l_proc->p_pid,
-		    kauth_cred_geteuid(l->l_cred));
-		create.jc_id = id;
-		if (oldp == NULL) {
-			*oldlenp = sizeof(create);
-			return 0;
-		}
-		if (*oldlenp < sizeof(create))
-			return ENOMEM;
-		*oldlenp = sizeof(create);
-		return sysctl_copyout(l, &create, oldp, sizeof(create));
-	}
-
 	log(LOG_INFO,
-	    "secmodel_jail: created jail id=%u by pid=%d euid=%u\n",
-	    id, l->l_proc->p_pid, kauth_cred_geteuid(l->l_cred));
-
+	    "secmodel_jail: created jail id=%u name=\"%s\" root=\"%s\" profile=%u by pid=%d euid=%u\n",
+	    id, create.jc_name, create.jc_root,
+	    (unsigned)configp->jc_profile, l->l_proc->p_pid,
+	    kauth_cred_geteuid(l->l_cred));
+	create.jc_id = id;
 	if (oldp == NULL) {
-		*oldlenp = 0;
+		*oldlenp = sizeof(create);
 		return 0;
 	}
 
-	if (*oldlenp < sizeof(id))
+	if (*oldlenp < sizeof(create))
 		return ENOMEM;
 
-	*oldlenp = sizeof(id);
-	return sysctl_copyout(l, &id, oldp, sizeof(id));
+	*oldlenp = sizeof(create);
+	return sysctl_copyout(l, &create, oldp, sizeof(create));
 }
 
 /*
@@ -802,6 +784,23 @@ secmodel_jail_sysctl_list(SYSCTLFN_ARGS)
 	LIST_FOREACH(entry, &jail_list, je_entry) {
 		entries[i].ji_id = entry->je_id;
 		entries[i].ji_refcount = 0;
+		entries[i].ji_cpu_quota = entry->je_cpu_quota;
+		entries[i].ji_cpu_period = entry->je_cpu_period;
+		entries[i].ji_cpu_weight = entry->je_cpu_weight;
+		entries[i].ji_memory_max = entry->je_memory_max;
+		entries[i].ji_proc_max = entry->je_proc_max;
+		entries[i].ji_fd_max = entry->je_fd_max;
+		entries[i].ji_sockbuf_max = entry->je_sockbuf_max;
+		entries[i].ji_proc_current = 0;
+		entries[i].ji_fd_current = entry->je_fd_current;
+		entries[i].ji_sockbuf_current = entry->je_sockbuf_current;
+		entries[i].ji_memory_current = entry->je_memory_current;
+		entries[i].ji_cpu_usage = entry->je_cpu_usage;
+		entries[i].ji_deny_proc = entry->je_deny_proc;
+		entries[i].ji_deny_fd = entry->je_deny_fd;
+		entries[i].ji_deny_sockbuf = entry->je_deny_sockbuf;
+		entries[i].ji_deny_memory = entry->je_deny_memory;
+		entries[i].ji_throttle_cpu = entry->je_throttle_cpu;
 		strlcpy(entries[i].ji_name, entry->je_name,
 		    sizeof(entries[i].ji_name));
 		strlcpy(entries[i].ji_root, entry->je_root,
@@ -818,6 +817,7 @@ secmodel_jail_sysctl_list(SYSCTLFN_ARGS)
 		for (i = 0; i < count; i++) {
 			if (entries[i].ji_id == id) {
 				entries[i].ji_refcount++;
+				entries[i].ji_proc_current++;
 				break;
 			}
 		}
@@ -829,6 +829,7 @@ secmodel_jail_sysctl_list(SYSCTLFN_ARGS)
 		for (i = 0; i < count; i++) {
 			if (entries[i].ji_id == id) {
 				entries[i].ji_refcount++;
+				entries[i].ji_proc_current++;
 				break;
 			}
 		}
@@ -1109,6 +1110,40 @@ secmodel_jail_process_cb(kauth_cred_t cred, kauth_action_t action,
 	(void)arg3;
 
 	switch (action) {
+	case KAUTH_PROCESS_FORK: {
+		jailid_t id;
+		struct jail_entry *entry;
+		uint64_t current;
+
+		id = secmodel_jail_cred_id(cred);
+		if (id == JAILID_HOST)
+			return KAUTH_RESULT_DEFER;
+
+		current = 0;
+		mutex_enter(&proc_lock);
+		PROCLIST_FOREACH(p, &allproc) {
+			if (secmodel_jail_cred_id(p->p_cred) == id)
+				current++;
+		}
+		PROCLIST_FOREACH(p, &zombproc) {
+			if (secmodel_jail_cred_id(p->p_cred) == id)
+				current++;
+		}
+		mutex_exit(&proc_lock);
+
+		mutex_enter(&jail_lock);
+		entry = secmodel_jail_lookup(id);
+		if (entry != NULL) {
+			entry->je_proc_current = current;
+			if (entry->je_proc_max != 0 && current >= entry->je_proc_max) {
+				entry->je_deny_proc++;
+				mutex_exit(&jail_lock);
+				return KAUTH_RESULT_DENY;
+			}
+		}
+		mutex_exit(&jail_lock);
+		return KAUTH_RESULT_DEFER;
+	}
 	case KAUTH_PROCESS_CANSEE:
 	case KAUTH_PROCESS_SIGNAL:
 		p = arg0;

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -145,7 +145,7 @@ secmodel_jail_within_limit(uint64_t current, uint64_t delta, uint64_t limit)
 	return current + delta <= limit;
 }
 
-bool
+static bool
 secmodel_jail_memory_admit(kauth_cred_t cred, uint64_t current, uint64_t delta)
 {
 	struct jail_entry *entry;
@@ -171,7 +171,7 @@ secmodel_jail_memory_admit(kauth_cred_t cred, uint64_t current, uint64_t delta)
 	return true;
 }
 
-void
+static void
 secmodel_jail_memory_set_current(kauth_cred_t cred, uint64_t current)
 {
 	struct jail_entry *entry;
@@ -188,7 +188,7 @@ secmodel_jail_memory_set_current(kauth_cred_t cred, uint64_t current)
 	mutex_exit(&jail_lock);
 }
 
-bool
+static bool
 secmodel_jail_fd_admit(kauth_cred_t cred, uint64_t current, uint64_t delta)
 {
 	struct jail_entry *entry;
@@ -214,7 +214,7 @@ secmodel_jail_fd_admit(kauth_cred_t cred, uint64_t current, uint64_t delta)
 	return true;
 }
 
-void
+static void
 secmodel_jail_fd_set_current(kauth_cred_t cred, uint64_t current)
 {
 	struct jail_entry *entry;
@@ -231,7 +231,7 @@ secmodel_jail_fd_set_current(kauth_cred_t cred, uint64_t current)
 	mutex_exit(&jail_lock);
 }
 
-bool
+static bool
 secmodel_jail_sockbuf_charge(kauth_cred_t cred, uint64_t bytes)
 {
 	struct jail_entry *entry;
@@ -1336,23 +1336,80 @@ static int
 secmodel_jail_eval(const char *what, void *arg, void *ret)
 {
 	const struct secmodel_jail_eval_cred_matches_args *a;
+	const struct secmodel_jail_eval_admit_args *aa;
+	const struct secmodel_jail_eval_set_current_args *sca;
+	const struct secmodel_jail_eval_sockbuf_charge_args *sba;
 	bool *matchp;
+	bool *okp;
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_CRED_MATCHES) != 0)
-		return ENOENT;
-	if (arg == NULL || ret == NULL)
-		return EINVAL;
+	if (strcasecmp(what, SECMODEL_JAIL_EVAL_CRED_MATCHES) == 0) {
+		if (arg == NULL || ret == NULL)
+			return EINVAL;
 
-	a = arg;
-	matchp = ret;
-	log(LOG_DEBUG,
-	    "secmodel_jail debug: eval what=\"%s\" cred_matches name=%s\n",
-	    what, a->name ? a->name : "<none>");
-	*matchp = secmodel_jail_cred_matches(a->cred, a->name);
-	log(LOG_DEBUG,
-	    "secmodel_jail debug: eval result what=\"%s\" match=%d\n",
-	    what, *matchp);
-	return 0;
+		a = arg;
+		matchp = ret;
+		log(LOG_DEBUG,
+		    "secmodel_jail debug: eval what=\"%s\" cred_matches name=%s\n",
+		    what, a->name ? a->name : "<none>");
+		*matchp = secmodel_jail_cred_matches(a->cred, a->name);
+		log(LOG_DEBUG,
+		    "secmodel_jail debug: eval result what=\"%s\" match=%d\n",
+		    what, *matchp);
+		return 0;
+	}
+
+	if (strcasecmp(what, SECMODEL_JAIL_EVAL_MEMORY_ADMIT) == 0) {
+		if (arg == NULL || ret == NULL)
+			return EINVAL;
+		aa = arg;
+		okp = ret;
+		*okp = secmodel_jail_memory_admit(aa->cred, aa->current, aa->delta);
+		return 0;
+	}
+
+	if (strcasecmp(what, SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT) == 0) {
+		if (arg == NULL)
+			return EINVAL;
+		sca = arg;
+		secmodel_jail_memory_set_current(sca->cred, sca->current);
+		return 0;
+	}
+
+	if (strcasecmp(what, SECMODEL_JAIL_EVAL_FD_ADMIT) == 0) {
+		if (arg == NULL || ret == NULL)
+			return EINVAL;
+		aa = arg;
+		okp = ret;
+		*okp = secmodel_jail_fd_admit(aa->cred, aa->current, aa->delta);
+		return 0;
+	}
+
+	if (strcasecmp(what, SECMODEL_JAIL_EVAL_FD_SET_CURRENT) == 0) {
+		if (arg == NULL)
+			return EINVAL;
+		sca = arg;
+		secmodel_jail_fd_set_current(sca->cred, sca->current);
+		return 0;
+	}
+
+	if (strcasecmp(what, SECMODEL_JAIL_EVAL_SOCKBUF_CHARGE) == 0) {
+		if (arg == NULL || ret == NULL)
+			return EINVAL;
+		sba = arg;
+		okp = ret;
+		*okp = secmodel_jail_sockbuf_charge(sba->cred, sba->bytes);
+		return 0;
+	}
+
+	if (strcasecmp(what, SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE) == 0) {
+		if (arg == NULL)
+			return EINVAL;
+		sba = arg;
+		secmodel_jail_sockbuf_uncharge(sba->cred, sba->bytes);
+		return 0;
+	}
+
+	return ENOENT;
 }
 
 /*

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -130,6 +130,156 @@ struct jail_config {
 };
 
 /*
+ * Generic helper for jail-scoped "current + delta <= limit" admission.
+ *
+ * A limit value of zero means "unlimited" for that specific resource.
+ */
+static bool
+secmodel_jail_within_limit(uint64_t current, uint64_t delta, uint64_t limit)
+{
+
+	if (limit == 0)
+		return true;
+	if (delta > UINT64_MAX - current)
+		return false;
+	return current + delta <= limit;
+}
+
+bool
+secmodel_jail_memory_admit(kauth_cred_t cred, uint64_t current, uint64_t delta)
+{
+	struct jail_entry *entry;
+	jailid_t id;
+
+	id = secmodel_jail_cred_id(cred);
+	if (id == JAILID_HOST)
+		return true;
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry == NULL) {
+		mutex_exit(&jail_lock);
+		return true;
+	}
+	entry->je_memory_current = current;
+	if (!secmodel_jail_within_limit(current, delta, entry->je_memory_max)) {
+		entry->je_deny_memory++;
+		mutex_exit(&jail_lock);
+		return false;
+	}
+	mutex_exit(&jail_lock);
+	return true;
+}
+
+void
+secmodel_jail_memory_set_current(kauth_cred_t cred, uint64_t current)
+{
+	struct jail_entry *entry;
+	jailid_t id;
+
+	id = secmodel_jail_cred_id(cred);
+	if (id == JAILID_HOST)
+		return;
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry != NULL)
+		entry->je_memory_current = current;
+	mutex_exit(&jail_lock);
+}
+
+bool
+secmodel_jail_fd_admit(kauth_cred_t cred, uint64_t current, uint64_t delta)
+{
+	struct jail_entry *entry;
+	jailid_t id;
+
+	id = secmodel_jail_cred_id(cred);
+	if (id == JAILID_HOST)
+		return true;
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry == NULL) {
+		mutex_exit(&jail_lock);
+		return true;
+	}
+	entry->je_fd_current = current;
+	if (!secmodel_jail_within_limit(current, delta, entry->je_fd_max)) {
+		entry->je_deny_fd++;
+		mutex_exit(&jail_lock);
+		return false;
+	}
+	mutex_exit(&jail_lock);
+	return true;
+}
+
+void
+secmodel_jail_fd_set_current(kauth_cred_t cred, uint64_t current)
+{
+	struct jail_entry *entry;
+	jailid_t id;
+
+	id = secmodel_jail_cred_id(cred);
+	if (id == JAILID_HOST)
+		return;
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry != NULL)
+		entry->je_fd_current = current;
+	mutex_exit(&jail_lock);
+}
+
+bool
+secmodel_jail_sockbuf_charge(kauth_cred_t cred, uint64_t bytes)
+{
+	struct jail_entry *entry;
+	jailid_t id;
+
+	id = secmodel_jail_cred_id(cred);
+	if (id == JAILID_HOST || bytes == 0)
+		return true;
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry == NULL) {
+		mutex_exit(&jail_lock);
+		return true;
+	}
+	if (!secmodel_jail_within_limit(entry->je_sockbuf_current, bytes,
+	    entry->je_sockbuf_max)) {
+		entry->je_deny_sockbuf++;
+		mutex_exit(&jail_lock);
+		return false;
+	}
+	entry->je_sockbuf_current += bytes;
+	mutex_exit(&jail_lock);
+	return true;
+}
+
+void
+secmodel_jail_sockbuf_uncharge(kauth_cred_t cred, uint64_t bytes)
+{
+	struct jail_entry *entry;
+	jailid_t id;
+
+	id = secmodel_jail_cred_id(cred);
+	if (id == JAILID_HOST || bytes == 0)
+		return;
+
+	mutex_enter(&jail_lock);
+	entry = secmodel_jail_lookup(id);
+	if (entry != NULL) {
+		if (bytes >= entry->je_sockbuf_current)
+			entry->je_sockbuf_current = 0;
+		else
+			entry->je_sockbuf_current -= bytes;
+	}
+	mutex_exit(&jail_lock);
+}
+
+/*
  * Fetch the jail id associated with a credential. The value lives in the
  * secmodel-specific kauth data slot.
  */

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -42,10 +42,15 @@ typedef uint32_t jailid_t;
 
 #define JAILID_HOST 0
 
-#define JAIL_CREATE_MEMLIMIT	0x00000001
-#define JAIL_CREATE_CPULIMIT	0x00000002
-#define JAIL_CREATE_PROFILE	0x00000004
-#define JAIL_CREATE_PORTS	0x00000008
+#define JAIL_CREATE_CPU_QUOTA	0x00000001
+#define JAIL_CREATE_CPU_PERIOD	0x00000002
+#define JAIL_CREATE_CPU_WEIGHT	0x00000004
+#define JAIL_CREATE_MEMORY_MAX	0x00000008
+#define JAIL_CREATE_PROC_MAX	0x00000010
+#define JAIL_CREATE_FD_MAX	0x00000020
+#define JAIL_CREATE_SOCKBUF_MAX	0x00000040
+#define JAIL_CREATE_PROFILE	0x00000080
+#define JAIL_CREATE_PORTS	0x00000100
 
 #define JAIL_PORTS_MAX	32
 
@@ -57,8 +62,13 @@ struct jail_create {
 	uint32_t jc_flags;
 	uint32_t jc_id;
 	uint32_t jc_profile;
-	uint64_t jc_mem_limit;
-	uint64_t jc_cpu_limit;
+	uint64_t jc_cpu_quota;
+	uint64_t jc_cpu_period;
+	uint64_t jc_cpu_weight;
+	uint64_t jc_memory_max;
+	uint64_t jc_proc_max;
+	uint64_t jc_fd_max;
+	uint64_t jc_sockbuf_max;
 	uint16_t jc_nports;
 	uint16_t jc_ports[JAIL_PORTS_MAX];
 	char jc_name[JAIL_NAME_MAX + 1];
@@ -70,6 +80,23 @@ struct jail_info {
 	uint32_t ji_refcount;
 	char ji_name[JAIL_NAME_MAX + 1];
 	char ji_root[JAIL_ROOT_MAX + 1];
+	uint64_t ji_cpu_quota;
+	uint64_t ji_cpu_period;
+	uint64_t ji_cpu_weight;
+	uint64_t ji_memory_max;
+	uint64_t ji_proc_max;
+	uint64_t ji_fd_max;
+	uint64_t ji_sockbuf_max;
+	uint64_t ji_proc_current;
+	uint64_t ji_fd_current;
+	uint64_t ji_sockbuf_current;
+	uint64_t ji_memory_current;
+	uint64_t ji_cpu_usage;
+	uint64_t ji_deny_proc;
+	uint64_t ji_deny_fd;
+	uint64_t ji_deny_sockbuf;
+	uint64_t ji_deny_memory;
+	uint64_t ji_throttle_cpu;
 };
 
 #endif /* !_SYS_JAIL_H_ */

--- a/sys/uvm/uvm_mmap.c
+++ b/sys/uvm/uvm_mmap.c
@@ -61,6 +61,7 @@ __KERNEL_RCSID(0, "$NetBSD: uvm_mmap.c,v 1.184 2022/07/07 11:29:18 rin Exp $");
 
 #include <sys/syscallargs.h>
 
+#include <secmodel/secmodel.h>
 #include <secmodel/jail/jail.h>
 
 #include <uvm/uvm.h>
@@ -424,10 +425,17 @@ sys_mmap(struct lwp *l, const struct sys_mmap_args *uap, register_t *retval)
 		if (uobj)
 			(*uobj->pgops->pgo_reference)(uobj);
 	}
-	if (!secmodel_jail_memory_admit(l->l_cred,
-	    (uint64_t)p->p_vmspace->vm_map.size, (uint64_t)size)) {
-		error = ENOMEM;
-		goto out;
+	{
+		struct secmodel_jail_eval_admit_args aa;
+		bool ok;
+		aa.cred = l->l_cred;
+		aa.current = (uint64_t)p->p_vmspace->vm_map.size;
+		aa.delta = (uint64_t)size;
+		if (secmodel_eval(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_EVAL_MEMORY_ADMIT, &aa, &ok) == 0 && !ok) {
+			error = ENOMEM;
+			goto out;
+		}
 	}
 	error = uvm_mmap(&p->p_vmspace->vm_map, &addr, size, prot, maxprot,
 	    flags, advice, uobj, pos, p->p_rlimit[RLIMIT_MEMLOCK].rlim_cur);
@@ -435,10 +443,17 @@ sys_mmap(struct lwp *l, const struct sys_mmap_args *uap, register_t *retval)
 		if (error) {
 			addr = defaddr;
 			pax_aslr_mmap(l, &addr, orig_addr, flags);
-			if (!secmodel_jail_memory_admit(l->l_cred,
-			    (uint64_t)p->p_vmspace->vm_map.size, (uint64_t)size)) {
-				error = ENOMEM;
-				goto out;
+			{
+				struct secmodel_jail_eval_admit_args aa;
+				bool ok;
+				aa.cred = l->l_cred;
+				aa.current = (uint64_t)p->p_vmspace->vm_map.size;
+				aa.delta = (uint64_t)size;
+				if (secmodel_eval(SECMODEL_JAIL_ID,
+				    SECMODEL_JAIL_EVAL_MEMORY_ADMIT, &aa, &ok) == 0 && !ok) {
+					error = ENOMEM;
+					goto out;
+				}
 			}
 			error = uvm_mmap(&p->p_vmspace->vm_map, &addr, size,
 			    prot, maxprot, flags, advice, uobj, pos,
@@ -449,8 +464,11 @@ sys_mmap(struct lwp *l, const struct sys_mmap_args *uap, register_t *retval)
 		}
 	}
 	if (error == 0) {
-		secmodel_jail_memory_set_current(l->l_cred,
-		    (uint64_t)p->p_vmspace->vm_map.size);
+		struct secmodel_jail_eval_set_current_args sca;
+		sca.cred = l->l_cred;
+		sca.current = (uint64_t)p->p_vmspace->vm_map.size;
+		(void)secmodel_eval(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT, &sca, NULL);
 	}
 
 	/* remember to add offset */

--- a/sys/uvm/uvm_mmap.c
+++ b/sys/uvm/uvm_mmap.c
@@ -61,6 +61,8 @@ __KERNEL_RCSID(0, "$NetBSD: uvm_mmap.c,v 1.184 2022/07/07 11:29:18 rin Exp $");
 
 #include <sys/syscallargs.h>
 
+#include <secmodel/jail/jail.h>
+
 #include <uvm/uvm.h>
 #include <uvm/uvm_device.h>
 
@@ -422,12 +424,22 @@ sys_mmap(struct lwp *l, const struct sys_mmap_args *uap, register_t *retval)
 		if (uobj)
 			(*uobj->pgops->pgo_reference)(uobj);
 	}
+	if (!secmodel_jail_memory_admit(l->l_cred,
+	    (uint64_t)p->p_vmspace->vm_map.size, (uint64_t)size)) {
+		error = ENOMEM;
+		goto out;
+	}
 	error = uvm_mmap(&p->p_vmspace->vm_map, &addr, size, prot, maxprot,
 	    flags, advice, uobj, pos, p->p_rlimit[RLIMIT_MEMLOCK].rlim_cur);
 	if (addrhint) {
 		if (error) {
 			addr = defaddr;
 			pax_aslr_mmap(l, &addr, orig_addr, flags);
+			if (!secmodel_jail_memory_admit(l->l_cred,
+			    (uint64_t)p->p_vmspace->vm_map.size, (uint64_t)size)) {
+				error = ENOMEM;
+				goto out;
+			}
 			error = uvm_mmap(&p->p_vmspace->vm_map, &addr, size,
 			    prot, maxprot, flags, advice, uobj, pos,
 			    p->p_rlimit[RLIMIT_MEMLOCK].rlim_cur);
@@ -435,6 +447,10 @@ sys_mmap(struct lwp *l, const struct sys_mmap_args *uap, register_t *retval)
 			/* Release the exta reference we took.  */
 			(*uobj->pgops->pgo_detach)(uobj);
 		}
+	}
+	if (error == 0) {
+		secmodel_jail_memory_set_current(l->l_cred,
+		    (uint64_t)p->p_vmspace->vm_map.size);
 	}
 
 	/* remember to add offset */

--- a/sys/uvm/uvm_unix.c
+++ b/sys/uvm/uvm_unix.c
@@ -52,6 +52,7 @@ __KERNEL_RCSID(0, "$NetBSD: uvm_unix.c,v 1.51 2022/01/10 18:04:20 christos Exp $
 #include <sys/param.h>
 #include <sys/systm.h>
 
+#include <secmodel/secmodel.h>
 #include <secmodel/jail/jail.h>
 #include <sys/proc.h>
 #include <sys/resourcevar.h>
@@ -106,7 +107,14 @@ sys_obreak(struct lwp *l, const struct sys_obreak_args *uap, register_t *retval)
 		
 		delta = nbreak - obreak;
 		current = (uint64_t)vm->vm_map.size;
-		if (!secmodel_jail_memory_admit(l->l_cred, current, delta)) {
+		struct secmodel_jail_eval_admit_args aa;
+		bool ok;
+
+		aa.cred = l->l_cred;
+		aa.current = current;
+		aa.delta = delta;
+		if (secmodel_eval(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_EVAL_MEMORY_ADMIT, &aa, &ok) == 0 && !ok) {
 			mutex_exit(&p->p_auxlock);
 			return ENOMEM;
 		}
@@ -127,13 +135,23 @@ sys_obreak(struct lwp *l, const struct sys_obreak_args *uap, register_t *retval)
 			mutex_exit(&p->p_auxlock);
 			return (error);
 		}
-		secmodel_jail_memory_set_current(l->l_cred,
-		    (uint64_t)vm->vm_map.size);
+		{
+			struct secmodel_jail_eval_set_current_args sca;
+			sca.cred = l->l_cred;
+			sca.current = (uint64_t)vm->vm_map.size;
+			(void)secmodel_eval(SECMODEL_JAIL_ID,
+			    SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT, &sca, NULL);
+		}
 		vm->vm_dsize += atop(nbreak - obreak);
 	} else {
 		uvm_deallocate(&vm->vm_map, nbreak, obreak - nbreak);
-		secmodel_jail_memory_set_current(l->l_cred,
-		    (uint64_t)vm->vm_map.size);
+		{
+			struct secmodel_jail_eval_set_current_args sca;
+			sca.cred = l->l_cred;
+			sca.current = (uint64_t)vm->vm_map.size;
+			(void)secmodel_eval(SECMODEL_JAIL_ID,
+			    SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT, &sca, NULL);
+		}
 		vm->vm_dsize -= atop(obreak - nbreak);
 	}
 	mutex_exit(&p->p_auxlock);

--- a/sys/uvm/uvm_unix.c
+++ b/sys/uvm/uvm_unix.c
@@ -51,6 +51,8 @@ __KERNEL_RCSID(0, "$NetBSD: uvm_unix.c,v 1.51 2022/01/10 18:04:20 christos Exp $
 
 #include <sys/param.h>
 #include <sys/systm.h>
+
+#include <secmodel/jail/jail.h>
 #include <sys/proc.h>
 #include <sys/resourcevar.h>
 
@@ -99,10 +101,19 @@ sys_obreak(struct lwp *l, const struct sys_obreak_args *uap, register_t *retval)
 	if (nbreak > obreak) {
 		vm_prot_t prot = UVM_PROT_RW;
 		vm_prot_t maxprot;
+		vsize_t delta;
+		uint64_t current;
 		
+		delta = nbreak - obreak;
+		current = (uint64_t)vm->vm_map.size;
+		if (!secmodel_jail_memory_admit(l->l_cred, current, delta)) {
+			mutex_exit(&p->p_auxlock);
+			return ENOMEM;
+		}
+
 		maxprot = PAX_MPROTECT_MAXPROTECT(l, prot, 0, UVM_PROT_ALL);
 
-		error = uvm_map(&vm->vm_map, &obreak, nbreak - obreak, NULL,
+		error = uvm_map(&vm->vm_map, &obreak, delta, NULL,
 		    UVM_UNKNOWN_OFFSET, 0,
 		    UVM_MAPFLAG(prot, maxprot,
 				UVM_INH_COPY,
@@ -116,9 +127,13 @@ sys_obreak(struct lwp *l, const struct sys_obreak_args *uap, register_t *retval)
 			mutex_exit(&p->p_auxlock);
 			return (error);
 		}
+		secmodel_jail_memory_set_current(l->l_cred,
+		    (uint64_t)vm->vm_map.size);
 		vm->vm_dsize += atop(nbreak - obreak);
 	} else {
 		uvm_deallocate(&vm->vm_map, nbreak, obreak - nbreak);
+		secmodel_jail_memory_set_current(l->l_cred,
+		    (uint64_t)vm->vm_map.size);
 		vm->vm_dsize -= atop(obreak - nbreak);
 	}
 	mutex_exit(&p->p_auxlock);

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -134,15 +134,12 @@ jail_create(const struct jail_create *create)
 {
 	jailid_t id;
 	size_t len;
-	int one;
 
-	/*
-	 * Support both create ABI variants:
-	 * - structured request with metadata/limits
-	 * - legacy integer payload for bare jail-id allocation
-	 */
+	/* Structured create payload is mandatory in the jail-native ABI. */
 	id = 0;
-	if (create != NULL) {
+	if (create == NULL)
+		errx(1, "internal error: create payload is required");
+	{
 		struct jail_create req;
 
 		req = *create;
@@ -151,12 +148,6 @@ jail_create(const struct jail_create *create)
 		    &req, sizeof(req)) == -1)
 			err(1, "create jail");
 		id = req.jc_id;
-	} else {
-		len = sizeof(id);
-		one = 1;
-		if (sysctlbyname("security.models.jail.create", &id, &len,
-		    &one, sizeof(one)) == -1)
-			err(1, "create jail");
 	}
 
 	return id;
@@ -190,10 +181,13 @@ jail_list(void)
 		return;
 	}
 
-	printf("%-8s %-8s %-16s %s\n", "ID", "PROCS", "NAME", "ROOT");
+	printf("%-8s %-8s %-8s %-10s %-10s %-16s %s\n",
+	    "ID", "PROCS", "PMAX", "MEMORY", "DENYPROC", "NAME", "ROOT");
 	for (i = 0; i < count; i++) {
-		printf("%-8" PRIu32 " %-8" PRIu32 " %-16s %s\n",
+		printf("%-8" PRIu32 " %-8" PRIu32 " %-8" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-16s %s\n",
 		    entries[i].ji_id, entries[i].ji_refcount,
+		    entries[i].ji_proc_max, entries[i].ji_memory_max,
+		    entries[i].ji_deny_proc,
 		    entries[i].ji_name[0] != '\0' ? entries[i].ji_name : "-",
 		    entries[i].ji_root[0] != '\0' ? entries[i].ji_root : "-");
 	}
@@ -845,23 +839,63 @@ main(int argc, char *argv[])
 		name = NULL;
 		create.jc_profile = JAIL_PROFILE_HIGH;
 		optind = 2;
-		while ((ch = getopt(argc, argv, "c:m:n:p:r:")) != -1) {
+		while ((ch = getopt(argc, argv, "q:C:w:M:P:F:S:n:p:r:")) != -1) {
 			switch (ch) {
-			case 'c':
+			case 'q':
 				errno = 0;
 				num = strtoumax(optarg, &endp, 0);
 				if (errno != 0 || *endp != '\0')
-					errx(1, "invalid cpu limit: %s", optarg);
-				create.jc_flags |= JAIL_CREATE_CPULIMIT;
-				create.jc_cpu_limit = num;
+					errx(1, "invalid cpu quota: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_CPU_QUOTA;
+				create.jc_cpu_quota = num;
 				break;
-			case 'm':
+			case 'C':
 				errno = 0;
 				num = strtoumax(optarg, &endp, 0);
 				if (errno != 0 || *endp != '\0')
-					errx(1, "invalid memory limit: %s", optarg);
-				create.jc_flags |= JAIL_CREATE_MEMLIMIT;
-				create.jc_mem_limit = num;
+					errx(1, "invalid cpu period: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_CPU_PERIOD;
+				create.jc_cpu_period = num;
+				break;
+			case 'w':
+				errno = 0;
+				num = strtoumax(optarg, &endp, 0);
+				if (errno != 0 || *endp != '\0')
+					errx(1, "invalid cpu weight: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_CPU_WEIGHT;
+				create.jc_cpu_weight = num;
+				break;
+			case 'M':
+				errno = 0;
+				num = strtoumax(optarg, &endp, 0);
+				if (errno != 0 || *endp != '\0')
+					errx(1, "invalid memory.max: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_MEMORY_MAX;
+				create.jc_memory_max = num;
+				break;
+			case 'P':
+				errno = 0;
+				num = strtoumax(optarg, &endp, 0);
+				if (errno != 0 || *endp != '\0')
+					errx(1, "invalid proc.max: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_PROC_MAX;
+				create.jc_proc_max = num;
+				break;
+			case 'F':
+				errno = 0;
+				num = strtoumax(optarg, &endp, 0);
+				if (errno != 0 || *endp != '\0')
+					errx(1, "invalid fd.max: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_FD_MAX;
+				create.jc_fd_max = num;
+				break;
+			case 'S':
+				errno = 0;
+				num = strtoumax(optarg, &endp, 0);
+				if (errno != 0 || *endp != '\0')
+					errx(1, "invalid sockbuf.max: %s", optarg);
+				create.jc_flags |= JAIL_CREATE_SOCKBUF_MAX;
+				create.jc_sockbuf_max = num;
 				break;
 			case 'n':
 				name = optarg;
@@ -877,6 +911,10 @@ main(int argc, char *argv[])
 				usage();
 			}
 		}
+
+		if (((create.jc_flags & JAIL_CREATE_CPU_QUOTA) != 0) !=
+		    ((create.jc_flags & JAIL_CREATE_CPU_PERIOD) != 0))
+			errx(1, "cpu.quota and cpu.period must be provided together");
 
 		if (optind >= argc || name == NULL || argc != optind + 1)
 			usage();
@@ -973,7 +1011,7 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s create [-c cpu-ms] [-m bytes] [-p low|medium|high] [-r port[,port...]] -n name <root>\n"
+	    "usage: %s create [-q cpu.quota -C cpu.period] [-w cpu.weight] [-M memory.max-bytes] [-P proc.max] [-F fd.max] [-S sockbuf.max-bytes] [-p low|medium|high] [-r port[,port...]] -n name <root>\n"
 	    "       %s supervise [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <jail-id|name> <command [args...]>\n"
 	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id|name>\n"

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -518,7 +518,7 @@ CONF
 
 jail_exists() {
 	name=$1
-	jailctl list | awk -v n="${name}" '$3==n{found=1} END{exit !found}'
+	jailctl list | awk -v n="${name}" '$6==n{found=1} END{exit !found}'
 }
 
 # Start sequence: load config, mount root overlays, allocate kernel jail ID
@@ -542,7 +542,7 @@ start_jail_internal() {
 	mount_jail_root
 
 	if jail_exists "${name}"; then
-		jid=$(jailctl list | awk -v n="${name}" '$3==n{print $1; exit}')
+		jid=$(jailctl list | awk -v n="${name}" '$6==n{print $1; exit}')
 		if [ "${supervise}" != "YES" ]; then
 			echo "Jail ${name} already running"
 			return
@@ -556,10 +556,10 @@ start_jail_internal() {
 	else
 		set -- jailctl create -n "${name}"
 		if [ -n "${JAIL_CREATE_CPU_MS:-}" ]; then
-			set -- "$@" -c "${JAIL_CREATE_CPU_MS}"
+			set -- "$@" -q "${JAIL_CREATE_CPU_MS}" -C 1000
 		fi
 		if [ -n "${JAIL_CREATE_MEMORY_MB:-}" ]; then
-			set -- "$@" -m "$(memory_mb_to_bytes "${JAIL_CREATE_MEMORY_MB}")"
+			set -- "$@" -M "$(memory_mb_to_bytes "${JAIL_CREATE_MEMORY_MB}")"
 		fi
 		if [ -n "${JAIL_CREATE_PROFILE:-}" ]; then
 			set -- "$@" -p "${JAIL_CREATE_PROFILE}"
@@ -609,7 +609,7 @@ stop_jail() {
 	name=$1
 
 	if jail_exists "${name}"; then
-		jid=$(jailctl list | awk -v n="${name}" '$3==n{print $1}')
+		jid=$(jailctl list | awk -v n="${name}" '$6==n{print $1}')
 		stop_jail_processes "${name}" "${jid}"
 		jailctl destroy "${jid}"
 		echo "Destroyed jail ${name} (jid ${jid})"
@@ -653,7 +653,7 @@ stop_all() {
 
 jail_jid_by_name() {
 	name=$1
-	jailctl list | awk -v n="${name}" '$3==n{print $1; exit}'
+	jailctl list | awk -v n="${name}" '$6==n{print $1; exit}'
 }
 
 require_apply_tools() {

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -130,7 +130,10 @@ Usage: $0 <command> [args]
 
 Commands:
   bootstrap                   Download sets and build shared base layer
-  create [-a] [-s cmd] [-c cpu-percent] [-m memory-mb] [-p profile] [-r port[,port...]] [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <name>
+  create [-a] [-s cmd] [-q cpu.quota] [-C cpu.period] [-w cpu.weight]
+         [-M memory.max-bytes] [-P proc.max] [-F fd.max]
+         [-S sockbuf.max-bytes] [-p profile] [-r port[,port...]]
+         [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <name>
                               Create jail instance directories and persist jail.conf
   start <name>                Mount jail root and supervise jail via jailctl
   start --all                 Start all configured jails
@@ -157,32 +160,6 @@ is_uint() {
 		return 0
 		;;
 	esac
-}
-
-cpu_percent_to_ms() {
-	cpu_percent=$1
-	if ! is_uint "${cpu_percent}"; then
-		echo "cpu percent (-c) must be an integer (0-100)" >&2
-		exit 1
-	fi
-	if [ "${cpu_percent}" -gt 100 ]; then
-		echo "cpu percent (-c) must be in range 0-100" >&2
-		exit 1
-	fi
-
-	# secmodel_jail limits CPU in milliseconds per one-second window.
-	# 1% == 10ms/s, 25% == 250ms/s, 100% == 1000ms/s.
-	printf '%s' $((cpu_percent * 10))
-}
-
-memory_mb_to_bytes() {
-	memory_mb=$1
-	if ! is_uint "${memory_mb}"; then
-		echo "memory limit (-m) must be an integer megabyte count" >&2
-		exit 1
-	fi
-
-	printf '%s' $((memory_mb * 1024 * 1024))
 }
 
 # Guard helper used by all mutating operations; jail lifecycle changes are
@@ -351,8 +328,13 @@ load_jail_conf() {
 
 	JAIL_NAME=
 	JAIL_SUPERVISE_CMD=
-	JAIL_CREATE_CPU_MS=
-	JAIL_CREATE_MEMORY_MB=
+	JAIL_CREATE_CPU_QUOTA=
+	JAIL_CREATE_CPU_PERIOD=
+	JAIL_CREATE_CPU_WEIGHT=
+	JAIL_CREATE_MEMORY_MAX=
+	JAIL_CREATE_PROC_MAX=
+	JAIL_CREATE_FD_MAX=
+	JAIL_CREATE_SOCKBUF_MAX=
 	JAIL_CREATE_PROFILE=
 	JAIL_CREATE_RESERVED_PORTS=
 	JAIL_SUPERVISE_FACILITY=
@@ -471,14 +453,19 @@ create_jail() {
 	name=$1
 	autostart=${2:-NO}
 	supervise_cmd=${3:-/bin/sleep 60}
-	create_cpu_ms=${4:-}
-	create_memory_mb=${5:-}
-	create_profile=${6:-}
-	create_reserved_ports=${7:-}
-	supervise_facility=${8:-}
-	supervise_stdout_level=${9:-}
-	supervise_stderr_level=${10:-}
-	supervise_tag=${11:-}
+	create_cpu_quota=${4:-}
+	create_cpu_period=${5:-}
+	create_cpu_weight=${6:-}
+	create_memory_max=${7:-}
+	create_proc_max=${8:-}
+	create_fd_max=${9:-}
+	create_sockbuf_max=${10:-}
+	create_profile=${11:-}
+	create_reserved_ports=${12:-}
+	supervise_facility=${13:-}
+	supervise_stdout_level=${14:-}
+	supervise_stderr_level=${15:-}
+	supervise_tag=${16:-}
 	escaped_create_profile=$(escape_dq "${create_profile}")
 	escaped_create_reserved_ports=$(escape_dq "${create_reserved_ports}")
 	escaped_supervise_cmd=$(escape_dq "${supervise_cmd}")
@@ -499,9 +486,14 @@ JAIL_NAME=${name}
 JAIL_RELEASE=${RELEASE}
 JAIL_ARCH=${MACHINE_ARCH}
 JAIL_AUTOSTART=${autostart}
-# Optional jailctl create(8) resource controls:
-JAIL_CREATE_CPU_MS="${create_cpu_ms}"
-JAIL_CREATE_MEMORY_MB="${create_memory_mb}"
+# Optional jailctl create(8) resource controls (jail-native ABI fields):
+JAIL_CREATE_CPU_QUOTA="${create_cpu_quota}"
+JAIL_CREATE_CPU_PERIOD="${create_cpu_period}"
+JAIL_CREATE_CPU_WEIGHT="${create_cpu_weight}"
+JAIL_CREATE_MEMORY_MAX="${create_memory_max}"
+JAIL_CREATE_PROC_MAX="${create_proc_max}"
+JAIL_CREATE_FD_MAX="${create_fd_max}"
+JAIL_CREATE_SOCKBUF_MAX="${create_sockbuf_max}"
 JAIL_CREATE_PROFILE="${escaped_create_profile}"
 JAIL_CREATE_RESERVED_PORTS="${escaped_create_reserved_ports}"
 # Optional jailctl supervise(8) logging controls:
@@ -555,11 +547,28 @@ start_jail_internal() {
 		fi
 	else
 		set -- jailctl create -n "${name}"
-		if [ -n "${JAIL_CREATE_CPU_MS:-}" ]; then
-			set -- "$@" -q "${JAIL_CREATE_CPU_MS}" -C 1000
+		# Persisted jailmgr values map 1:1 to jailctl create options so
+		# operators can reason about policy without hidden unit conversion.
+		if [ -n "${JAIL_CREATE_CPU_QUOTA:-}" ]; then
+			set -- "$@" -q "${JAIL_CREATE_CPU_QUOTA}"
 		fi
-		if [ -n "${JAIL_CREATE_MEMORY_MB:-}" ]; then
-			set -- "$@" -M "$(memory_mb_to_bytes "${JAIL_CREATE_MEMORY_MB}")"
+		if [ -n "${JAIL_CREATE_CPU_PERIOD:-}" ]; then
+			set -- "$@" -C "${JAIL_CREATE_CPU_PERIOD}"
+		fi
+		if [ -n "${JAIL_CREATE_CPU_WEIGHT:-}" ]; then
+			set -- "$@" -w "${JAIL_CREATE_CPU_WEIGHT}"
+		fi
+		if [ -n "${JAIL_CREATE_MEMORY_MAX:-}" ]; then
+			set -- "$@" -M "${JAIL_CREATE_MEMORY_MAX}"
+		fi
+		if [ -n "${JAIL_CREATE_PROC_MAX:-}" ]; then
+			set -- "$@" -P "${JAIL_CREATE_PROC_MAX}"
+		fi
+		if [ -n "${JAIL_CREATE_FD_MAX:-}" ]; then
+			set -- "$@" -F "${JAIL_CREATE_FD_MAX}"
+		fi
+		if [ -n "${JAIL_CREATE_SOCKBUF_MAX:-}" ]; then
+			set -- "$@" -S "${JAIL_CREATE_SOCKBUF_MAX}"
 		fi
 		if [ -n "${JAIL_CREATE_PROFILE:-}" ]; then
 			set -- "$@" -p "${JAIL_CREATE_PROFILE}"
@@ -839,8 +848,13 @@ case "${cmd}" in
 	create)
 		autostart=NO
 		supervise_cmd="/bin/sleep 60"
-		create_cpu_ms=
-		create_memory_mb=
+		create_cpu_quota=
+		create_cpu_period=
+		create_cpu_weight=
+		create_memory_max=
+		create_proc_max=
+		create_fd_max=
+		create_sockbuf_max=
 		create_profile=
 		create_reserved_ports=
 		supervise_facility=
@@ -859,23 +873,95 @@ case "${cmd}" in
 				supervise_cmd=$2
 				shift 2
 				;;
-			-c)
+			-q)
 				[ $# -ge 2 ] || { usage; exit 1; }
-				[ -z "${create_cpu_ms}" ] || {
-					echo "cpu percent (-c) may be provided only once" >&2
+				[ -z "${create_cpu_quota}" ] || {
+					echo "cpu quota (-q) may be provided only once" >&2
 					exit 1
 				}
-				create_cpu_ms=$(cpu_percent_to_ms "$2")
+				is_uint "$2" || {
+					echo "cpu quota (-q) must be an integer" >&2
+					exit 1
+				}
+				create_cpu_quota=$2
 				shift 2
 				;;
-			-m)
+			-C)
 				[ $# -ge 2 ] || { usage; exit 1; }
-				[ -z "${create_memory_mb}" ] || {
-					echo "memory limit (-m) may be provided only once" >&2
+				[ -z "${create_cpu_period}" ] || {
+					echo "cpu period (-C) may be provided only once" >&2
 					exit 1
 				}
-				memory_mb_to_bytes "$2" >/dev/null
-				create_memory_mb=$2
+				is_uint "$2" || {
+					echo "cpu period (-C) must be an integer" >&2
+					exit 1
+				}
+				create_cpu_period=$2
+				shift 2
+				;;
+			-w)
+				[ $# -ge 2 ] || { usage; exit 1; }
+				[ -z "${create_cpu_weight}" ] || {
+					echo "cpu weight (-w) may be provided only once" >&2
+					exit 1
+				}
+				is_uint "$2" || {
+					echo "cpu weight (-w) must be an integer" >&2
+					exit 1
+				}
+				create_cpu_weight=$2
+				shift 2
+				;;
+			-M)
+				[ $# -ge 2 ] || { usage; exit 1; }
+				[ -z "${create_memory_max}" ] || {
+					echo "memory.max (-M) may be provided only once" >&2
+					exit 1
+				}
+				is_uint "$2" || {
+					echo "memory.max (-M) must be an integer" >&2
+					exit 1
+				}
+				create_memory_max=$2
+				shift 2
+				;;
+			-P)
+				[ $# -ge 2 ] || { usage; exit 1; }
+				[ -z "${create_proc_max}" ] || {
+					echo "proc.max (-P) may be provided only once" >&2
+					exit 1
+				}
+				is_uint "$2" || {
+					echo "proc.max (-P) must be an integer" >&2
+					exit 1
+				}
+				create_proc_max=$2
+				shift 2
+				;;
+			-F)
+				[ $# -ge 2 ] || { usage; exit 1; }
+				[ -z "${create_fd_max}" ] || {
+					echo "fd.max (-F) may be provided only once" >&2
+					exit 1
+				}
+				is_uint "$2" || {
+					echo "fd.max (-F) must be an integer" >&2
+					exit 1
+				}
+				create_fd_max=$2
+				shift 2
+				;;
+			-S)
+				[ $# -ge 2 ] || { usage; exit 1; }
+				[ -z "${create_sockbuf_max}" ] || {
+					echo "sockbuf.max (-S) may be provided only once" >&2
+					exit 1
+				}
+				is_uint "$2" || {
+					echo "sockbuf.max (-S) must be an integer" >&2
+					exit 1
+				}
+				create_sockbuf_max=$2
 				shift 2
 				;;
 			-p)
@@ -921,10 +1007,18 @@ case "${cmd}" in
 			usage
 			exit 1
 		fi
+		if { [ -n "${create_cpu_quota}" ] && [ -z "${create_cpu_period}" ]; } ||
+		   { [ -z "${create_cpu_quota}" ] && [ -n "${create_cpu_period}" ]; }; then
+			echo "cpu quota (-q) and cpu period (-C) must be specified together" >&2
+			exit 1
+		fi
 		name=$1
 		create_jail "${name}" "${autostart}" "${supervise_cmd}" \
-		    "${create_cpu_ms}" "${create_memory_mb}" \
-		    "${create_profile}" "${create_reserved_ports}" \
+		    "${create_cpu_quota}" "${create_cpu_period}" \
+		    "${create_cpu_weight}" "${create_memory_max}" \
+		    "${create_proc_max}" "${create_fd_max}" \
+		    "${create_sockbuf_max}" "${create_profile}" \
+		    "${create_reserved_ports}" \
 		    "${supervise_facility}" "${supervise_stdout_level}" \
 		    "${supervise_stderr_level}" "${supervise_tag}"
 		;;


### PR DESCRIPTION
### Motivation
- Replace the legacy per-process `RLIMIT` fallback with the jail-native resource model described in doc/specs (phase 9.7) so resource policy is keyed and accounted by jail id (jid) rather than per-process UID.
- Provide a clear, structured control-plane ABI for creating/listing jails with jail-scoped policy and observability fields.
- Enforce a first kernel-level jail admission control (`proc.max`) inside the jail identity scope to prevent surprising cross-jail coupling from uid-keyed limits.

### Description
- Added new jail-native create flags/fields in `struct jail_create` and extended `struct jail_info` in `sys/sys/jail.h` to carry `cpu.quota`, `cpu.period`, `cpu.weight`, `memory.max`, `proc.max`, `fd.max`, `sockbuf.max` and usage/deny/throttle counters.
- Reworked `secmodel_jail` to store jail-scoped policy in per-jail state and removed all code that applied `dosetrlimit(2)`/`RLIMIT_*` on jail entry; the old RLIMIT behavior and any compatibility path are fully removed.
- Made the structured `create` payload mandatory for `security.models.jail.create` and adjusted the sysctl handler to accept and validate the new fields, including a consistency check that `cpu.quota` and `cpu.period` are provided together.
- Implemented kernel-side admission check for `proc.max` in `secmodel_jail` at `KAUTH_PROCESS_FORK` with per-jail `je_proc_current` and `je_deny_proc` counters and updated `security.models.jail.list` payload to include configured limits, current usage and deny/throttle counters.
- Updated `jailctl` CLI to require the structured create payload, added new `create` options (`-q`, `-C`, `-w`, `-M`, `-P`, `-F`, `-S`) mapping to the new jail-native fields, and adapted `jailctl list` output to show key policy/usage/deny columns.
- Adjusted `jailmgr` scripts to parse the new `jailctl list` column layout and to pass the new `jailctl create` flags when bootstrapping jails.

### Testing
- Ran static shell syntax check on the modified jail manager script with `sh -n usr.sbin/jailmgr/jailmgr`, which succeeded.
- Attempted to build `usr.sbin/jailctl` in this environment with `make -C usr.sbin/jailctl`, which failed due to the local environment lacking NetBSD build tooling; `bmake` is not available here, so in-tree compilation could not be validated.
- Ran repository scans and small runtime/logic checks (multiple `rg` and `sed` inspections) to verify that legacy `jc_mem_limit`/`jc_cpu_limit` and `dosetrlimit` usage were removed and that new fields/flags are wired through `sysctl` and userland paths (these textual checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab6fbfb7c832aab2e9ca5325d5f76)