### PR TITLE
jailctl: allow host-cred reads and add -h inetd HTTP header for Prometheus stats

### DIFF
--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -451,13 +451,22 @@ secmodel_jail_cred_matches(kauth_cred_t cred, const char *name)
 }
 
 /*
+ * Host credentials are those with jail id 0.
+ */
+static bool
+secmodel_jail_is_host_cred(kauth_cred_t cred)
+{
+	return secmodel_jail_cred_id(cred) == JAILID_HOST;
+}
+
+/*
  * Host root (euid 0, jail id 0) bypasses jail restrictions.
  */
 static bool
 secmodel_jail_is_host_root(kauth_cred_t cred)
 {
 	return kauth_cred_geteuid(cred) == 0 &&
-	    secmodel_jail_cred_id(cred) == JAILID_HOST;
+	    secmodel_jail_is_host_cred(cred);
 }
 
 /*
@@ -1019,7 +1028,7 @@ secmodel_jail_sysctl_list(SYSCTLFN_ARGS)
 
 	if (newp != NULL)
 		return EPERM;
-	if (!secmodel_jail_is_host_root(l->l_cred))
+	if (!secmodel_jail_is_host_cred(l->l_cred))
 		return EPERM;
 
 	mutex_enter(&jail_lock);

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -63,6 +63,11 @@
 .Op Ar args ...
 .Nm
 .Cm list
+.Nm
+.Cm stats
+.Op Fl P
+.Op Fl v
+.Op Fl h
 .Sh DESCRIPTION
 The
 .Nm
@@ -70,6 +75,9 @@ utility manages jails provided by the secmodel jail security model.
 Jails are process groups identified by a jail id.
 Processes in a jail can only signal or see other processes with the same
 jail id, while the host root user (jail id 0) can access all processes.
+Host users in jail id 0 may run read-only listing commands
+.Pq Cm list and Cm stats
+without root privileges.
 .Pp
 The commands are as follows:
 .Bl -tag -width Ds
@@ -179,6 +187,29 @@ using the root stored in kernel jail metadata and execute
 If no command is provided, an interactive shell is started.
 .It Cm list
 List active jail ids, process counts, configured jail names, and roots.
+.It Cm stats Op Fl P Op Fl v Op Fl h
+Show current jail resource usage from kernel accounting
+.Pq CPU, process, descriptor, socket buffer, and memory counters .
+By default, output is a compact human-readable table without configured limits.
+With
+.Fl v ,
+show an extended table that includes
+.Dq current/max
+pairs for process count, file descriptors, socket buffers, and memory.
+With
+.Fl P ,
+output Prometheus-compatible metrics, one sample per jail and counter.
+With
+.Fl h ,
+prepend an HTTP response header suitable for running
+.Cm stats Fl P
+behind
+.Xr inetd 8
+.Pq e.g. status line plus text/plain content type .
+The
+.Fl h
+option requires
+.Fl P .
 .El
 .Sh BUGS
 The jail resource model enforces jail-scoped admission checks for memory,

--- a/usr.sbin/jailctl/jailctl.c
+++ b/usr.sbin/jailctl/jailctl.c
@@ -73,6 +73,8 @@ static int	parse_log_level_arg(const char *);
 static uint32_t	parse_profile(const char *);
 static void	parse_port_list(struct jail_create *, const char *);
 static void	sanitize_field(const char *, char *, size_t);
+static void	jail_stats(bool, bool, bool);
+static void	prom_escape_label(const char *, char *, size_t);
 static bool	jail_lookup_by_name(const char *, struct jail_info *);
 static bool	jail_lookup_by_id(jailid_t, struct jail_info *);
 static void	log_stream_data(int, const char *, jailid_t, const char *,
@@ -196,6 +198,119 @@ jail_list(void)
 }
 
 static void
+jail_stats(bool prometheus, bool verbose, bool http_header)
+{
+	struct jail_info *entries;
+	size_t count, i;
+
+	entries = jail_fetch_list(&count);
+	if (prometheus && http_header) {
+		printf("HTTP/1.1 200 OK\r\n");
+		printf("Content-Type: text/plain\r\n\r\n");
+	}
+	if (count == 0) {
+		if (!prometheus)
+			printf("no jails\n");
+		return;
+	}
+
+	if (!prometheus) {
+		if (!verbose) {
+			printf("%-8s %-16s %-10s %-10s %-10s %-10s %-10s %-10s\n",
+			    "ID", "NAME", "CPU", "PROC", "FD", "SOCKBUF",
+			    "MEMORY", "THROTTLE");
+			for (i = 0; i < count; i++) {
+				printf("%-8" PRIu32 " %-16s %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 "\n",
+				    entries[i].ji_id,
+				    entries[i].ji_name[0] != '\0' ? entries[i].ji_name : "-",
+				    entries[i].ji_cpu_usage,
+				    entries[i].ji_proc_current,
+				    entries[i].ji_fd_current,
+				    entries[i].ji_sockbuf_current,
+				    entries[i].ji_memory_current,
+				    entries[i].ji_throttle_cpu);
+			}
+		} else {
+			printf("%-8s %-16s %-10s %-10s %-10s %-10s %-10s %-10s %-10s %-10s %-10s %-10s\n",
+			    "ID", "NAME", "CPU", "PROC", "PROC_MAX", "FD",
+			    "FD_MAX", "SOCKBUF", "SOCKBUF_MAX", "MEMORY",
+			    "MEMORY_MAX", "THROTTLE");
+			for (i = 0; i < count; i++) {
+				printf("%-8" PRIu32 " %-16s %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 " %-10" PRIu64 "\n",
+				    entries[i].ji_id,
+				    entries[i].ji_name[0] != '\0' ? entries[i].ji_name : "-",
+				    entries[i].ji_cpu_usage,
+				    entries[i].ji_proc_current,
+				    entries[i].ji_proc_max,
+				    entries[i].ji_fd_current,
+				    entries[i].ji_fd_max,
+				    entries[i].ji_sockbuf_current,
+				    entries[i].ji_sockbuf_max,
+				    entries[i].ji_memory_current,
+				    entries[i].ji_memory_max,
+				    entries[i].ji_throttle_cpu);
+			}
+		}
+		free(entries);
+		return;
+	}
+
+	printf("# TYPE jail_cpu_usage_ticks gauge\n");
+	printf("# TYPE jail_processes_current gauge\n");
+	printf("# TYPE jail_processes_max gauge\n");
+	printf("# TYPE jail_fd_current gauge\n");
+	printf("# TYPE jail_fd_max gauge\n");
+	printf("# TYPE jail_sockbuf_current gauge\n");
+	printf("# TYPE jail_sockbuf_max gauge\n");
+	printf("# TYPE jail_memory_current_bytes gauge\n");
+	printf("# TYPE jail_memory_max_bytes gauge\n");
+	printf("# TYPE jail_deny_process_total counter\n");
+	printf("# TYPE jail_deny_fd_total counter\n");
+	printf("# TYPE jail_deny_sockbuf_total counter\n");
+	printf("# TYPE jail_deny_memory_total counter\n");
+	printf("# TYPE jail_throttle_cpu_total counter\n");
+
+	for (i = 0; i < count; i++) {
+		char name[(JAIL_NAME_MAX + 1) * 2 + 1];
+		char root[(JAIL_ROOT_MAX + 1) * 2 + 1];
+
+		prom_escape_label(entries[i].ji_name, name, sizeof(name));
+		prom_escape_label(entries[i].ji_root, root, sizeof(root));
+
+		printf("jail_cpu_usage_ticks{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_cpu_usage);
+		printf("jail_processes_current{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_proc_current);
+		printf("jail_processes_max{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_proc_max);
+		printf("jail_fd_current{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_fd_current);
+		printf("jail_fd_max{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_fd_max);
+		printf("jail_sockbuf_current{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_sockbuf_current);
+		printf("jail_sockbuf_max{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_sockbuf_max);
+		printf("jail_memory_current_bytes{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_memory_current);
+		printf("jail_memory_max_bytes{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_memory_max);
+		printf("jail_deny_process_total{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_deny_proc);
+		printf("jail_deny_fd_total{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_deny_fd);
+		printf("jail_deny_sockbuf_total{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_deny_sockbuf);
+		printf("jail_deny_memory_total{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_deny_memory);
+		printf("jail_throttle_cpu_total{jid=\"%" PRIu32 "\",name=\"%s\",root=\"%s\"} %" PRIu64 "\n",
+		    entries[i].ji_id, name, root, entries[i].ji_throttle_cpu);
+	}
+
+	free(entries);
+}
+
+static void
 sanitize_field(const char *src, char *dst, size_t dsz)
 {
 	size_t i, j;
@@ -205,6 +320,27 @@ sanitize_field(const char *src, char *dst, size_t dsz)
 			dst[j++] = ' ';
 		else
 			dst[j++] = src[i];
+	}
+	dst[j] = '\0';
+}
+
+static void
+prom_escape_label(const char *src, char *dst, size_t dsz)
+{
+	size_t i, j;
+
+	for (i = 0, j = 0; src[i] != '\0' && j + 1 < dsz; i++) {
+		if ((src[i] == '\\' || src[i] == '"') && j + 2 < dsz) {
+			dst[j++] = '\\';
+			dst[j++] = src[i];
+		} else if (src[i] == '\n' && j + 2 < dsz) {
+			dst[j++] = '\\';
+			dst[j++] = 'n';
+		} else if (src[i] == '\r' || src[i] == '\t') {
+			dst[j++] = ' ';
+		} else {
+			dst[j++] = src[i];
+		}
 	}
 	dst[j] = '\0';
 }
@@ -995,6 +1131,38 @@ main(int argc, char *argv[])
 		return 0;
 	}
 
+	if (strcmp(argv[1], "stats") == 0) {
+		bool prometheus, verbose, http_header;
+		int ch;
+
+		prometheus = false;
+		verbose = false;
+		http_header = false;
+		optind = 2;
+		while ((ch = getopt(argc, argv, "Pvh")) != -1) {
+			switch (ch) {
+			case 'P':
+				prometheus = true;
+				break;
+			case 'v':
+				verbose = true;
+				break;
+			case 'h':
+				http_header = true;
+				break;
+			default:
+				usage();
+			}
+		}
+		if (optind != argc)
+			usage();
+		if (http_header && !prometheus)
+			errx(1, "-h requires -P");
+
+		jail_stats(prometheus, verbose, http_header);
+		return 0;
+	}
+
 	usage();
 	/* NOTREACHED */
 }
