### PR TITLE
jailmgr.8: clarify RESOURCE QUOTA TUNING, explain ticks/period and add practical examples

### DIFF
--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -405,6 +405,116 @@ include that jail in
 and
 .Cm restart --all .
 .El
+.Sh RESOURCE QUOTA TUNING
+The resource values accepted by
+.Nm
+are forwarded to
+.Xr jailctl 8
+as-is.
+That means quota tuning should follow application behaviour,
+not generic defaults.
+.Pp
+Quick meaning of the create-time quota flags:
+.Bl -tag -width "Fl s Ar sockbuf.max-bytes"
+.It Fl m Ar memory.max-bytes
+Maximum memory growth admitted for the jail.
+If this is too low,
+processes can fail allocations
+.Pq often seen as Dv ENOMEM .
+.It Fl p Ar proc.max
+Maximum number of processes in the jail.
+Too low usually appears as failed forks or missing worker processes
+.Pq Dv EAGAIN .
+.It Fl d Ar fd.max
+Maximum number of file descriptors across jail processes.
+Too low causes
+.Dv EMFILE
+and accept/connect/open failures.
+.It Fl s Ar sockbuf.max-bytes
+Maximum socket-buffer reservation for the jail.
+Too low limits throughput under many concurrent connections.
+.It Fl q Ar cpu.quota
+CPU budget per period in scheduler ticks.
+.It Fl c Ar cpu.period
+Length of one CPU accounting window in microseconds.
+The jail can consume up to
+.Ar cpu.quota
+scheduler ticks during each
+.Ar cpu.period
+window.
+.El
+.Pp
+For CPU tuning,
+.Dq ticks
+are scheduler clock ticks
+.Pq see Dv kern.hz via Xr sysctl 8 .
+A practical approximation for average CPU share is:
+.Bd -literal -offset indent
+share ~= cpu.quota / (kern.hz * cpu.period_seconds)
+.Ed
+Example with
+.Dv kern.hz=100
+and
+.Ar -c 1000000
+.Pq 1 second period :
+.Ar -q 50
+is about 50% of one CPU,
+.Ar -q 100
+about 100% of one CPU,
+and
+.Ar -q 200
+about two CPU-seconds per second aggregate
+.Pq e.g. one core fully plus burst on another core .
+.Pp
+If your host uses a different
+.Dv kern.hz ,
+scale
+.Ar cpu.quota
+proportionally.
+Longer periods smooth throughput but make throttling bursts longer;
+shorter periods react faster but can feel more "choppy" at tight quotas.
+.Pp
+Recommended practical workflow:
+.Bl -enum
+.It
+Start with realistic traffic and no tight limits,
+measure peaks,
+then set limits.
+.It
+Set
+.Fl m
+first
+.Pq peak + 20-30% headroom for restart/update bursts .
+.It
+Set
+.Fl p
+from worst-case worker/process fan-out.
+.It
+Set
+.Fl d
+from concurrent clients and per-worker fd usage.
+For web services,
+count at least listener sockets + active connections + log files.
+.It
+Set
+.Fl s
+for the expected connection profile:
+higher for many concurrent high-latency clients,
+lower for internal batch jobs.
+.It
+Set
+.Fl q
+and
+.Fl c
+last,
+and test both steady load and burst events
+.Pq startup, reload, log rotation, package upgrades .
+.El
+.Pp
+Change one class of limit at a time,
+re-test,
+and keep chosen values documented in each jail's
+.Pa jail.conf .
 .Sh FILES
 .Bl -tag -width "/usr/share/examples/jailmgr/jailmgr.conf.sample"
 .It Pa /etc/jailmgr.conf


### PR DESCRIPTION
### Motivation
- Make the `RESOURCE QUOTA TUNING` guidance in `jailmgr(8)` more practical and actionable for operators rather than leaving tuning to guesswork. 
- Explicitly explain create-time quota flags and the observable failure modes when limits are too low. 
- Clarify CPU `ticks`/`period` semantics so operators can convert `cpu.quota`/`cpu.period` into an approximate CPU share and pick sensible values. 

### Description
- Reworked the `RESOURCE QUOTA TUNING` section in `usr.sbin/jailmgr/jailmgr.8` to include concise definitions for `-m`, `-p`, `-d`, `-s`, `-q`, and `-c` and the typical kernel error symptoms (`ENOMEM`, `EAGAIN`, `EMFILE`) for too-low settings. 
- Added an explanation that scheduler "ticks" map to `kern.hz` (with a reference to `sysctl(8)`), a simple formula `share ~= cpu.quota / (kern.hz * cpu.period_seconds)`, and concrete examples using `kern.hz=100` and `-c 1000000` to show how `-q` maps to CPU share. 
- Inserted practical tuning workflow steps (measure realistic load, set `-m` first, then `-p`, `-d`, `-s`, and `-q`/`-c` last), and guidance to validate limits under maintenance/startup bursts and document chosen values in `jail.conf`. 
- The single modified file is `usr.sbin/jailmgr/jailmgr.8`. 

### Testing
- Attempted to lint the updated manpage with `mandoc -Tlint usr.sbin/jailmgr/jailmgr.8`, but `mandoc` is not available in this environment so linting could not be performed. 
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b347bd28c832a8c28a2b2ae02a730)