### PR TITLE
mtree: add /usr/share/examples/svcmgr directory

### DIFF
--- a/etc/mtree/NetBSD.dist.base
+++ b/etc/mtree/NetBSD.dist.base
@@ -514,6 +514,7 @@
 ./usr/share/examples/rpcapd
 ./usr/share/examples/rtadvd
 ./usr/share/examples/slip
+./usr/share/examples/svcmgr
 ./usr/share/examples/syslogd
 ./usr/share/examples/tmux
 ./usr/share/examples/wpa_supplicant


### PR DESCRIPTION
### Motivation
- Ensure `/usr/share/examples/svcmgr` is present in the mtree skeleton so the directory exists in `DESTDIR` before installing `usr.sbin/svcmgr/svcmgr.conf.sample`, avoiding the `mkstemp: No such file or directory` install failure.

### Description
- Add a single mtree entry `./usr/share/examples/svcmgr` to `etc/mtree/NetBSD.dist.base` so the directory is created as part of the distribution skeleton.

### Testing
- Verified the new entry is present in `etc/mtree/NetBSD.dist.base` using `nl -ba etc/mtree/NetBSD.dist.base | sed -n '500,525p'` and confirmed `rg` searches for `svcmgr`/examples show the expected references; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5f0859a8832a87b935cc91ed3de4)