### PR TITLE
Add pragmatic operations guide for jails-v2 (secmodel_jail → jailctl → jailmgr → svcmgr)

### DIFF
--- a/distrib/sets/lists/base/mi
+++ b/distrib/sets/lists/base/mi
@@ -1561,6 +1561,7 @@
 ./usr/sbin/iwictl				base-sysutil-bin
 ./usr/sbin/jailctl				base-sysutil-bin
 ./usr/sbin/jailmgr				base-sysutil-bin
+./usr/sbin/svcmgr				base-sysutil-bin
 ./usr/sbin/kadmin				base-krb5-bin		kerberos
 ./usr/sbin/kcm					base-krb5-bin		kerberos
 ./usr/sbin/kdc					base-krb5-bin		kerberos
@@ -2518,6 +2519,8 @@
 ./usr/share/examples/jailmgr			base-sysutil-examples
 ./usr/share/examples/jailmgr/README		base-sysutil-examples	share
 ./usr/share/examples/jailmgr/jailmgr.conf.sample	base-sysutil-examples	share
+./usr/share/examples/svcmgr			base-sysutil-examples
+./usr/share/examples/svcmgr/svcmgr.conf.sample	base-sysutil-examples	share
 ./usr/share/examples/kerberos			base-krb5-examples
 ./usr/share/examples/lua			base-sys-examples
 ./usr/share/examples/lua/README			base-sys-examples	share

--- a/distrib/sets/lists/man/mi
+++ b/distrib/sets/lists/man/mi
@@ -6134,6 +6134,7 @@
 ./usr/share/man/html8/iwictl.html		man-sysutil-htmlman	html
 ./usr/share/man/html8/jailctl.html		man-sysutil-htmlman	html
 ./usr/share/man/html8/jailmgr.html		man-sysutil-htmlman	html
+./usr/share/man/html8/svcmgr.html		man-sysutil-htmlman	html
 ./usr/share/man/html8/kadmin.html		man-krb5-htmlman	kerberos,html
 ./usr/share/man/html8/kadmind.html		man-krb5-htmlman	kerberos,html
 ./usr/share/man/html8/kcm.html			man-krb5-htmlman	kerberos,html
@@ -9512,6 +9513,7 @@
 ./usr/share/man/man8/iwictl.8			man-sysutil-man		.man
 ./usr/share/man/man8/jailctl.8			man-sysutil-man		.man
 ./usr/share/man/man8/jailmgr.8			man-sysutil-man		.man
+./usr/share/man/man8/svcmgr.8			man-sysutil-man		.man
 ./usr/share/man/man8/kadmin.8			man-krb5-man		kerberos,.man
 ./usr/share/man/man8/kadmind.8			man-krb5-man		kerberos,.man
 ./usr/share/man/man8/kcm.8			man-krb5-man		kerberos,.man

