### PR TITLE
uipc_socket2: include secmodel/jail headers unconditionally

### DIFF
--- a/sys/kern/uipc_socket2.c
+++ b/sys/kern/uipc_socket2.c
@@ -82,13 +82,12 @@ __KERNEL_RCSID(0, "$NetBSD: uipc_socket2.c,v 1.142 2022/10/26 23:38:09 riastradh
 #include <sys/kauth.h>
 #include <sys/pool.h>
 #include <sys/uidinfo.h>
+#include <secmodel/secmodel.h>
+#include <secmodel/jail/jail.h>
 
 #ifdef DDB
 #include <sys/filedesc.h>
 #include <ddb/db_active.h>
-
-#include <secmodel/secmodel.h>
-#include <secmodel/jail/jail.h>
 #endif
 
 /*


### PR DESCRIPTION
### Motivation
- Fix build failures where `SECMODEL_JAIL_*` identifiers are undefined when DDB is not enabled but jail secmodel code is compiled (such as in rump builds).

### Description
- Move `#include <secmodel/secmodel.h>` and `#include <secmodel/jail/jail.h>` out of the `#ifdef DDB` block in `sys/kern/uipc_socket2.c` and retain only DDB-specific headers under `#ifdef DDB`.

### Testing
- Attempted `nbmake -C lib/librumpnet uipc_socket2.po` and `bmake -C lib/librumpnet uipc_socket2.po`, but both failed because `nbmake`/`bmake` are not available in this environment, and `make -C lib/librumpnet uipc_socket2.po` failed because GNU `make` cannot parse NetBSD `bmake` makefiles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ae8dd9fa8832a9b9e527ae91bb655)