### PR TITLE
secmodel/jail: include <sys/kauth.h> in jail.h

### DIFF
--- a/sys/secmodel/jail/jail.h
+++ b/sys/secmodel/jail/jail.h
@@ -33,6 +33,7 @@
 #define _SECMODEL_JAIL_JAIL_H_
 
 #include <sys/types.h>
+#include <sys/kauth.h>
 
 #include <secmodel/secmodel.h>
 


### PR DESCRIPTION
### Motivation
- Kernel builds failed with "unknown type name 'kauth_action_t'" because `sys/secmodel/jail/jail.h` declared callbacks using `kauth_action_t` but did not include the header that defines it.

### Description
- Add `#include <sys/kauth.h>` to `sys/secmodel/jail/jail.h` so `kauth_action_t` and related kauth types are available whenever `jail.h` is included.

### Testing
- The original kernel build produced an error about `kauth_action_t` (failure); a local `make -C sys/secmodel/jail` attempt failed because the container uses GNU `make` which cannot parse NetBSD makefiles (failure); attempting `bmake -C sys/modules/secmodel_jail` could not be run because `bmake` is not installed in the environment (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1054dc18832ab4283a8a250cb701)