### PR TITLE
secmodel_jail: reduce lock churn and eval dispatch overhead

### DIFF
--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -180,18 +180,17 @@ secmodel_jail_cpu_account_tick(void *arg)
 	mutex_exit(&jail_lock);
 
 	mutex_enter(&proc_lock);
+	mutex_enter(&jail_lock);
 	PROCLIST_FOREACH(p, &allproc) {
 		id = secmodel_jail_cred_id(p->p_cred);
 		if (id == JAILID_HOST)
 			continue;
 		ticks = p->p_uticks + p->p_sticks + p->p_iticks;
-
-		mutex_enter(&jail_lock);
 		entry = secmodel_jail_lookup(id);
 		if (entry != NULL)
 			entry->je_cpu_total_ticks += ticks;
-		mutex_exit(&jail_lock);
 	}
+	mutex_exit(&jail_lock);
 	mutex_exit(&proc_lock);
 
 	mutex_enter(&jail_lock);
@@ -1458,7 +1457,7 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 	bool *matchp;
 	bool *okp;
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_CRED_MATCHES) == 0) {
+	if (strcmp(what, SECMODEL_JAIL_EVAL_CRED_MATCHES) == 0) {
 		if (arg == NULL || ret == NULL)
 			return EINVAL;
 
@@ -1474,7 +1473,7 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_MEMORY_ADMIT) == 0) {
+	if (strcmp(what, SECMODEL_JAIL_EVAL_MEMORY_ADMIT) == 0) {
 		if (arg == NULL || ret == NULL)
 			return EINVAL;
 		aa = arg;
@@ -1483,7 +1482,7 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT) == 0) {
+	if (strcmp(what, SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT) == 0) {
 		if (arg == NULL)
 			return EINVAL;
 		sca = arg;
@@ -1491,7 +1490,7 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_FD_ADMIT) == 0) {
+	if (strcmp(what, SECMODEL_JAIL_EVAL_FD_ADMIT) == 0) {
 		if (arg == NULL || ret == NULL)
 			return EINVAL;
 		aa = arg;
@@ -1500,7 +1499,7 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_FD_SET_CURRENT) == 0) {
+	if (strcmp(what, SECMODEL_JAIL_EVAL_FD_SET_CURRENT) == 0) {
 		if (arg == NULL)
 			return EINVAL;
 		sca = arg;
@@ -1508,7 +1507,7 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_SOCKBUF_CHARGE) == 0) {
+	if (strcmp(what, SECMODEL_JAIL_EVAL_SOCKBUF_CHARGE) == 0) {
 		if (arg == NULL || ret == NULL)
 			return EINVAL;
 		sba = arg;
@@ -1517,7 +1516,7 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE) == 0) {
+	if (strcmp(what, SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE) == 0) {
 		if (arg == NULL)
 			return EINVAL;
 		sba = arg;
@@ -1525,7 +1524,7 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcasecmp(what, SECMODEL_JAIL_EVAL_CPU_CAN_RUN) == 0) {
+	if (strcmp(what, SECMODEL_JAIL_EVAL_CPU_CAN_RUN) == 0) {
 		if (arg == NULL || ret == NULL)
 			return EINVAL;
 		cra = arg;


### PR DESCRIPTION
### Motivation

- Reduce mutex churn and improve scalability in the periodic CPU-accounting pass that iterates `allproc` by avoiding a per-process lock/unlock pair.  
- Reduce dispatch overhead in `secmodel_jail_eval()` by removing unnecessary case-insensitive comparisons for fixed canonical evaluator keys.  

### Description

- In `secmodel_jail_cpu_account_tick()` take `jail_lock` once around the `PROCLIST_FOREACH(allproc)` scan while holding `proc_lock` instead of entering/exiting `jail_lock` per-process.  
- Replace `strcasecmp()` with `strcmp()` for evaluator dispatch checks in `secmodel_jail_eval()` where the `what` values are fixed canonical constants (e.g. `SECMODEL_JAIL_EVAL_CRED_MATCHES`, `SECMODEL_JAIL_EVAL_MEMORY_ADMIT`, `SECMODEL_JAIL_EVAL_FD_ADMIT`, `SECMODEL_JAIL_EVAL_SOCKBUF_CHARGE`, `SECMODEL_JAIL_EVAL_CPU_CAN_RUN`, etc.).  
- Preserve existing semantics and lock ordering (`proc_lock` -> `jail_lock`) so functionality is unchanged while reducing hot-path overhead.  

### Testing

- Ran `git diff --check` to ensure no whitespace or diff errors and it succeeded.  
- Verified the expected text replacements and new lock placement with `rg -n` searches for the modified symbols and patterns and the findings matched the intended edits.  
- Inspected the modified file (`sys/secmodel/jail/secmodel_jail.c`) to confirm the lock ordering and evaluator condition changes were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b227fb3a8832a965c370083fef64f)