### PR TITLE
uvm: refresh secmodel_jail memory current after munmap

### DIFF
--- a/sys/uvm/uvm_mmap.c
+++ b/sys/uvm/uvm_mmap.c
@@ -611,6 +611,14 @@ sys_munmap(struct lwp *l, const struct sys_munmap_args *uap, register_t *retval)
 	vm_map_unlock(map);
 	if (dead_entries != NULL)
 		uvm_unmap_detach(dead_entries, 0);
+	{
+		struct secmodel_jail_eval_set_current_args sca;
+
+		sca.cred = l->l_cred;
+		sca.current = (uint64_t)p->p_vmspace->vm_map.size;
+		(void)secmodel_eval(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT, &sca, NULL);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
### Motivation

- Ensure jail memory accounting in `secmodel_jail` reflects releases performed via `munmap` immediately, preventing stale `je_memory_current` until another tracked path updates it.

### Description

- Invoke `SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT` via `secmodel_eval` at the end of `sys_munmap`, setting `sca.cred = l->l_cred` and `sca.current = (uint64_t)p->p_vmspace->vm_map.size` so the secmodel sees the new VM size after unmap.

### Testing

- Performed repository searches with `rg` to locate related admit/set_current callsites, inspected the patch with `git diff` and `nl`, and committed the change with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2a1cfe6c832aa76c5bfcd80e2d9c)