### PR TITLE
Normalize jailctl/jailmgr create flags to lowercase

### DIFF
--- a/doc/specs/netbsd-jails-specification.txt
+++ b/doc/specs/netbsd-jails-specification.txt
@@ -141,17 +141,17 @@ jails-v2 jail-scoped control path.
 - Thin userland controller over security.models.jail sysctls.
 
 4.2 Core operations
-- create [-q cpu.quota] [-C cpu.period] [-M memory.max-bytes]
-         [-P proc.max] [-F fd.max] [-S sockbuf.max-bytes]
-         [-p low|medium|high] [-r port[,port...]] -n name <root>
+- create [-q cpu.quota] [-c cpu.period] [-m memory.max-bytes]
+         [-p proc.max] [-d fd.max] [-s sockbuf.max-bytes]
+         [-l low|medium|high] [-r port[,port...]] -n name <root>
 - destroy <jail-id|name>
 - exec <jail-id|name> [command [args...]]
 - supervise [logging flags] <jail-id|name> <command> [args...]
 - list
 
 4.3 Resource options
-- -q and -C configure cpu.quota/cpu.period and must be provided together.
-- -M/-P/-F/-S configure memory/proc/fd/sockbuf jail-scoped ceilings.
+- -q and -c configure cpu.quota/cpu.period and must be provided together.
+- -m/-p/-d/-s configure memory/proc/fd/sockbuf jail-scoped ceilings.
 - Values are forwarded unchanged to kernel create payload.
 
 4.4 Reserved port options

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -35,12 +35,12 @@
 .Nm
 .Cm create
 .Op Fl q Ar cpu.quota
-.Op Fl C Ar cpu.period
-.Op Fl M Ar memory.max-bytes
-.Op Fl P Ar proc.max
-.Op Fl F Ar fd.max
-.Op Fl S Ar sockbuf.max-bytes
-.Op Fl p Ar profile
+.Op Fl c Ar cpu.period
+.Op Fl m Ar memory.max-bytes
+.Op Fl p Ar proc.max
+.Op Fl d Ar fd.max
+.Op Fl s Ar sockbuf.max-bytes
+.Op Fl l Ar profile
 .Op Fl r Ar port[,port...]
 .Fl n Ar name
 .Ar root
@@ -73,7 +73,7 @@ jail id, while the host root user (jail id 0) can access all processes.
 .Pp
 The commands are as follows:
 .Bl -tag -width Ds
-.It Cm create Op Fl q Ar cpu.quota Op Fl C Ar cpu.period Op Fl M Ar memory.max-bytes Op Fl P Ar proc.max Op Fl F Ar fd.max Op Fl S Ar sockbuf.max-bytes Op Fl p Ar profile Op Fl r Ar port[,port...] Fl n Ar name Ar root
+.It Cm create Op Fl q Ar cpu.quota Op Fl c Ar cpu.period Op Fl m Ar memory.max-bytes Op Fl p Ar proc.max Op Fl d Ar fd.max Op Fl s Ar sockbuf.max-bytes Op Fl l Ar profile Op Fl r Ar port[,port...] Fl n Ar name Ar root
 Create a new jail id, assign it the unique
 .Ar name ,
 and store jail name and root metadata in the kernel jail model.
@@ -84,20 +84,20 @@ The optional flags set jail-scoped resource policy at creation time.
 .It Fl q Ar cpu.quota
 Set the CPU quota budget per window (in scheduler ticks).
 Must be used together with
-.Fl C .
-.It Fl C Ar cpu.period
+.Fl c .
+.It Fl c Ar cpu.period
 Set the CPU quota window length in microseconds.
 Must be used together with
 .Fl q .
-.It Fl M Ar memory.max-bytes
+.It Fl m Ar memory.max-bytes
 Set the jail memory admission ceiling for VM growth and mmap paths.
-.It Fl P Ar proc.max
+.It Fl p Ar proc.max
 Set the jail process-count ceiling (enforced at fork admission).
-.It Fl F Ar fd.max
+.It Fl d Ar fd.max
 Set the jail file-descriptor allocation ceiling.
-.It Fl S Ar sockbuf.max-bytes
+.It Fl s Ar sockbuf.max-bytes
 Set the jail socket-buffer reservation ceiling.
