### PR TITLE
doc/specs: add jails-v2 developer guide and align specs/ops docs with implementation

### DIFF
--- a/doc/specs/netbsd-jails-developers-guide.txt
+++ b/doc/specs/netbsd-jails-developers-guide.txt
@@ -1,0 +1,307 @@
+NetBSD jails-v2 developer guide (implementation deep dive)
+===========================================================
+
+Status
+------
+This document is an implementation-oriented guide for the current jails-v2
+stack in this source tree. It explains what each layer does, how it is wired,
+and where to read the code first.
+
+Covered components:
+- secmodel_jail (kernel security model + jail-native resource accounting)
+- jailctl (sysctl transport + supervise/runtime adapter)
+- jailmgr (host orchestration shell tool)
+- svcmgr (inside-jail multi-service runner)
+
+
+1. NetBSD context and design placement
+--------------------------------------
+The stack is intentionally NetBSD-native:
+- policy and enforcement in the kernel via secmodel/kauth
+- narrow userland tools that mostly transport intent
+- host-root controlled lifecycle and logging via existing syslogd paths
+
+Relevant code entry points:
+- Kernel model registration and lifecycle:
+  - sys/secmodel/jail/secmodel_jail.c
+  - sys/secmodel/jail/jail.h
+- Shared jail ABI types/flags:
+  - sys/sys/jail.h
+- Userland control/orchestration:
+  - usr.sbin/jailctl/jailctl.c
+  - usr.sbin/jailmgr/jailmgr
+  - usr.sbin/svcmgr/svcmgr.c
+
+
+2. secmodel_jail internals (kernel)
+-----------------------------------
+2.1 Core data model
+- `struct jail_entry` is the authoritative in-kernel object per jail:
+  identity, metadata (name/root), profile, configured limits, reserved ports,
+  and live counters (`je_*` fields).
+- Global state:
+  - list head (`jail_list`)
+  - model lock (`jail_lock`)
+  - monotonic id allocator (`jail_next_id`, host remains id 0)
+  - 1 Hz callout for CPU accounting (`jail_cpu_account_ch`)
+
+Read first:
+- struct definitions and globals near top of
+  `sys/secmodel/jail/secmodel_jail.c`.
+
+2.2 Control plane via sysctl
+secmodel_jail exports the control ABI under `security.models.jail.*`.
+
+Handlers:
+- `id`: read current credential jail id / write to request jail entry
+  (host-root only for write).
+- `create`: structured write-only input (`struct jail_create`), validates
+  flags and payload invariants, allocates new jail id, and returns it.
+- `destroy`: remove empty jail object by id.
+- `list`: snapshot array of `struct jail_info` with policy + counters.
+
+Implementation notes:
+- `create` rejects unknown flags, zero-valued configured limits, duplicated or
+  invalid reserved ports, and partial CPU tuple (quota xor period).
+- profile defaults to HIGH when not explicitly set.
+- `destroy` refuses if procs/zombies still reference the jail.
+
+Read first:
+- `secmodel_jail_sysctl_id`
+- `secmodel_jail_sysctl_create`
+- `secmodel_jail_sysctl_destroy`
+- `secmodel_jail_sysctl_list`
+
+2.3 Enforcement model: kauth listeners
+Listeners are registered for process, cred, system, and network scopes.
+
+Process scope:
+- `KAUTH_PROCESS_CANSEE` and `KAUTH_PROCESS_SIGNAL` enforce same-jail boundary
+  (except host-root bypass).
+- `KAUTH_PROCESS_FORK` enforces process limit and CPU over-quota fork throttling.
+
+Credential scope:
+- `KAUTH_CRED_INIT` initializes jid to host (0).
+- `KAUTH_CRED_COPY` preserves source jid.
+
+System scope:
+- jailed credentials are constrained for host-wide admin classes
+  (mount/module/reboot/time/sysctl-write families and more), depending on
+  profile (`low`, `medium`, `high`).
+- medium keeps SysV IPC admin requests deferred where high denies.
+
+Network scope:
+- bind checks apply per-port reservation ownership.
+- if port is reserved by any jail, only owning jail credentials may bind.
+- ephemeral port 0 is intentionally not reservation-restricted.
+
+Read first:
+- `secmodel_jail_process_cb`
+- `secmodel_jail_cred_cb`
+- `secmodel_jail_system_cb`
+- `secmodel_jail_network_cb`
+
+2.4 Resource controls and accounting
+Active jail-scoped controls:
+- memory.max: admit + set-current hooks
+- fd.max: admit + set-current hooks
+- sockbuf.max: charge + uncharge hooks
+- proc.max: enforced at fork gate
+- cpu.quota/cpu.period: accounted in callout window + scheduler/fork gate
+
+Important details:
+- limit value 0 means unlimited.
+- `secmodel_jail_within_limit(current, delta, limit)` provides common overflow-
+  safe gate.
+- CPU accounting samples per-process uticks/sticks/iticks at 1 Hz,
+  computes per-window usage, sets over-quota state, and increments throttle
+  counters when transitions/denials happen.
+
+Kernel integrations calling secmodel eval:
+- memory hooks in UVM (`sys/uvm/uvm_mmap.c`, `sys/uvm/uvm_unix.c`)
+- fd hooks in descriptor allocation paths (`sys/kern/kern_descrip.c`)
+- socket buffer hooks (`sys/kern/uipc_socket2.c`)
+- scheduler run gate (`sys/kern/kern_runq.c`)
+
+Eval API surface (brokered by secmodel core):
+- `cred-matches`
+- `memory-admit`, `memory-set-current`
+- `fd-admit`, `fd-set-current`
+- `sockbuf-charge`, `sockbuf-uncharge`
+- `cpu-can-run`
+
+Read first:
+- `sys/secmodel/jail/jail.h` eval constants + arg structs
+- `secmodel_jail_eval` dispatcher
+
+2.5 Concurrency and lifecycle
+- Most jail state is under `jail_lock`.
+- process table walks coordinate `proc_lock` + `jail_lock`.
+- module init path:
+  1) secmodel registration (`secmodel_register`)
+  2) sysctl tree + key init
+  3) kauth listeners start
+  4) CPU callout scheduled
+- module stop path removes listeners and callout.
+
+
+3. jailctl internals (userland control adapter)
+-----------------------------------------------
+3.1 ABI boundary and object translation
+- `jailctl create` builds a `struct jail_create` and writes it to
+  `security.models.jail.create`.
+- `jailctl list` reads `security.models.jail.list` and prints table output.
+- `jailctl destroy` writes target id to `security.models.jail.destroy`.
+- `jailctl exec/supervise` writes target id through `security.models.jail.id`
+  before `chroot + chdir + execvp` in child path.
+
+`jailctl` intentionally performs very little policy logic; validation is mostly
+argument sanity and forwarding into kernel ABI fields.
+
+3.2 Supervise mode
+`jailctl supervise` is a detached monitor process that:
+- daemonizes
+- starts one command inside target jail
+- captures child stdout/stderr using pipes
+- forwards line-oriented logs to syslog with separate priorities
+- restarts the command on exit with exponential backoff (1..10s)
+- resets backoff if runtime lasted >= 30s
+- supports clean shutdown on TERM/INT/QUIT
+
+This is the host-side glue used by `jailmgr start`.
+
+3.3 Stats output
+`jailctl stats` exposes `security.models.jail.list` counters as:
+- human table mode
+- verbose table mode
+- Prometheus text format (`-P`), optional HTTP header (`-h`)
+
+Read first:
+- command dispatch in `main()` and `usage()`
+- `jail_fetch_list`
+- `jail_supervise_loop`
+- `jail_run_monitor_once`
+- `jail_stats`
+
+
+4. jailmgr internals (host orchestration)
+-----------------------------------------
+4.1 Implementation style
+- `jailmgr` is a POSIX shell tool (`usr.sbin/jailmgr/jailmgr`) with
+  explicit command orchestration around `jailctl`, mounts, and config files.
+- global config: `/etc/jailmgr.conf`
+- per-jail config: `${JAIL_DATA_DIR}/<name>/jail.conf`
+
+4.2 Bootstrap path
+`bootstrap` performs platform preparation:
+- ensures root/tools
+- ensures secmodel_jail module is loaded now (`modload secmodel_jail`)
+- persists module autoload line in `/etc/modules.conf`
+- fetches base/etc sets and builds shared base layer
+- writes default `/etc/jailmgr.conf` if absent
+- ensures rc.conf has `jailmgr=NO` default entry
+
+4.3 Filesystem composition
+Per jail:
+- read-only null mount of shared base to `<root>`
+- writable null mount of jail data directory to `<root>/.data`
+- shared base contains symlinks (`/etc`, `/var`, `/tmp`, `/home`, `/root`,
+  `/usr/pkg`, dotfiles) into `/.data/...`
+- optional jail-local `/dev` tmpfs + `MAKEDEV`, optional `ptyfs` on `/dev/pts`
+
+This yields immutable base with writable per-jail state.
+
+4.4 Lifecycle commands
+- `create`: create dirs + etc seed + persist jail.conf defaults/options.
+- `start`: mount root, `jailctl create`, then `jailctl supervise`.
+- `stop`: terminate supervise monitor, destroy jail id, unmount.
+- `restart`: stop then start.
+- `start --all` / `stop --all`: operate on autostart-enabled jails.
+- `apply [--ephemeral]`: execute script in jail via `jailctl exec`.
+- `status` and `list`: reporting helpers over config and runtime.
+
+Policy forwarding model:
+- persisted `JAIL_CREATE_*` fields are mapped 1:1 to `jailctl create` flags
+  with no unit conversion or hidden defaults.
+
+Read first:
+- `start_jail_internal`
+- `create_jail`
+- `mount_jail_root` / `umount_jail_root`
+- `ensure_secmodel_jail`
+- `apply_jail_script`
+
+
+5. svcmgr internals (inside-jail process bundle runner)
+-------------------------------------------------------
+5.1 Config format
+Default config file is `/etc/svcmgr.conf`.
+Each non-empty, non-comment line is:
+
+  <tag><whitespace><command...>
+
+Parser preserves the full command tail after first separator.
+
+5.2 Runtime model
+- one child per configured service (`/bin/sh -c <command>`)
+- each child runs in own session/process-group (`setsid`)
+- monitor event loop polls stdout/stderr pipes from all services
+- output is transformed to line records and emitted as:
+
+  <tag> <line>
+
+- stdout/stderr are line-buffered (`setvbuf(..., _IOLBF, ...)`) and flushed
+  per emitted line
+- on TERM/INT/QUIT: send SIGTERM to all running groups, wait up to 5s,
+  then SIGKILL remaining groups
+- no automatic respawn; service restarts are delegated to outer supervisor
+  layer (typically `jailctl supervise`)
+
+Read first:
+- `load_config`
+- `spawn_service`
+- `monitor_services`
+- `process_stream_chunk`
+
+
+6. End-to-end control/data flow
+-------------------------------
+Create/start path:
+1) jailmgr prepares mounts + config
+2) jailmgr calls `jailctl create` (structured create payload)
+3) kernel secmodel_jail allocates id + stores policy
+4) jailmgr calls `jailctl supervise`
+5) supervise enters jail and executes command (often svcmgr)
+6) application logs -> svcmgr tag lines (if used) -> jailctl syslog forward
+
+Runtime enforcement path:
+- kernel subsystems call `secmodel_eval(...SECMODEL_JAIL_ID...)` where wired
+- secmodel_jail admits/denies and updates counters centrally
+
+
+7. Source-map quick reference
+-----------------------------
+Kernel and ABI:
+- `sys/secmodel/jail/secmodel_jail.c`
+- `sys/secmodel/jail/jail.h`
+- `sys/sys/jail.h`
+
+Kernel call sites into eval hooks:
+- `sys/uvm/uvm_mmap.c`
+- `sys/uvm/uvm_unix.c`
+- `sys/kern/kern_descrip.c`
+- `sys/kern/uipc_socket2.c`
+- `sys/kern/kern_runq.c`
+
+Userland tools:
+- `usr.sbin/jailctl/jailctl.c`
+- `usr.sbin/jailctl/jailctl.8`
+- `usr.sbin/jailmgr/jailmgr`
+- `usr.sbin/jailmgr/jailmgr.8`
+- `usr.sbin/svcmgr/svcmgr.c`
+- `usr.sbin/svcmgr/svcmgr.8`
+
+Existing specs/ops docs:
+- `doc/specs/netbsd-jails-specification.txt`
+- `doc/specs/netbsd-jails-operations-guide.txt`
+