--- a/doc/specs/netbsd-jails-operations-guide.txt
+++ b/doc/specs/netbsd-jails-operations-guide.txt
@@ -1,0 +1,256 @@
+NetBSD jails-v2 operations guide (pragmatic)
+============================================
+
+Status
+------
+This document explains the operational model for the jails-v2 stack from a
+DevOps/SRE perspective. It is intentionally practical and complements the
+formal specification in:
+- doc/specs/netbsd-jails-specification.txt
+
+Scope covered here:
+- secmodel_jail (kernel policy and accounting)
+- jailctl (low-level control and supervised runtime entry)
+- jailmgr (fleet-level provisioning and lifecycle orchestration)
+- svcmgr (inside-jail lightweight multi-service launcher)
+
+
+1. Why this stack exists
+------------------------
+The stack follows a strict layering model:
+- kernel owns policy, accounting, and enforcement
+- userland tools transport intent with minimal hidden behavior
+- logs are centralized on the host through standard NetBSD syslog paths
+
+In practice this means:
+- secmodel_jail is the source of truth for jail identity and resource policy
+- jailctl is the precise operational tool
+- jailmgr scales that operation for many jails and persistent config
+- svcmgr lets one jail run multiple tightly-coupled processes while still
+  presenting tagged logs through one supervise entrypoint
+
+
+2. Layered architecture at a glance
+-----------------------------------
+
++---------------------------------------------------------------+
+| Host root (jid 0)                                              |
+|                                                               |
+|  +----------------------+     +-----------------------------+  |
+|  | jailmgr              | --> | jailctl supervise/create... |  |
+|  | (orchestration)      |     | (runtime/control adapter)   |  |
+|  +----------------------+     +--------------+--------------+  |
+|                                               |                 |
+|                                               v                 |
+|                              +-------------------------------+  |
+|                              | secmodel_jail (kernel)        |  |
+|                              | - jail metadata               |  |
+|                              | - profile / quotas / ports    |  |
+|                              | - admission & accounting      |  |
+|                              +-------------------------------+  |
+|                                                               |
+| Host syslogd <--- stdout/stderr forwarded by jailctl supervise |
++---------------------------------------------------------------+
+
+Inside each jail runtime:
+
++---------------------------------------------------------------+
+| Jail "X"                                                      |
+|  svcmgr (optional)                                             |
+|   |- service A (stdout/stderr)                                 |
+|   |- service B (stdout/stderr)                                 |
+|   `- service C (stdout/stderr)                                 |
++---------------------------------------------------------------+
+
+
+3. Who does what (operational contract)
+---------------------------------------
+3.1 secmodel_jail (kernel)
+- Enforces jail-scoped identity and process boundaries.
+- Enforces create-time policy (profile, limits, reserved ports).
+- Tracks runtime counters and performs admission/charging checks.
+
+Operational takeaway:
+- If policy behavior is surprising, inspect kernel/jail config first.
+- Userland tools are thin and generally do not "reinterpret" policy.
+
+3.2 jailctl
+- Creates/destroys/lists jails.
+- Enters jail runtime via exec.
+- Runs one supervised command per invocation:
+  - daemonized monitor
+  - stdout/stderr forwarding to host syslog
+  - restart with backoff
+
+Operational takeaway:
+- jailctl is the exact low-level primitive to debug first.
+- If you can do it with jailctl manually, jailmgr can generally automate it.
+
+3.3 jailmgr
+- Prepares filesystem/base layers and persistent per-jail config.
+- Encodes desired state in jail.conf and applies it at start.
+- Starts/stops multiple jails consistently.
+
+Operational takeaway:
+- Treat jailmgr as the fleet operator and source of persisted intent.
+
+3.4 svcmgr
+- Optional helper used as the single supervised entrypoint inside one jail.
+- Reads /etc/svcmgr.conf and starts multiple services in parallel.
+- Prefixes each emitted line with a service tag and flushes per line.
+
+Operational takeaway:
+- Use svcmgr when one jail intentionally contains a small process bundle.
+- Keep the host model simple: one supervise command per jail.
+
+
+4. Practical topology example
+-----------------------------
+Example desired topology:
+- Jail "mantisbt": nginx (port 3000) + php-fpm
+- Jail "postgresql": PostgreSQL service
+- Jail "egress": nginx (port 443) as edge ingress/egress endpoint
+
+ASCII deployment map:
+
+                         Internet
+                             |
+                             v
+                  +-----------------------+
+                  | jail: egress          |
+                  | nginx :443            |
+                  +-----------+-----------+
+                              |
+                              | upstream over TCP
+                              v
+                  +-----------------------+
+                  | jail: mantisbt        |
+                  | nginx :3000           |
+                  | php-fpm               |
+                  +-----------+-----------+
+                              |
+                              | DB over TCP
+                              v
+                  +-----------------------+
+                  | jail: postgresql      |
+                  | postgresql :5432      |
+                  +-----------------------+
+
+Notes:
+- Cross-jail communication is typically TCP.
+- Keep explicit ports and network paths documented per jail.
+- Use reserved-port/profile controls at create time as needed.
+
+
+5. Recommended setup flow
+-------------------------
+5.1 Bootstrap and base prep (host)
+1) Ensure secmodel_jail is active (bootstrap path).
+2) Prepare base layers and jailmgr directories.
+3) Keep /etc/jailmgr.conf under config management.
+
+5.2 Create jails with jailmgr
+- Create mantisbt, postgresql, egress jails.
+- Set create-time limits/profile/ports in each jail.conf.
+
+5.3 Define runtime entrypoints
+Option A (single process jail):
+- JAIL_SUPERVISE_CMD starts the service directly.
+
+Option B (multi-process jail, recommended for tightly-coupled app stacks):
+- JAIL_SUPERVISE_CMD starts svcmgr.
+- /etc/svcmgr.conf defines tagged services.
+
+Example for mantisbt jail:
+- tag: nginx, command: nginx foreground mode on 3000
+- tag: phpfpm, command: php-fpm no-daemon mode
+
+5.4 Start and verify
+- Start jails via jailmgr start <name> (or --all with autostart).
+- Verify runtime with jailctl list/status paths.
+- Verify host syslog contains expected tagged lines.
+
+
+6. Log-flow model (important)
+-----------------------------
+The log path is intentionally stdout/stderr-centric and NetBSD-native.
+
+For one jail using svcmgr:
+
+service stdout/stderr
+        |
+        v
+      svcmgr (prefixes with service tag, line-buffered flush)
+        |
+        v
+jailctl supervise monitor (host side)
+  - forwards stdout/stderr to syslog with configured facility/levels/tag
+        |
+        v
+   host syslogd (central concentrator)
+
+Why this is operationally useful:
+- one canonical host log sink (syslogd)
+- no hidden side-channel per service by default
+- standard NetBSD syslog tooling applies uniformly
+
+Practical guidance:
+- Prefer foreground/no-daemon modes for supervised services.
+- Prefer service logging to stdout/stderr where possible.
+- If a daemon defaults to internal syslog only, decide explicitly whether to:
+  - keep internal syslog behavior, or
+  - switch to stderr/stdout mode for unified host forwarding.
+
+
+7. Example configuration snippets (illustrative)
+------------------------------------------------
+7.1 Host-side jailmgr intent (conceptual)
+- mantisbt jail:
+  - JAIL_SUPERVISE_CMD="/usr/sbin/svcmgr -c /etc/svcmgr.conf"
+- postgresql jail:
+  - JAIL_SUPERVISE_CMD="/usr/pkg/bin/postgres -D /var/db/postgresql"
+- egress jail:
+  - JAIL_SUPERVISE_CMD="/usr/libexec/httpd -I 443 -X -f -s /var/www/egress"
+
+7.2 /etc/svcmgr.conf inside mantisbt jail (conceptual)
+nginx  /usr/libexec/httpd -I 3000 -X -f -s /var/www/mantisbt
+phpfpm /usr/pkg/sbin/php-fpm --nodaemonize
+
+7.3 /etc/svcmgr.conf style notes
+- first token: log tag
+- separator: spaces or tabs
+- remainder: command line
+
+
+8. Operational runbook (day-2)
+------------------------------
+8.1 Incident triage order
+1) Host syslog: confirm service-level tagged output present.
+2) jailctl/jailmgr status: confirm jail exists and supervise process is alive.
+3) Service command health inside jail (jailctl exec ...).
+4) Policy constraints: limits/profile/port reservations.
+
+8.2 Restart strategy
+- Prefer restarting at the smallest effective scope:
+  - service-level (if svcmgr/service tooling supports it)
+  - jail-level via jailmgr restart <name>
+- For persistent crash loops, inspect command flags and foreground/logging mode.
+
+8.3 Change management
+- Keep jailmgr config and per-jail jail.conf in version control.
+- Treat svcmgr.conf as application deployment artifact.
+- Roll changes one jail at a time in production.
+
+
+9. NetBSD standards and operational philosophy
+-----------------------------------------------
+This stack intentionally follows NetBSD conventions:
+- explicit, auditable control paths
+- syslogd-centered logging aggregation
+- small tools with clear boundaries
+- host-root control-plane for jail operations
+
+The result is a practical model for DevOps teams:
+- understandable layering
+- predictable lifecycle semantics
+- centralized logging without inventing a parallel platform

--- a/usr.sbin/Makefile
+++ b/usr.sbin/Makefile
@@ -14,6 +14,7 @@ SUBDIR=	ac accton acpitools altq apm apmd arp autofs \
 	i2cscan ifwatchd inetd installboot intrctl iopctl iostat ipwctl irdaattach \
 	isibootd iteconfig iwictl \
 	jailctl jailmgr kgmon \
+	svcmgr \
 	lastlogin ldpd link lockstat lpr \
 	mailwrapper makefs map-mbone mdconfig memswitch mlxctl mmcformat \
 	mopd mountd moused mrinfo mrouted mscdlabel mtrace mtree \

--- a/usr.sbin/svcmgr/Makefile
+++ b/usr.sbin/svcmgr/Makefile
@@ -1,0 +1,9 @@
+#	$NetBSD$
+
+PROG=	svcmgr
+MAN=	svcmgr.8
+
+FILES+=	svcmgr.conf.sample
+FILESDIR=	/usr/share/examples/svcmgr
+
+.include <bsd.prog.mk>

--- a/usr.sbin/svcmgr/svcmgr.8
+++ b/usr.sbin/svcmgr/svcmgr.8
@@ -1,0 +1,109 @@
+." $NetBSD$
+."-
+." Copyright (c) 2026
+." The NetBSD Foundation, Inc.
+." All rights reserved.
+." 
+." Redistribution and use in source and binary forms, with or without
+." modification, are permitted provided that the following conditions
+." are met:
+." 1. Redistributions of source code must retain the above copyright
+."    notice, this list of conditions and the following disclaimer.
+." 2. Redistributions in binary form must reproduce the above copyright
+."    notice, this list of conditions and the following disclaimer in the
+."    documentation and/or other materials provided with the distribution.
+." 
+." THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+." ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+." TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+." PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+." BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+." CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+." SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+." INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+." CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+." ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+." POSSIBILITY OF SUCH DAMAGE.
+."-
+.Dd February 23, 2026
+.Dt SVCMGR 8
+.Os
+.Sh NAME
+.Nm svcmgr
+.Nd lightweight multi-service launcher for one supervised jail entrypoint
+.Sh SYNOPSIS
+.Nm
+.Op Fl c Ar config
+.Sh DESCRIPTION
+The
+.Nm
+utility starts multiple services in parallel from a single configuration file
+and forwards each child process output line-by-line with a service tag prefix.
+It is designed for jail environments where one host-level supervisor command
+is preferred, while still allowing multiple tightly coupled processes inside
+that jail.
+.Pp
+This model keeps host-side orchestration simple
+.Pq one supervise command per jail
+while preserving per-service log classification in the shared output stream.
+.Pp
+The options are as follows:
+.Bl -tag -width "-c config"
+.It Fl c Ar config
+Read service definitions from
+.Ar config
+instead of
+.Pa /etc/svcmgr.conf .
+.El
+.Pp
+Each non-empty, non-comment line in the configuration file has this form:
+.Pp
+.Dl logtag command [args ...]
+.Pp
+The first token is the log tag. One or more spaces and/or tabs separate
+log tag and command. The rest of the line is executed via
+.Pa /bin/sh -c .
+.Pp
+For every line,
+.Nm
+starts one child process and captures both stdout and stderr.
+Output is buffered per stream until a full newline is received; each emitted
+line is prefixed with the service log tag and then flushed immediately.
+This avoids fragmented partial lines in outer supervisors.
+.Pp
+On
+.Dv SIGTERM ,
+.Dv SIGINT ,
+or
+.Dv SIGQUIT ,
+.Nm
+forwards
+.Dv SIGTERM
+to all running child process groups, waits 5 seconds, then sends
+.Dv SIGKILL
+to any remaining processes.
+.Sh FILES
+.Bl -tag -width /usr/share/examples/svcmgr/svcmgr.conf.sample
+.It Pa /etc/svcmgr.conf
+Default service list.
+.It Pa /usr/share/examples/svcmgr/svcmgr.conf.sample
+Example configuration file.
+.El
+.Sh EXAMPLES
+Sample
+.Pa /etc/svcmgr.conf :
+.Bd -literal -offset indent
+site1 /usr/libexec/httpd -I 8080 -X -f -s /var/www/site1
+site2 /usr/libexec/httpd -I 8081 -X -f -s /var/www/site2
+.Ed
+.Sh SEE ALSO
+.Xr jailctl 8 ,
+.Xr jailmgr 8 ,
+.Xr sh 1
+.Sh HISTORY
+The
+.Nm
+utility first appeared in
+.Nx 10.1 .
+.Sh AUTHORS
+.An Matthias Petermann Aq Mt mp@petermann-digital.de

--- a/usr.sbin/svcmgr/svcmgr.c
+++ b/usr.sbin/svcmgr/svcmgr.c
@@ -1,0 +1,630 @@
+/*	$NetBSD$	*/
+
+/*-
+ * Copyright (c) 2026
+ * The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * svcmgr designed and implemented by Matthias Petermann,
+ * inspired by runit.
+ */
+
+#include <sys/cdefs.h>
+#ifndef __RCSID
+#define __RCSID(x) extern const int __svcmgr_no_rcsid
+#endif
+#ifndef lint
+__RCSID("$NetBSD$");
+#endif /* not lint */
+
+#include <sys/types.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <err.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define SVCMGR_LINE_MAX	4096
+#define SVCMGR_CHUNK_SIZE 512
+#define SVCMGR_KILL_GRACE_MS 5000
+
+struct stream_state {
+	int fd;
+	bool open;
+	char line[SVCMGR_LINE_MAX];
+	size_t used;
+};
+
+struct service {
+	char *tag;
+	char *cmd;
+	pid_t pid;
+	bool running;
+	struct stream_state out;
+	struct stream_state err;
+};
+
+static volatile sig_atomic_t shutdown_requested;
+static const char *progname = "svcmgr";
+
+/*
+ * Keep the signal handler async-signal-safe by only toggling a flag.
+ * The monitor loop performs the actual shutdown sequencing.
+ */
+static void
+signal_handler(int signo)
+{
+
+	(void)signo;
+	shutdown_requested = 1;
+}
+
+static void
+usage(void)
+{
+
+	fprintf(stderr, "usage: %s [-c config]\n", progname);
+	exit(1);
+}
+
+static void
+set_nonblocking(int fd)
+{
+	int flags;
+
+	flags = fcntl(fd, F_GETFL, 0);
+	if (flags == -1)
+		err(1, "fcntl(F_GETFL)");
+	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+		err(1, "fcntl(F_SETFL)");
+}
+
+static bool
+is_blank_or_comment(const char *s)
+{
+
+	while (*s != '\0') {
+		if (isspace((unsigned char)*s)) {
+			s++;
+			continue;
+		}
+		return *s == '#';
+	}
+	return true;
+}
+
+static void
+parse_config_line(char *line, char **tagp, char **cmdp)
+{
+	char *tag, *cmd;
+
+	/*
+	 * Configuration format:
+	 *   <logtag><space-or-tab><command ...>
+	 * Any isspace(3) separator is accepted, including tabs.
+	 */
+	while (isspace((unsigned char)*line))
+		line++;
+	tag = line;
+	while (*line != '\0' && !isspace((unsigned char)*line))
+		line++;
+	if (*line == '\0')
+		errx(1, "invalid config line: missing command");
+	*line++ = '\0';
+	while (isspace((unsigned char)*line))
+		line++;
+	if (*line == '\0')
+		errx(1, "invalid config line: missing command");
+	cmd = line;
+
+	*tagp = tag;
+	*cmdp = cmd;
+}
+
+static struct service *
+load_config(const char *path, size_t *nsvcp)
+{
+	FILE *fp;
+	struct service *svcs;
+	size_t nsvc, cap;
+	char *line;
+	size_t linesz;
+	ssize_t nread;
+
+	fp = fopen(path, "r");
+	if (fp == NULL)
+		err(1, "%s", path);
+
+	svcs = NULL;
+	nsvc = 0;
+	cap = 0;
+	line = NULL;
+	linesz = 0;
+
+	/*
+	 * Read line-by-line so we can preserve the original command text
+	 * (everything after the first separator) exactly as configured.
+	 */
+	while ((nread = getline(&line, &linesz, fp)) != -1) {
+		char *tag, *cmd;
+
+		if (nread > 0 && line[nread - 1] == '\n')
+			line[nread - 1] = '\0';
+		if (is_blank_or_comment(line))
+			continue;
+
+		if (cap == nsvc) {
+			struct service *tmp;
+			size_t ncap = cap == 0 ? 8 : cap * 2;
+
+			tmp = realloc(svcs, ncap * sizeof(*svcs));
+			if (tmp == NULL)
+				err(1, "realloc");
+			svcs = tmp;
+			cap = ncap;
+		}
+
+		parse_config_line(line, &tag, &cmd);
+		svcs[nsvc].tag = strdup(tag);
+		svcs[nsvc].cmd = strdup(cmd);
+		if (svcs[nsvc].tag == NULL || svcs[nsvc].cmd == NULL)
+			err(1, "strdup");
+		svcs[nsvc].pid = -1;
+		svcs[nsvc].running = false;
+		svcs[nsvc].out.fd = -1;
+		svcs[nsvc].out.open = false;
+		svcs[nsvc].out.used = 0;
+		svcs[nsvc].err.fd = -1;
+		svcs[nsvc].err.open = false;
+		svcs[nsvc].err.used = 0;
+		nsvc++;
+	}
+
+	if (ferror(fp) != 0)
+		err(1, "%s", path);
+	if (fclose(fp) == EOF)
+		err(1, "%s", path);
+	free(line);
+
+	if (nsvc == 0)
+		errx(1, "%s: no services configured", path);
+
+	*nsvcp = nsvc;
+	return svcs;
+}
+
+static struct service *
+service_by_pid(struct service *svcs, size_t nsvc, pid_t pid)
+{
+	size_t i;
+
+	for (i = 0; i < nsvc; i++) {
+		if (svcs[i].pid == pid)
+			return &svcs[i];
+	}
+	return NULL;
+}
+
+static size_t
+running_services(struct service *svcs, size_t nsvc)
+{
+	size_t i, running;
+
+	running = 0;
+	for (i = 0; i < nsvc; i++) {
+		if (svcs[i].running)
+			running++;
+	}
+	return running;
+}
+
+static bool
+any_open_streams(struct service *svcs, size_t nsvc)
+{
+	size_t i;
+
+	for (i = 0; i < nsvc; i++) {
+		if (svcs[i].out.open || svcs[i].err.open)
+			return true;
+	}
+	return false;
+}
+
+static void
+emit_line(FILE *fp, const char *tag, const char *line)
+{
+
+	if (fprintf(fp, "%s %s\n", tag, line) < 0)
+		err(1, "fprintf");
+	if (fflush(fp) == EOF)
+		err(1, "fflush");
+}
+
+static void
+flush_stream_buffer(FILE *fp, struct service *svc, struct stream_state *st)
+{
+
+	if (st->used == 0)
+		return;
+	st->line[st->used] = '\0';
+	emit_line(fp, svc->tag, st->line);
+	st->used = 0;
+}
+
+static void
+process_stream_chunk(FILE *fp, struct service *svc, struct stream_state *st,
+    const char *buf, size_t len)
+{
+	size_t i;
+
+	/*
+	 * Convert an arbitrary byte stream into newline-delimited records.
+	 * Partial lines are kept in the per-stream buffer until complete.
+	 */
+	for (i = 0; i < len; i++) {
+		if (buf[i] == '\n') {
+			flush_stream_buffer(fp, svc, st);
+			continue;
+		}
+		if (st->used + 1 >= sizeof(st->line))
+			flush_stream_buffer(fp, svc, st);
+		st->line[st->used++] = buf[i];
+	}
+}
+
+static void
+close_stream(struct service *svc, struct stream_state *st, FILE *fp)
+{
+
+	if (!st->open)
+		return;
+	if (close(st->fd) == -1)
+		warn("close");
+	st->open = false;
+	st->fd = -1;
+	flush_stream_buffer(fp, svc, st);
+}
+
+static void
+spawn_service(struct service *svc)
+{
+	int outpipe[2], errpipe[2];
+	pid_t pid;
+
+	if (pipe(outpipe) == -1)
+		err(1, "pipe");
+	if (pipe(errpipe) == -1)
+		err(1, "pipe");
+
+	pid = fork();
+	if (pid == -1)
+		err(1, "fork");
+	if (pid == 0) {
+		int devnull;
+
+		/*
+		 * Isolate each service in its own session/process-group so
+		 * shutdown signals can target the complete service tree.
+		 */
+		if (setsid() == -1)
+			err(1, "setsid");
+		close(outpipe[0]);
+		close(errpipe[0]);
+		devnull = open("/dev/null", O_RDONLY);
+		if (devnull == -1)
+			err(1, "/dev/null");
+		if (dup2(devnull, STDIN_FILENO) == -1 ||
+		    dup2(outpipe[1], STDOUT_FILENO) == -1 ||
+		    dup2(errpipe[1], STDERR_FILENO) == -1)
+			err(1, "dup2");
+		if (devnull > STDERR_FILENO)
+			close(devnull);
+		close(outpipe[1]);
+		close(errpipe[1]);
+
+		execl("/bin/sh", "sh", "-c", svc->cmd, (char *)NULL);
+		err(1, "execl /bin/sh");
+	}
+
+	close(outpipe[1]);
+	close(errpipe[1]);
+	set_nonblocking(outpipe[0]);
+	set_nonblocking(errpipe[0]);
+
+	svc->pid = pid;
+	svc->running = true;
+	svc->out.fd = outpipe[0];
+	svc->out.open = true;
+	svc->out.used = 0;
+	svc->err.fd = errpipe[0];
+	svc->err.open = true;
+	svc->err.used = 0;
+}
+
+static void
+reap_children(struct service *svcs, size_t nsvc)
+{
+	int status;
+	pid_t pid;
+
+	for (;;) {
+		pid = waitpid(-1, &status, WNOHANG);
+		if (pid > 0) {
+			struct service *svc = service_by_pid(svcs, nsvc, pid);
+			if (svc != NULL)
+				svc->running = false;
+			continue;
+		}
+		if (pid == 0)
+			return;
+		if (errno == EINTR)
+			continue;
+		if (errno == ECHILD)
+			return;
+		warn("waitpid");
+		return;
+	}
+}
+
+static void
+send_signal_to_running(struct service *svcs, size_t nsvc, int signo,
+    bool *sent_flag)
+{
+	size_t i;
+
+	for (i = 0; i < nsvc; i++) {
+		if (!svcs[i].running)
+			continue;
+		if (kill(-svcs[i].pid, signo) == -1 && errno != ESRCH)
+			warn("kill(%d, -%jd)", signo, (intmax_t)svcs[i].pid);
+		if (sent_flag != NULL)
+			sent_flag[i] = true;
+	}
+}
+
+static void
+monitor_services(struct service *svcs, size_t nsvc)
+{
+	bool term_sent_global, kill_sent_global;
+	struct timespec deadline;
+	bool have_deadline;
+
+	term_sent_global = false;
+	kill_sent_global = false;
+	have_deadline = false;
+
+	/*
+	 * Event loop responsibilities:
+	 *  - drain child stdout/stderr without blocking
+	 *  - emit complete tagged lines with immediate flush
+	 *  - on shutdown: SIGTERM first, then SIGKILL after grace period
+	 */
+	while (running_services(svcs, nsvc) > 0 || any_open_streams(svcs, nsvc)) {
+		struct pollfd *pfds;
+		size_t i, nfd;
+		int timeout_ms, rv;
+
+		reap_children(svcs, nsvc);
+
+		if (shutdown_requested && !term_sent_global) {
+			send_signal_to_running(svcs, nsvc, SIGTERM, NULL);
+			if (clock_gettime(CLOCK_MONOTONIC, &deadline) == -1)
+				err(1, "clock_gettime");
+			deadline.tv_sec += SVCMGR_KILL_GRACE_MS / 1000;
+			deadline.tv_nsec +=
+			    (SVCMGR_KILL_GRACE_MS % 1000) * 1000000L;
+			if (deadline.tv_nsec >= 1000000000L) {
+				deadline.tv_sec++;
+				deadline.tv_nsec -= 1000000000L;
+			}
+			have_deadline = true;
+			term_sent_global = true;
+		}
+
+		timeout_ms = 500;
+		if (have_deadline && !kill_sent_global) {
+			struct timespec now;
+			long sec, nsec;
+
+			if (clock_gettime(CLOCK_MONOTONIC, &now) == -1)
+				err(1, "clock_gettime");
+			if (now.tv_sec > deadline.tv_sec ||
+			    (now.tv_sec == deadline.tv_sec &&
+			    now.tv_nsec >= deadline.tv_nsec)) {
+				send_signal_to_running(svcs, nsvc, SIGKILL, NULL);
+				kill_sent_global = true;
+				timeout_ms = 0;
+			} else {
+				sec = deadline.tv_sec - now.tv_sec;
+				nsec = deadline.tv_nsec - now.tv_nsec;
+				if (nsec < 0) {
+					sec--;
+					nsec += 1000000000L;
+				}
+				timeout_ms = (int)(sec * 1000 + nsec / 1000000L);
+				if (timeout_ms < 0)
+					timeout_ms = 0;
+				if (timeout_ms > 500)
+					timeout_ms = 500;
+			}
+		}
+
+		nfd = 0;
+		for (i = 0; i < nsvc; i++) {
+			if (svcs[i].out.open)
+				nfd++;
+			if (svcs[i].err.open)
+				nfd++;
+		}
+		if (nfd == 0) {
+			if (timeout_ms > 0) {
+				struct timespec delay;
+				delay.tv_sec = timeout_ms / 1000;
+				delay.tv_nsec = (timeout_ms % 1000) * 1000000L;
+				(void)nanosleep(&delay, NULL);
+			}
+			continue;
+		}
+
+		pfds = calloc(nfd, sizeof(*pfds));
+		if (pfds == NULL)
+			err(1, "calloc");
+
+		nfd = 0;
+		for (i = 0; i < nsvc; i++) {
+			if (svcs[i].out.open) {
+				pfds[nfd].fd = svcs[i].out.fd;
+				pfds[nfd].events = POLLIN;
+				nfd++;
+			}
+			if (svcs[i].err.open) {
+				pfds[nfd].fd = svcs[i].err.fd;
+				pfds[nfd].events = POLLIN;
+				nfd++;
+			}
+		}
+
+		rv = poll(pfds, nfd, timeout_ms);
+		if (rv < 0) {
+			if (errno == EINTR) {
+				free(pfds);
+				continue;
+			}
+			warn("poll");
+			free(pfds);
+			continue;
+		}
+
+		if (rv > 0) {
+			for (i = 0; i < nfd; i++) {
+				size_t s;
+				bool is_err;
+				struct stream_state *st;
+				FILE *fp;
+				char buf[SVCMGR_CHUNK_SIZE];
+				ssize_t n;
+
+				if ((pfds[i].revents &
+				    (POLLIN | POLLHUP | POLLERR | POLLNVAL)) == 0)
+					continue;
+
+				for (s = 0; s < nsvc; s++) {
+					if (svcs[s].out.open && svcs[s].out.fd == pfds[i].fd)
+						break;
+					if (svcs[s].err.open && svcs[s].err.fd == pfds[i].fd)
+						break;
+				}
+				if (s == nsvc)
+					continue;
+
+				is_err = (svcs[s].err.open && svcs[s].err.fd == pfds[i].fd);
+				st = is_err ? &svcs[s].err : &svcs[s].out;
+				fp = is_err ? stderr : stdout;
+
+				for (;;) {
+					n = read(st->fd, buf, sizeof(buf));
+					if (n > 0) {
+						process_stream_chunk(fp, &svcs[s], st,
+						    buf, (size_t)n);
+						continue;
+					}
+					if (n == 0) {
+						close_stream(&svcs[s], st, fp);
+						break;
+					}
+					if (errno == EINTR)
+						continue;
+					if (errno == EAGAIN || errno == EWOULDBLOCK)
+						break;
+					warn("read");
+					close_stream(&svcs[s], st, fp);
+					break;
+				}
+			}
+		}
+		free(pfds);
+	}
+
+	reap_children(svcs, nsvc);
+}
+
+int
+main(int argc, char *argv[])
+{
+	if (argc > 0 && argv[0] != NULL && argv[0][0] != '\0')
+		progname = argv[0];
+	const char *config;
+	struct sigaction sa;
+	struct service *svcs;
+	size_t nsvc, i;
+	int ch;
+
+	config = "/etc/svcmgr.conf";
+	while ((ch = getopt(argc, argv, "c:")) != -1) {
+		switch (ch) {
+		case 'c':
+			config = optarg;
+			break;
+		default:
+			usage();
+		}
+	}
+	if (optind != argc)
+		usage();
+
+	setvbuf(stdout, NULL, _IOLBF, 0);
+	setvbuf(stderr, NULL, _IOLBF, 0);
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = signal_handler;
+	sigemptyset(&sa.sa_mask);
+	if (sigaction(SIGTERM, &sa, NULL) == -1 ||
+	    sigaction(SIGINT, &sa, NULL) == -1 ||
+	    sigaction(SIGQUIT, &sa, NULL) == -1)
+		err(1, "sigaction");
+
+	svcs = load_config(config, &nsvc);
+	for (i = 0; i < nsvc; i++)
+		spawn_service(&svcs[i]);
+
+	monitor_services(svcs, nsvc);
+
+	for (i = 0; i < nsvc; i++) {
+		free(svcs[i].tag);
+		free(svcs[i].cmd);
+	}
+	free(svcs);
+
+	return 0;
+}

--- a/usr.sbin/svcmgr/svcmgr.conf.sample
+++ b/usr.sbin/svcmgr/svcmgr.conf.sample
@@ -1,0 +1,9 @@
+# /etc/svcmgr.conf - service list for svcmgr(8)
+#
+# Format: <logtag><space-or-tab><command ...>
+# - logtag is a single token without whitespace.
+# - command is executed via /bin/sh -c "command ...".
+#
+# Example services:
+site1 /usr/libexec/httpd -I 8080 -X -f -s /var/www/site1
+site2 /usr/libexec/httpd -I 8081 -X -f -s /var/www/site2


### PR DESCRIPTION
### Motivation
- Provide a concise, practical operations guide that complements the formal jail specification and helps DevOps/SREs understand the end-to-end runtime model from `secmodel_jail` → `jailctl` → `jailmgr` → `svcmgr`.
- Capture pragmatic deployment/topology examples (ASCII diagrams), concrete service examples (jail `mantisbt` with nginx+php-fpm, `postgresql`, `egress` with nginx:443), and the log-flow model that relies on host `syslogd` and stdout/stderr forwarding.

### Description
- Add `doc/specs/netbsd-jails-operations-guide.txt` containing a pragmatic operations guide covering architecture, responsibilities of each component, ASCII diagrams, a concrete multi-jail topology, recommended setup flow, and a day-2 runbook.
- Document `svcmgr` usage patterns and how `svcmgr`-prefixed/stdout-stderr streams are forwarded by `jailctl supervise` to the host `syslogd`, with operational guidance on preferred foreground/no-daemon modes.
- Include example `svcmgr` configuration snippets and concise incident triage / restart / change-management recommendations tailored to NetBSD conventions.

### Testing
- Verified the new file was created and contains expected content with `wc -l doc/specs/netbsd-jails-operations-guide.txt` which reported the file length (256 lines) and therefore that the document was written successfully.
- Rendered the top of the document with `sed -n '1,80p' doc/specs/netbsd-jails-operations-guide.txt` to confirm the header and initial sections render as intended, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c39a2f9b8832a99151013052952bf)