### PR TITLE
Enforce CTLFLAG_PRIVATE authorization in sysctl_dispatch

### DIFF
--- a/sys/kern/kern_sysctl.c
+++ b/sys/kern/kern_sysctl.c
@@ -402,6 +402,15 @@ sysctl_dispatch(SYSCTLFN_ARGS)
 	fn = NULL;
 	error = sysctl_locate(l, name, namelen, &rnode, &ni);
 
+	/*
+	 * Enforce private-node read permissions on the final target even when
+	 * dispatching through a custom sysctl handler rather than sysctl_lookup().
+	 */
+	if (error == 0 && l != NULL && (rnode->sysctl_flags & CTLFLAG_PRIVATE) &&
+	    (error = kauth_authorize_system(l->l_cred, KAUTH_SYSTEM_SYSCTL,
+	    KAUTH_REQ_SYSTEM_SYSCTL_PRVT, NULL, NULL, NULL)) != 0)
+		goto out;
+
 	if (rnode->sysctl_func != NULL) {
 		/*
 		 * the node we ended up at has a function, so call it.  it can


### PR DESCRIPTION
### Motivation
- Ensure private sysctl nodes require proper authorization even when dispatching through a custom node handler rather than via `sysctl_lookup()`.

### Description
- After `sysctl_locate()` succeeds, check the resolved `rnode` for `CTLFLAG_PRIVATE` and call `kauth_authorize_system(l->l_cred, KAUTH_SYSTEM_SYSCTL, KAUTH_REQ_SYSTEM_SYSCTL_PRVT, NULL, NULL, NULL)`, returning the error if authorization fails.

### Testing
- Built the kernel and executed the sysctl regression tests; the build completed and the relevant sysctl tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e03a7f0c0832aa4fe097ee4c19aea)