### PR TITLE
Mark message-buffer sysctls private and deny private sysctl reads in jails

### DIFF
--- a/sbin/dmesg/dmesg.8
+++ b/sbin/dmesg/dmesg.8
@@ -29,7 +29,7 @@
 .\"
 .\"     @(#)dmesg.8	8.1 (Berkeley) 6/5/93
 .\"
-.Dd October 30, 2018
+.Dd February 24, 2026
 .Dt DMESG 8
 .Os
 .Sh NAME
@@ -43,6 +43,12 @@
 .Sh DESCRIPTION
 .Nm
 displays the contents of the system message buffer.
+.Pp
+Access to the live kernel message buffer may be restricted to privileged
+users by system policy.
+When access is denied,
+.Nm
+will fail to read the buffer.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds

--- a/sys/kern/subr_log.c
+++ b/sys/kern/subr_log.c
@@ -141,13 +141,13 @@ loginit(void)
 	    logsoftintr, NULL);
 
 	sysctl_createv(NULL, 0, NULL, NULL,
-		       CTLFLAG_PERMANENT,
+		       CTLFLAG_PERMANENT|CTLFLAG_PRIVATE,
 		       CTLTYPE_INT, "msgbufsize",
 		       SYSCTL_DESCR("Size of the kernel message buffer"),
 		       sysctl_msgbuf, 0, NULL, 0,
 		       CTL_KERN, KERN_MSGBUFSIZE, CTL_EOL);
 	sysctl_createv(NULL, 0, NULL, NULL,
-		       CTLFLAG_PERMANENT,
+		       CTLFLAG_PERMANENT|CTLFLAG_PRIVATE,
 		       CTLTYPE_INT, "msgbuf",
 		       SYSCTL_DESCR("Kernel message buffer"),
 		       sysctl_msgbuf, 0, NULL, 0,

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -1306,10 +1306,19 @@ secmodel_jail_system_cb(kauth_cred_t cred, kauth_action_t action,
 	if (!secmodel_jail_get_config(secmodel_jail_cred_id(cred), &config))
 		return KAUTH_RESULT_DEFER;
 
+	req = (enum kauth_system_req)(uintptr_t)arg0;
+
+	/*
+	 * Always deny private sysctl reads from jail context, regardless of
+	 * policy profile. This keeps private nodes (for example kern.msgbuf)
+	 * inaccessible to jailed credentials.
+	 */
+	if (action == KAUTH_SYSTEM_SYSCTL &&
+	    req == KAUTH_REQ_SYSTEM_SYSCTL_PRVT)
+		return KAUTH_RESULT_DENY;
+
 	if (config.jc_profile == JAIL_PROFILE_POLICY_LOW)
 		return KAUTH_RESULT_DEFER;
-
-	req = (enum kauth_system_req)(uintptr_t)arg0;
 
 	switch (action) {
 	case KAUTH_SYSTEM_MOUNT: /* Deny mounting/unmounting or mount reconfiguration inside jail. */
@@ -1351,7 +1360,6 @@ secmodel_jail_system_cb(kauth_cred_t cred, kauth_action_t action,
 		case KAUTH_REQ_SYSTEM_SYSCTL_ADD: /* Block runtime creation of sysctl nodes. */
 		case KAUTH_REQ_SYSTEM_SYSCTL_DELETE: /* Block runtime deletion of sysctl nodes. */
 		case KAUTH_REQ_SYSTEM_SYSCTL_MODIFY: /* Block writes to privileged sysctl values. */
-		case KAUTH_REQ_SYSTEM_SYSCTL_PRVT: /* Block reads of private/protected sysctls. */
 			return KAUTH_RESULT_DENY;
 		default:
 			return KAUTH_RESULT_DEFER;


### PR DESCRIPTION
### Motivation

- Prevent jailed processes from reading live kernel message-buffer sysctls by making those nodes private so system policy can block access. 
- Align `kern.msgbufsize` with the already-private `kern.msgbuf` to provide consistent protection for message-buffer controls. 
- Document that `dmesg` may fail for unprivileged users when access to the live kernel message buffer is denied by policy.

### Description

- Add `CTLFLAG_PRIVATE` to both `kern.msgbufsize` and `kern.msgbuf` in `sys/kern/subr_log.c` so the message-buffer-related sysctls are marked private. 
- Update `sbin/dmesg/dmesg.8` to note that access to the live kernel message buffer may be restricted and update the manpage date. 
- In `sys/secmodel/jail/secmodel_jail.c` move the `req` assignment earlier and unconditionally return `KAUTH_RESULT_DENY` when `action == KAUTH_SYSTEM_SYSCTL` and `req == KAUTH_REQ_SYSTEM_SYSCTL_PRVT`, and remove the now-redundant `KAUTH_REQ_SYSTEM_SYSCTL_PRVT` case from the profile-gated switch.

### Testing

- Inspected diffs with `git diff -- sys/kern/subr_log.c sbin/dmesg/dmesg.8 sys/secmodel/jail/secmodel_jail.c` to verify the changes. 
- Confirmed the `CTLFLAG_PRIVATE` additions by searching the tree with `rg -n "msgbufsize|CTLFLAG_PERMANENT\|CTLFLAG_PRIVATE" sys/kern/subr_log.c`. 
- Validated placement and surrounding context with `nl -ba sys/kern/subr_log.c | sed -n '140,152p'` and similar `nl` excerpts for `secmodel_jail.c`. 
- Attempted `mandoc -Tlint sbin/dmesg/dmesg.8` for manpage linting but `mandoc` is not available in the environment, so linting could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d8e1994bc832a8f057609c480f3dc)