-.It Fl p Ar profile
+.It Fl l Ar profile
 Select the jail security profile.
 Valid values are
 .Dq low ,

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -839,7 +839,7 @@ main(int argc, char *argv[])
 		name = NULL;
 		create.jc_profile = JAIL_PROFILE_HIGH;
 		optind = 2;
-		while ((ch = getopt(argc, argv, "q:C:M:P:F:S:n:p:r:")) != -1) {
+		while ((ch = getopt(argc, argv, "q:c:m:p:d:s:n:l:r:")) != -1) {
 			switch (ch) {
 			case 'q':
 				errno = 0;
@@ -849,7 +849,7 @@ main(int argc, char *argv[])
 				create.jc_flags |= JAIL_CREATE_CPU_QUOTA;
 				create.jc_cpu_quota = num;
 				break;
-			case 'C':
+			case 'c':
 				errno = 0;
 				num = strtoumax(optarg, &endp, 0);
 				if (errno != 0 || *endp != '\0')
@@ -857,7 +857,7 @@ main(int argc, char *argv[])
 				create.jc_flags |= JAIL_CREATE_CPU_PERIOD;
 				create.jc_cpu_period = num;
 				break;
-			case 'M':
+			case 'm':
 				errno = 0;
 				num = strtoumax(optarg, &endp, 0);
 				if (errno != 0 || *endp != '\0')
@@ -865,7 +865,7 @@ main(int argc, char *argv[])
 				create.jc_flags |= JAIL_CREATE_MEMORY_MAX;
 				create.jc_memory_max = num;
 				break;
-			case 'P':
+			case 'p':
 				errno = 0;
 				num = strtoumax(optarg, &endp, 0);
 				if (errno != 0 || *endp != '\0')
@@ -873,7 +873,7 @@ main(int argc, char *argv[])
 				create.jc_flags |= JAIL_CREATE_PROC_MAX;
 				create.jc_proc_max = num;
 				break;
-			case 'F':
+			case 'd':
 				errno = 0;
 				num = strtoumax(optarg, &endp, 0);
 				if (errno != 0 || *endp != '\0')
@@ -881,7 +881,7 @@ main(int argc, char *argv[])
 				create.jc_flags |= JAIL_CREATE_FD_MAX;
 				create.jc_fd_max = num;
 				break;
-			case 'S':
+			case 's':
 				errno = 0;
 				num = strtoumax(optarg, &endp, 0);
 				if (errno != 0 || *endp != '\0')
@@ -892,7 +892,7 @@ main(int argc, char *argv[])
 			case 'n':
 				name = optarg;
 				break;
-			case 'p':
+			case 'l':
 				create.jc_flags |= JAIL_CREATE_PROFILE;
 				create.jc_profile = parse_profile(optarg);
 				break;
@@ -1003,7 +1003,7 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s create [-q cpu.quota -C cpu.period] [-M memory.max-bytes] [-P proc.max] [-F fd.max] [-S sockbuf.max-bytes] [-p low|medium|high] [-r port[,port...]] -n name <root>\n"
+	    "usage: %s create [-q cpu.quota -c cpu.period] [-m memory.max-bytes] [-p proc.max] [-d fd.max] [-s sockbuf.max-bytes] [-l low|medium|high] [-r port[,port...]] -n name <root>\n"
 	    "       %s supervise [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <jail-id|name> <command [args...]>\n"
 	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id|name>\n"

--- a/usr.sbin/jailmgr/examples/README
+++ b/usr.sbin/jailmgr/examples/README
@@ -9,10 +9,10 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
 
 - `create <name>` creates/updates the jail config and filesystem layout.
 - `create -a <name>` does the same and initializes `JAIL_AUTOSTART=YES`.
-- `create -s '<cmd ...>' <name>` initializes `JAIL_SUPERVISE_CMD` in `jail.conf`.
-- `create -c <cpu-percent>` sets CPU limits for `jailctl create` (0-100; internally 1% = 10ms/s).
-- `create -m <memory-mb>` stores the memory limit in `jail.conf` (MB) and converts it to bytes only when starting the jail (`jailctl create -m`).
-- CPU and memory limits are enforced through per-process `RLIMIT` values when entering the jail.
+- `create -x '<cmd ...>' <name>` initializes `JAIL_SUPERVISE_CMD` in `jail.conf`.
+- `create -q <cpu.quota> -c <cpu.period>` configures CPU quota window policy for `jailctl create` and is passed through unchanged.
+- `create -m <memory.max-bytes>` stores the memory ceiling in `jail.conf` and forwards it unchanged to `jailctl create`.
+- Resource limits are enforced by secmodel_jail as jail-scoped admission controls.
 - `create -r <port[,port...]>` reserves one or more listening ports for the jail (`jailctl create -r`).
 - `create -f <facility> -o <stdout-level> -e <stderr-level> -t <tag>` initializes logging options for `jailctl supervise`.
 - `start <name>` and `restart <name>` use per-jail settings from `${JAIL_DATA_DIR}/<name>/jail.conf`.
@@ -46,8 +46,9 @@ It can also provide optional jail-local `/dev` (tmpfs + `MAKEDEV`).
    ```sh
    /usr/sbin/jailmgr create jail1
    /usr/sbin/jailmgr create -a jail2
-   /usr/sbin/jailmgr create -a -s '/bin/sleep 60' \
-       -c 25 -m 512 -r 80,443 -f local3 -o info -e err -t jail-web jail3
+   /usr/sbin/jailmgr create -a -x '/bin/sleep 60' \
+       -q 200 -c 1000000 -m 536870912 -p 512 -d 8192 -s 134217728 \
+       -l medium -r 80,443 -f local3 -o info -e err -t jail-web jail3
    ```
 
    Then set at least `JAIL_SUPERVISE_CMD` and `JAIL_AUTOSTART` in each

--- a/usr.sbin/jailmgr/jailmgr
+++ b/usr.sbin/jailmgr/jailmgr
@@ -130,9 +130,9 @@ Usage: $0 <command> [args]
 
 Commands:
   bootstrap                   Download sets and build shared base layer
-  create [-a] [-s cmd] [-q cpu.quota] [-C cpu.period]
-         [-M memory.max-bytes] [-P proc.max] [-F fd.max]
-         [-S sockbuf.max-bytes] [-p profile] [-r port[,port...]]
+  create [-a] [-x cmd] [-q cpu.quota] [-c cpu.period]
+         [-m memory.max-bytes] [-p proc.max] [-d fd.max]
+         [-s sockbuf.max-bytes] [-l profile] [-r port[,port...]]
          [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <name>
                               Create jail instance directories and persist jail.conf
   start <name>                Mount jail root and supervise jail via jailctl
@@ -550,22 +550,22 @@ start_jail_internal() {
 			set -- "$@" -q "${JAIL_CREATE_CPU_QUOTA}"
 		fi
 		if [ -n "${JAIL_CREATE_CPU_PERIOD:-}" ]; then
-			set -- "$@" -C "${JAIL_CREATE_CPU_PERIOD}"
+			set -- "$@" -c "${JAIL_CREATE_CPU_PERIOD}"
 		fi
 		if [ -n "${JAIL_CREATE_MEMORY_MAX:-}" ]; then
-			set -- "$@" -M "${JAIL_CREATE_MEMORY_MAX}"
+			set -- "$@" -m "${JAIL_CREATE_MEMORY_MAX}"
 		fi
 		if [ -n "${JAIL_CREATE_PROC_MAX:-}" ]; then
-			set -- "$@" -P "${JAIL_CREATE_PROC_MAX}"
+			set -- "$@" -p "${JAIL_CREATE_PROC_MAX}"
 		fi
 		if [ -n "${JAIL_CREATE_FD_MAX:-}" ]; then
-			set -- "$@" -F "${JAIL_CREATE_FD_MAX}"
+			set -- "$@" -d "${JAIL_CREATE_FD_MAX}"
 		fi
 		if [ -n "${JAIL_CREATE_SOCKBUF_MAX:-}" ]; then
-			set -- "$@" -S "${JAIL_CREATE_SOCKBUF_MAX}"
+			set -- "$@" -s "${JAIL_CREATE_SOCKBUF_MAX}"
 		fi
 		if [ -n "${JAIL_CREATE_PROFILE:-}" ]; then
-			set -- "$@" -p "${JAIL_CREATE_PROFILE}"
+			set -- "$@" -l "${JAIL_CREATE_PROFILE}"
 		fi
 		if [ -n "${JAIL_CREATE_RESERVED_PORTS:-}" ]; then
 			set -- "$@" -r "${JAIL_CREATE_RESERVED_PORTS}"
@@ -861,7 +861,7 @@ case "${cmd}" in
 				autostart=YES
 				shift
 				;;
-			-s)
+			-x)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				supervise_cmd=$2
 				shift 2
@@ -879,72 +879,72 @@ case "${cmd}" in
 				create_cpu_quota=$2
 				shift 2
 				;;
-			-C)
+			-c)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				[ -z "${create_cpu_period}" ] || {
-					echo "cpu period (-C) may be provided only once" >&2
+					echo "cpu period (-c) may be provided only once" >&2
 					exit 1
 				}
 				is_uint "$2" || {
-					echo "cpu period (-C) must be an integer" >&2
+					echo "cpu period (-c) must be an integer" >&2
 					exit 1
 				}
 				create_cpu_period=$2
 				shift 2
 				;;
-			-M)
+			-m)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				[ -z "${create_memory_max}" ] || {
-					echo "memory.max (-M) may be provided only once" >&2
+					echo "memory.max (-m) may be provided only once" >&2
 					exit 1
 				}
 				is_uint "$2" || {
-					echo "memory.max (-M) must be an integer" >&2
+					echo "memory.max (-m) must be an integer" >&2
 					exit 1
 				}
 				create_memory_max=$2
 				shift 2
 				;;