--- a/doc/specs/netbsd-jails-operations-guide.txt
+++ b/doc/specs/netbsd-jails-operations-guide.txt
@@ -7,6 +7,7 @@ This document explains the operational model for the jails-v2 stack from a
 DevOps/SRE perspective. It is intentionally practical and complements the
 formal specification in:
 - doc/specs/netbsd-jails-specification.txt
+- doc/specs/netbsd-jails-developers-guide.txt
 
 Scope covered here:
 - secmodel_jail (kernel policy and accounting)
@@ -98,6 +99,7 @@ Operational takeaway:
 - Optional helper used as the single supervised entrypoint inside one jail.
 - Reads /etc/svcmgr.conf and starts multiple services in parallel.
 - Prefixes each emitted line with a service tag and flushes per line.
+- Does not respawn services itself; restart is delegated to outer supervision.
 
 Operational takeaway:
 - Use svcmgr when one jail intentionally contains a small process bundle.
@@ -168,6 +170,7 @@ Example for mantisbt jail:
 5.4 Start and verify
 - Start jails via jailmgr start <name> (or --all with autostart).
 - Verify runtime with jailctl list/status paths.
+- Export counters with jailctl stats (human or Prometheus mode).
 - Verify host syslog contains expected tagged lines.
 
 

--- a/doc/specs/netbsd-jails-specification.txt
+++ b/doc/specs/netbsd-jails-specification.txt
@@ -8,6 +8,7 @@ this tree:
 - secmodel_jail (kernel policy model)
 - jailctl (low-level operational interface)
 - jailmgr (multi-jail provisioning/operations)
