### PR TITLE
Rename BUGS sections to NOTES in jail manuals

### DIFF
--- a/share/man/man9/secmodel_jail.9
+++ b/share/man/man9/secmodel_jail.9
@@ -93,7 +93,7 @@ emits concise kernel log entries for high-value lifecycle events:
 module load/unload and successful jail create/destroy operations.
 These messages are intended to help administrators correlate policy and
 management actions during incident analysis without excessive noise.
-.Sh BUGS
+.Sh NOTES
 CPU quota enforcement is currently admission-oriented:
 run-queue selection skips jailed LWPs while a jail is over quota,
 and fork admission is denied in the same state.

--- a/usr.sbin/jailctl/jailctl.8
+++ b/usr.sbin/jailctl/jailctl.8
@@ -211,7 +211,7 @@ The
 option requires
 .Fl P .
 .El
-.Sh BUGS
+.Sh NOTES
 The jail resource model enforces jail-scoped admission checks for memory,
 process count, file descriptors, and socket buffer reservations.
 CPU quota and period are accounted and throttled in periodic windows.

--- a/usr.sbin/jailmgr/jailmgr.8
+++ b/usr.sbin/jailmgr/jailmgr.8
@@ -574,7 +574,7 @@ APPLY
 # jailmgr config web
 # jailmgr start --all
 .Ed
-.Sh BUGS
+.Sh NOTES
 Jail resource controls are jail-scoped.
 Memory, process-count, file-descriptor, and socket-buffer ceilings are
 enforced at kernel admission points.


### PR DESCRIPTION
### Motivation
- The manual pages for the secmodel jail components described implementation details under a `BUGS` heading that are not actual bugs and should be presented as informational notes.

### Description
- Replace the `.Sh BUGS` heading with `.Sh NOTES` in `share/man/man9/secmodel_jail.9`, `usr.sbin/jailctl/jailctl.8`, and `usr.sbin/jailmgr/jailmgr.8` while leaving the explanatory text unchanged.
- Changes are committed on the current branch under the message "Rename BUGS sections to NOTES in jail manuals".

### Testing
- Located and verified the changed files with `rg` and `git diff`, which showed the expected heading updates and succeeded.
- Committed the changes with `git commit`, which succeeded.
- Attempted to run `mandoc -Tlint` on the modified manpages, which failed because `mandoc` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5f63a698832a910f1fc9d17ac4ae)