-			-P)
+			-p)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				[ -z "${create_proc_max}" ] || {
-					echo "proc.max (-P) may be provided only once" >&2
+					echo "proc.max (-p) may be provided only once" >&2
 					exit 1
 				}
 				is_uint "$2" || {
-					echo "proc.max (-P) must be an integer" >&2
+					echo "proc.max (-p) must be an integer" >&2
 					exit 1
 				}
 				create_proc_max=$2
 				shift 2
 				;;
-			-F)
+			-d)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				[ -z "${create_fd_max}" ] || {
-					echo "fd.max (-F) may be provided only once" >&2
+					echo "fd.max (-d) may be provided only once" >&2
 					exit 1
 				}
 				is_uint "$2" || {
-					echo "fd.max (-F) must be an integer" >&2
+					echo "fd.max (-d) must be an integer" >&2
 					exit 1
 				}
 				create_fd_max=$2
 				shift 2
 				;;
-			-S)
+			-s)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				[ -z "${create_sockbuf_max}" ] || {
-					echo "sockbuf.max (-S) may be provided only once" >&2
+					echo "sockbuf.max (-s) may be provided only once" >&2
 					exit 1
 				}
 				is_uint "$2" || {
-					echo "sockbuf.max (-S) must be an integer" >&2
+					echo "sockbuf.max (-s) must be an integer" >&2
 					exit 1
 				}
 				create_sockbuf_max=$2
 				shift 2
 				;;