+- svcmgr (inside-jail service bundle launcher)
 
 This implementation is referred to as "jails-v2".
 The design focus of jails-v2 is jail-native resource control and accounting.
@@ -40,11 +41,17 @@ jails-v2 jail-scoped control path.
   - creates/destroys/lists jails
   - enters jails and executes workloads
   - provides supervised process mode with syslog forwarding
+  - exports runtime counters as table or Prometheus metrics via stats
   - passes jail-native resource policy at create time
 - jailmgr:
   - prepares base filesystem layout for many jails
   - persists per-jail configuration and automates start/stop/restart
+  - supports host-driven in-jail script execution via apply
   - maps persisted policy values 1:1 into jailctl create options
+- svcmgr:
+  - starts multiple tagged services from config inside one jail
+  - multiplexes service stdout/stderr into tagged line output
+  - performs coordinated TERM/KILL shutdown without auto-respawn
 
 
 3. secmodel_jail kernel specification
@@ -148,6 +155,7 @@ jails-v2 jail-scoped control path.
 - exec <jail-id|name> [command [args...]]
 - supervise [logging flags] <jail-id|name> <command> [args...]
 - list
+- stats [-P] [-v] [-h]
 
 4.3 Resource options
 - -q and -c configure cpu.quota/cpu.period and must be provided together.
