### PR TITLE
secmodel_jail: fix cpu accounting callback wiring

### DIFF
--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -79,6 +79,7 @@ static bool	secmodel_jail_port_reserved_by_id(jailid_t, in_port_t);
 static bool	secmodel_jail_port_reserved_any(in_port_t);
 static bool	secmodel_jail_addr_port(const struct sockaddr *, in_port_t *);
 static bool	secmodel_jail_has_entries(void);
+static jailid_t	secmodel_jail_cred_id(kauth_cred_t);
 
 /*
  * Each jail is tracked by an entry in a global list. The entry stores identity
@@ -1181,6 +1182,8 @@ secmodel_jail_init(void)
 {
 	mutex_init(&jail_lock, MUTEX_DEFAULT, IPL_NONE);
 	callout_init(&jail_cpu_account_ch, CALLOUT_MPSAFE);
+	callout_setfunc(&jail_cpu_account_ch, secmodel_jail_cpu_account_tick,
+	    NULL);
 	if (kauth_register_key(jail_sm, &jail_key) != 0)
 		printf("secmodel_jail: unable to register kauth key\n");
 }


### PR DESCRIPTION
### Motivation
- Resolve an implicit-declaration/type-conflict for `secmodel_jail_cred_id()` and ensure the CPU accounting callout is wired to `secmodel_jail_cpu_account_tick()` so per-jail CPU accounting is actually invoked.

### Description
- Add a forward declaration `static jailid_t secmodel_jail_cred_id(kauth_cred_t);` to avoid implicit declaration when the function is referenced earlier in the file.
- Register the callout callback in `secmodel_jail_init()` with `callout_setfunc(&jail_cpu_account_ch, secmodel_jail_cpu_account_tick, NULL);` so the callout schedules the correct handler.

### Testing
- Attempted a local object build via `make -C sys/secmodel/jail secmodel_jail.o`, which exercised the change but failed to complete in this environment because the container lacks NetBSD kernel build headers/macros (e.g. `__KERNEL_RCSID` and `<sys/kauth.h>`), so compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b005d3de8832a80267f8390a323a7)