-			-p)
+			-l)
 				[ $# -ge 2 ] || { usage; exit 1; }
 				create_profile=$2
 				shift 2
@@ -989,7 +989,7 @@ case "${cmd}" in
 		fi
 		if { [ -n "${create_cpu_quota}" ] && [ -z "${create_cpu_period}" ]; } ||
 		   { [ -z "${create_cpu_quota}" ] && [ -n "${create_cpu_period}" ]; }; then
-			echo "cpu quota (-q) and cpu period (-C) must be specified together" >&2
+			echo "cpu quota (-q) and cpu period (-c) must be specified together" >&2
 			exit 1
 		fi
 		name=$1

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -88,7 +88,7 @@ Then
 extract
 .Pa base.tar.xz
 into the configured shared base layer directory.
-.It Cm create Op Fl a Op Fl s Ar cmd Op Fl q Ar cpu.quota Op Fl C Ar cpu.period Op Fl M Ar memory.max-bytes Op Fl P Ar proc.max Op Fl F Ar fd.max Op Fl S Ar sockbuf.max-bytes Op Fl p Ar profile Op Fl r Ar port[,port...] Op Fl f Ar facility Op Fl o Ar stdout-level Op Fl e Ar stderr-level Op Fl t Ar tag Ar name
+.It Cm create Op Fl a Op Fl x Ar cmd Op Fl q Ar cpu.quota Op Fl c Ar cpu.period Op Fl m Ar memory.max-bytes Op Fl p Ar proc.max Op Fl d Ar fd.max Op Fl s Ar sockbuf.max-bytes Op Fl l Ar profile Op Fl r Ar port[,port...] Op Fl f Ar facility Op Fl o Ar stdout-level Op Fl e Ar stderr-level Op Fl t Ar tag Ar name
 Create directories and metadata for one jail:
 .Pa root ,
 .Pa data ,
@@ -130,7 +130,7 @@ is initialized to
 in that generated
 .Pa jail.conf .
 When
-.Fl s
+.Fl x
 is provided,
 .Ev JAIL_SUPERVISE_CMD
 is initialized to the specified command string in the generated
@@ -138,18 +138,18 @@ is initialized to the specified command string in the generated
 When
 .Fl q
 and
-.Fl C
+.Fl c
 are provided,
 .Nm
 persists jail CPU quota and period window values and forwards them unchanged to
 .Xr jailctl 8
 at start time.
 When
-.Fl M ,
-.Fl P ,
-.Fl F ,
+.Fl m ,
+.Fl p ,
+.Fl d ,
 and
-.Fl S
+.Fl s
 are provided,
 .Nm
 persists jail-scoped memory/process/fd/socket-buffer ceilings and forwards them unchanged to
@@ -157,7 +157,7 @@ persists jail-scoped memory/process/fd/socket-buffer ceilings and forwards them 
 at start time.
 
 When
-.Fl p
+.Fl l
 is provided,
 the generated
 .Pa jail.conf
@@ -420,7 +420,7 @@ Operational notes and quick-start guidance.
 Bring a host to operational readiness and deploy one web jail:
 .Bd -literal -offset indent
 # jailmgr bootstrap
-# jailmgr create -a -s '/usr/libexec/httpd -I 8080 -X -f -s /var/www/mysite' -q 200 -C 1000000 -M 536870912 -P 512 -F 8192 -S 134217728 -p medium -r 8080 -f local3 -o info -e err -t jail-web web
+# jailmgr create -a -x '/usr/libexec/httpd -I 8080 -X -f -s /var/www/mysite' -q 200 -c 1000000 -m 536870912 -p 512 -d 8192 -s 134217728 -l medium -r 8080 -f local3 -o info -e err -t jail-web web
 # jailmgr apply --ephemeral web <<'APPLY'
 mkdir -p /var/www/mysite
 echo "<html>Hello NetBSD!</html>" > /var/www/mysite/index.html


### PR DESCRIPTION
### Motivation
- Make `jailctl` and `jailmgr` CLI flags consistent and follow common CLI best-practice by using lowercase short options.
- Remove mixed uppercase/lowercase flag set and eliminate the `-s` conflict in `jailmgr create` by introducing a dedicated `-x` for supervise-command initialization.
- Converge the semantics of flags between `jailctl` and `jailmgr` so forwarded options map 1:1 without hidden conversion.

### Description
- Replaced uppercase create flags in `jailctl` with lowercase equivalents: `-C->-c`, `-M->-m`, `-P->-p`, `-F->-d`, `-S->-s`, and changed profile flag `-p->-l`; updated usage and parsing in `usr.sbin/jailctl/jailctl.c` and its manpage `usr.sbin/jailctl/jailctl.8`.
- Updated `jailmgr` to accept the same canonical flags and to forward them to `jailctl create` with the new names, including changing `jailmgr create -s <cmd>` to `-x <cmd>` to avoid `-s` collision; edits are in `usr.sbin/jailmgr/jailmgr` and `usr.sbin/jailmgr/jailmgr.8`.
- Synchronized documentation and examples to the new flag set in `doc/specs/netbsd-jails-specification.txt` and `usr.sbin/jailmgr/examples/README` and updated usage strings accordingly.
- Updated mapping in `jailmgr` where persisted per-jail values are assembled into the `jailctl create` invocation so flags are forwarded with the new lowercase names.

### Testing
- Ran a shell-syntax check with `sh -n usr.sbin/jailmgr/jailmgr`, which completed successfully.
- Performed repository-wide pattern checks with `rg` to verify manpages, spec and README were updated to the new flag names, which succeeded.
- Attempted a C syntax-only check with `cc -fsyntax-only usr.sbin/jailctl/jailctl.c`, which cannot complete successfully in this environment due to missing NetBSD kernel headers and build-context (e.g. `sys/jail.h`, `__RCSID`), so full compile-time verification must be performed in a NetBSD build environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b30065de0832a9ae7a53b450973aa)