@@ -161,6 +169,11 @@ jails-v2 jail-scoped control path.
 4.5 Supervision model
 - supervise daemonizes and forwards stdout/stderr to syslog.
 - restart strategy uses exponential backoff with cap.
+
+4.6 Metrics model
+- stats reads the same jail_info snapshot used by list.
+- default mode prints human-oriented tabular counters.
+- -P emits Prometheus text exposition; -h prepends HTTP 200 headers.
 
 
 5. jailmgr specification
@@ -178,15 +191,38 @@ jails-v2 jail-scoped control path.
 - Persists optional create-time CPU/memory/proc/fd/sockbuf/profile/ports.
 - Forwards persisted settings unchanged to jailctl create on start.
 
-5.4 Runtime coupling note
+5.4 Additional lifecycle operations
+- apply executes shell scripts inside a jail via jailctl exec
+  (optionally with ephemeral start/stop behavior).
+- list and status provide lightweight fleet/runtime visibility helpers.
+
+5.5 Runtime coupling note
 - The management path is intentionally explicit about secmodel_jail dependency.
 - If secmodel_jail is absent, jailctl sysctl operations fail; there is no
   implicit fallback mode that emulates jail behavior via generic defaults.
 
 
-6. Integration points and coupling
+6. svcmgr specification
+-----------------------
+6.1 Scope
+- Minimal inside-jail service launcher for small multi-process bundles.
+
+6.2 Configuration and execution
+- Reads `/etc/svcmgr.conf` by default.
+- Each configured line is `<tag> <command...>`.
+- Spawns each command under `/bin/sh -c` with independent session/group.
+
+6.3 Stream handling and shutdown
+- Polls stdout/stderr pipes for all services and emits `tag + line` records.
+- Flushes line-buffered output immediately.
+- On TERM/INT/QUIT sends SIGTERM to all running service groups, then SIGKILL
+  after grace timeout for holdouts.
+- No built-in service respawn loop; outer jail-level supervisor handles restarts.
+
+
+7. Integration points and coupling
 ----------------------------------