@@ -1007,8 +1175,9 @@ usage(void)
 	    "       %s supervise [-f facility] [-o stdout-level] [-e stderr-level] [-t tag] <jail-id|name> <command [args...]>\n"
 	    "       %s exec <jail-id|name> [command [args...]]\n"
 	    "       %s destroy <jail-id|name>\n"
-	    "       %s list\n",
+	    "       %s list\n"
+	    "       %s stats [-P] [-v] [-h]\n",
 	    getprogname(), getprogname(), getprogname(), getprogname(),
-	    getprogname());
+	    getprogname(), getprogname());
 	exit(1);
 }


### PR DESCRIPTION
### Motivation
- Allow non-root host users (credentials with jail id 0) to run read-only listing commands so `jailctl list` and `jailctl stats` can be exposed from inetd or other unprivileged contexts. 
- Provide an inetd-friendly way to publish Prometheus metrics by prepending an HTTP header to `stats -P` output. 
- Keep privileged operations (like creating/destroying jails) restricted to host root while making read-only sysctl access less restrictive.

### Description
- Add `secmodel_jail_is_host_cred(kauth_cred_t)` helper and permit `security.models.jail.list` reads for any host credential (jid 0) instead of requiring host root. 
- Retain host-root checks for privileged sysctl handlers (e.g. create/destroy) so only root can perform mutations. 
- Extend `jail_stats` to `jail_stats(bool prometheus, bool verbose, bool http_header)` and add a `-h` flag to `stats` that, when used with `-P`, prepends an HTTP response header (`HTTP/1.1 200 OK` and `Content-Type: text/plain`). 
- Update CLI parsing (`getopt` usage), `usage()` text, and the `jailctl(8)` manpage to document the new `-h` option and the note that host users with jid 0 may run `list`/`stats` without root.

### Testing
- Attempted `make -C usr.sbin/jailctl`, which failed in this environment because GNU `make` cannot parse NetBSD's makefile (error: "missing separator"). 
- Attempted `bmake -C usr.sbin/jailctl`, but `bmake` is not available in the environment so a native build could not be performed. 
- Performed source inspections with `rg`/`nl`/`sed` to verify changed symbols, `secmodel_jail_is_host_cred` usage, updated `jail_stats` signature and header-print insertion, and manpage updates, and confirmed the expected edits (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3f5d0f5c832aa231d1d8c42a3a4b)