### PR TITLE
jailmgr: remove legacy jail.conf variables and document current keys

### DIFF
--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -342,7 +342,34 @@ to support pseudo terminals.
 Each jail also has a jail-local configuration file at
 .Pa ${JAIL_DATA_DIR}/name/jail.conf
 that provides:
-.Bl -tag -width "JAIL_SUPERVISE_CMD"
+.Bl -tag -width "JAIL_CREATE_RESERVED_PORTS"
+.It Ev JAIL_NAME
+Jail name recorded by
+.Nm
+at create time.
+This must match the directory name used by
+.Nm
+.Pq Pa ${JAIL_DATA_DIR}/name/ .
+.It Ev JAIL_RELEASE
+Release value recorded by
+.Nm
+at create time.
+This is informational and tracks the host-side base-layer release used when
+the jail was created.
+.It Ev JAIL_ARCH
+Architecture value recorded by
+.Nm
+at create time.
+This is informational and tracks the host-side base-layer architecture used
+when the jail was created.
+.It Ev JAIL_AUTOSTART
+When set to
+.Dq YES ,
+include that jail in
+.Cm start --all ,
+.Cm stop --all ,
+and
+.Cm restart --all .
 .It Ev JAIL_SUPERVISE_CMD
 Required command (with optional arguments) passed to
 .Xr jailctl 8
@@ -355,21 +382,38 @@ without
 .Fl s )
 must be configured to emit to stderr if those logs should be captured by
 .Nm .
-.It Ev JAIL_CREATE_CPU_MS
+.It Ev JAIL_CREATE_CPU_QUOTA
+Optional value forwarded to
+.Xr jailctl 8
+.Cm create Fl q .
+.It Ev JAIL_CREATE_CPU_PERIOD
 Optional value forwarded to
 .Xr jailctl 8
 .Cm create Fl c .
-.It Ev JAIL_CREATE_MEMORY_MB
-Optional memory limit in megabytes persisted in
-.Pa jail.conf .
-.Nm
-converts this value to bytes before invoking
+.It Ev JAIL_CREATE_MEMORY_MAX
+Optional value forwarded to
 .Xr jailctl 8
-.Cm create Fl m .
-.It Ev JAIL_CREATE_PROFILE
+.Cm create Fl m
+.Pq memory.max-bytes .
+.It Ev JAIL_CREATE_PROC_MAX
 Optional value forwarded to
 .Xr jailctl 8
 .Cm create Fl p
+.Pq proc.max .
+.It Ev JAIL_CREATE_FD_MAX
+Optional value forwarded to
+.Xr jailctl 8
+.Cm create Fl d
+.Pq fd.max .
+.It Ev JAIL_CREATE_SOCKBUF_MAX
+Optional value forwarded to
+.Xr jailctl 8
+.Cm create Fl s
+.Pq sockbuf.max-bytes .
+.It Ev JAIL_CREATE_PROFILE
+Optional value forwarded to
+.Xr jailctl 8
+.Cm create Fl l
 .Pq one of
 .Dq low ,
 .Dq medium ,
@@ -396,14 +440,6 @@ Optional value forwarded to
 Optional value forwarded to
 .Xr jailctl 8
 .Cm supervise Fl t .
-.It Ev JAIL_AUTOSTART
-When set to
-.Dq YES ,
-include that jail in
-.Cm start --all ,
-.Cm stop --all ,
-and
-.Cm restart --all .
 .El
 .Sh RESOURCE QUOTA TUNING
 The resource values accepted by


### PR DESCRIPTION
### Motivation
- The manpage referenced legacy `JAIL_CREATE_CPU_MS` and `JAIL_CREATE_MEMORY_MB` variables that are no longer used and cause confusion, so the docs must be updated to reflect the actual `jailmgr` behavior. 
- Ensure the `jail.conf` key set is exhaustively and accurately documented so operators can reason about persisted create/supervise options without hidden conversions.

### Description
- Updated `usr.sbin/jailmgr/jailmgr.8` to remove `JAIL_CREATE_CPU_MS` and `JAIL_CREATE_MEMORY_MB` entries and to document the full set of `jail.conf` keys used by `jailmgr`. 
- Added explicit documentation for `JAIL_NAME`, `JAIL_RELEASE`, `JAIL_ARCH`, `JAIL_AUTOSTART`, `JAIL_CREATE_CPU_QUOTA`, `JAIL_CREATE_CPU_PERIOD`, `JAIL_CREATE_MEMORY_MAX`, `JAIL_CREATE_PROC_MAX`, `JAIL_CREATE_FD_MAX`, and `JAIL_CREATE_SOCKBUF_MAX`, and clarified that `JAIL_CREATE_PROFILE` maps to `jailctl create -l`. 
- Clarified the mapping of `jailmgr` persistent fields to the exact `jailctl` flags (`-q`, `-c`, `-m`, `-p`, `-d`, `-s`, `-l`, `-r`) and unified the `jail.conf` documentation layout. 
- Changes were committed as `ffcf187853` on branch `work`.

### Testing
- Ran `rg -n "JAIL_CREATE_CPU_MS|JAIL_CREATE_MEMORY_MB" usr.sbin/jailmgr` and confirmed there are no matches. 
- Attempted `mandoc -Tlint -Wwarning usr.sbin/jailmgr/jailmgr.8` but `mandoc` is not available in this environment. 
- Verified the file was staged and committed via `git commit` and `git log` and the commit `ffcf187853` is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bf011f80c832a8747a2668a8a0762)