-6.1 Resource-control integrations
+7.1 Resource-control integrations
 - Resource admission/charging updates are integrated through secmodel eval
   requests consumed by secmodel_jail:
   - memory-admit / memory-set-current
@@ -196,14 +232,14 @@ jails-v2 jail-scoped control path.
 - These are capability-style integration points: callers query secmodel_jail
   through a broker path rather than embedding policy logic locally.
 
-6.2 Coupling properties
+7.2 Coupling properties
 - Policy ownership remains centralized in secmodel_jail.
 - Userland tools remain thin and mostly transport configuration/commands.
 - Failure mode without secmodel_jail is explicit operation failure, not silent
   behavior change.
 
 
-7. Operational summary
+8. Operational summary
 ----------------------
 - Normal lifecycle:
   1) jailmgr create (or direct jailctl create)
@@ -213,7 +249,7 @@ jails-v2 jail-scoped control path.
 - Resource control in active code is jail-scoped and jail-native (jails-v2).
 
 
-8. Threat-model note
+9. Threat-model note
 --------------------
 - This model provides process-level containment and policy hardening but does
   not provide full virtualization guarantees.


### PR DESCRIPTION
### Motivation
- Provide an implementation-focused developer guide that explains how `secmodel_jail`, `jailctl`, `jailmgr` and `svcmgr` work end-to-end and where to read the code. 
- Bring the written specifications and operations guide into parity with the current implementation by documenting `svcmgr`, `jailctl stats` (Prometheus/human modes), and additional `jailmgr` lifecycle operations (`apply`, `list`, `status`).

### Description
- Added `doc/specs/netbsd-jails-developers-guide.txt`, an implementation deep-dive covering kernel data model, sysctl control plane, kauth enforcement listeners, resource admission/accounting, eval API surfaces, userland supervisors, and a source-map to the primary implementation files.
- Updated `doc/specs/netbsd-jails-specification.txt` to reflect the actual implementation by adding `svcmgr` to the stack scope, documenting `jailctl stats` and metrics exposition, adding `apply/list/status` to `jailmgr` lifecycle coverage, and adding a dedicated `svcmgr` specification section.
- Updated `doc/specs/netbsd-jails-operations-guide.txt` to reference the new developer guide and to clarify operational behavior (notably that `svcmgr` does not respawn services itself and `jailctl stats` can export Prometheus metrics).
- The documentation changes reference and were cross-checked against the implemented code paths in:
  - `sys/secmodel/jail/secmodel_jail.c` and `sys/secmodel/jail/jail.h`
  - `sys/sys/jail.h`
  - `usr.sbin/jailctl/jailctl.c`
  - `usr.sbin/jailmgr/jailmgr`
  - `usr.sbin/svcmgr/svcmgr.c`

### Testing
- Verified the new and modified docs renderable via line-oriented file reads using `sed -n` and `nl` to confirm content presence and structure; these commands completed successfully.
- Performed targeted repository searches (`rg`) to confirm the referenced symbols and files exist and match the described behavior; searches returned expected implementation locations.
- Reviewed diffs with `git diff` and validated the working tree state with `git status --short` to ensure the change set is self-contained; both checks succeeded.
- No unit tests were added or run (this change is documentation-only and was validated by the automated file inspections above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dbd366aac832aa1b38a400b956260)