### PR TITLE
secmodel: route secmodel_jail accounting updates via secmodel_setinfo

### DIFF
--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -960,11 +960,11 @@ fd_alloc(proc_t *p, int want, int *result)
 		    dt->dt_ff[i] == (fdfile_t *)fdp->fd_dfdfile[i]);
 		fd_checkmaps(fdp);
 		{
-			struct secmodel_jail_eval_set_current_args sca;
+			struct secmodel_jail_setinfo_set_current_args sca;
 			sca.cred = p->p_cred;
 			sca.current = fd_current + 1;
-			(void)secmodel_eval(SECMODEL_JAIL_ID,
-			    SECMODEL_JAIL_EVAL_FD_SET_CURRENT, &sca, NULL);
+			(void)secmodel_setinfo(SECMODEL_JAIL_ID,
+			    SECMODEL_JAIL_SETINFO_FD_SET_CURRENT, &sca);
 		}
 		mutex_exit(&fdp->fd_lock);
 		return 0;

--- a/sys/kern/uipc_socket2.c
+++ b/sys/kern/uipc_socket2.c
@@ -733,8 +733,8 @@ sbreserve(struct sockbuf *sb, u_long cc, struct socket *so)
 			struct secmodel_jail_eval_sockbuf_charge_args sba;
 			sba.cred = so->so_cred;
 			sba.bytes = cc - oldcc;
-			(void)secmodel_eval(SECMODEL_JAIL_ID,
-			    SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE, &sba, NULL);
+			(void)secmodel_setinfo(SECMODEL_JAIL_ID,
+			    SECMODEL_JAIL_SETINFO_SOCKBUF_UNCHARGE, &sba);
 		}
 		return 0;
 	}
@@ -742,8 +742,8 @@ sbreserve(struct sockbuf *sb, u_long cc, struct socket *so)
 		struct secmodel_jail_eval_sockbuf_charge_args sba;
 		sba.cred = so->so_cred;
 		sba.bytes = oldcc - cc;
-		(void)secmodel_eval(SECMODEL_JAIL_ID,
-		    SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE, &sba, NULL);
+		(void)secmodel_setinfo(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_SETINFO_SOCKBUF_UNCHARGE, &sba);
 	}
 	sb->sb_mbmax = uimin(cc * 2, sb_max);
 	if (sb->sb_lowat > sb->sb_hiwat)
@@ -770,8 +770,8 @@ sbrelease(struct sockbuf *sb, struct socket *so)
 		struct secmodel_jail_eval_sockbuf_charge_args sba;
 		sba.cred = so->so_cred;
 		sba.bytes = oldcc;
-		(void)secmodel_eval(SECMODEL_JAIL_ID,
-		    SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE, &sba, NULL);
+		(void)secmodel_setinfo(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_SETINFO_SOCKBUF_UNCHARGE, &sba);
 	}
 	sb->sb_mbmax = 0;
 }

--- a/sys/secmodel/jail/jail.h
+++ b/sys/secmodel/jail/jail.h
@@ -56,13 +56,17 @@ int secmodel_jail_cred_cb(kauth_cred_t, kauth_action_t, void *,
 
 bool secmodel_jail_cred_matches(kauth_cred_t, const char *);
 
+/*
+ * secmodel_jail eval operations: synchronous policy queries.
+ */
 #define SECMODEL_JAIL_EVAL_CRED_MATCHES "cred-matches"
 #define SECMODEL_JAIL_EVAL_MEMORY_ADMIT "memory-admit"
-#define SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT "memory-set-current"
+/* secmodel_jail setinfo operations: best-effort accounting updates. */
+#define SECMODEL_JAIL_SETINFO_MEMORY_SET_CURRENT "memory-set-current"
 #define SECMODEL_JAIL_EVAL_FD_ADMIT "fd-admit"
-#define SECMODEL_JAIL_EVAL_FD_SET_CURRENT "fd-set-current"
+#define SECMODEL_JAIL_SETINFO_FD_SET_CURRENT "fd-set-current"
 #define SECMODEL_JAIL_EVAL_SOCKBUF_CHARGE "sockbuf-charge"
-#define SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE "sockbuf-uncharge"
+#define SECMODEL_JAIL_SETINFO_SOCKBUF_UNCHARGE "sockbuf-uncharge"
 #define SECMODEL_JAIL_EVAL_CPU_CAN_RUN "cpu-can-run"
 
 struct secmodel_jail_eval_cred_matches_args {
@@ -76,12 +80,17 @@ struct secmodel_jail_eval_admit_args {
 	uint64_t delta;
 };
 
-struct secmodel_jail_eval_set_current_args {
+struct secmodel_jail_setinfo_set_current_args {
 	kauth_cred_t cred;
 	uint64_t current;
 };
 
 struct secmodel_jail_eval_sockbuf_charge_args {
+	kauth_cred_t cred;
+	uint64_t bytes;
+};
+
+struct secmodel_jail_setinfo_sockbuf_args {
 	kauth_cred_t cred;
 	uint64_t bytes;
 };

--- a/sys/secmodel/jail/secmodel_jail.c
+++ b/sys/secmodel/jail/secmodel_jail.c
@@ -1463,12 +1463,18 @@ secmodel_jail_cred_cb(kauth_cred_t cred, kauth_action_t action,
 	}
 }
 
+/*
+ * secmodel_jail_eval() handles only policy decisions that can succeed/fail.
+ *
+ * The complementary state/accounting updates are handled by
+ * secmodel_jail_setinfo(); keeping these paths separate makes call sites
+ * self-documenting and avoids conflating admission checks with telemetry.
+ */
 static int
 secmodel_jail_eval(const char *what, void *arg, void *ret)
 {
 	const struct secmodel_jail_eval_cred_matches_args *a;
 	const struct secmodel_jail_eval_admit_args *aa;
-	const struct secmodel_jail_eval_set_current_args *sca;
 	const struct secmodel_jail_eval_sockbuf_charge_args *sba;
 	const struct secmodel_jail_eval_cpu_can_run_args *cra;
 	bool *matchp;
@@ -1499,28 +1505,12 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcmp(what, SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT) == 0) {
-		if (arg == NULL)
-			return EINVAL;
-		sca = arg;
-		secmodel_jail_memory_set_current(sca->cred, sca->current);
-		return 0;
-	}
-
 	if (strcmp(what, SECMODEL_JAIL_EVAL_FD_ADMIT) == 0) {
 		if (arg == NULL || ret == NULL)
 			return EINVAL;
 		aa = arg;
 		okp = ret;
 		*okp = secmodel_jail_fd_admit(aa->cred, aa->current, aa->delta);
-		return 0;
-	}
-
-	if (strcmp(what, SECMODEL_JAIL_EVAL_FD_SET_CURRENT) == 0) {
-		if (arg == NULL)
-			return EINVAL;
-		sca = arg;
-		secmodel_jail_fd_set_current(sca->cred, sca->current);
 		return 0;
 	}
 
@@ -1533,20 +1523,51 @@ secmodel_jail_eval(const char *what, void *arg, void *ret)
 		return 0;
 	}
 
-	if (strcmp(what, SECMODEL_JAIL_EVAL_SOCKBUF_UNCHARGE) == 0) {
-		if (arg == NULL)
-			return EINVAL;
-		sba = arg;
-		secmodel_jail_sockbuf_uncharge(sba->cred, sba->bytes);
-		return 0;
-	}
-
 	if (strcmp(what, SECMODEL_JAIL_EVAL_CPU_CAN_RUN) == 0) {
 		if (arg == NULL || ret == NULL)
 			return EINVAL;
 		cra = arg;
 		okp = ret;
 		*okp = secmodel_jail_cpu_can_run(cra->cred);
+		return 0;
+	}
+
+	return ENOENT;
+}
+
+/*
+ * secmodel_jail_setinfo() receives best-effort runtime updates from other
+ * subsystems. These updates are intentionally side-effect free from an access
+ * control perspective: failure to deliver an update must not grant or deny a
+ * permission check.
+ */
+static int
+secmodel_jail_setinfo(const char *what, void *arg)
+{
+	const struct secmodel_jail_setinfo_set_current_args *sca;
+	const struct secmodel_jail_setinfo_sockbuf_args *sba;
+
+	if (strcmp(what, SECMODEL_JAIL_SETINFO_MEMORY_SET_CURRENT) == 0) {
+		if (arg == NULL)
+			return EINVAL;
+		sca = arg;
+		secmodel_jail_memory_set_current(sca->cred, sca->current);
+		return 0;
+	}
+
+	if (strcmp(what, SECMODEL_JAIL_SETINFO_FD_SET_CURRENT) == 0) {
+		if (arg == NULL)
+			return EINVAL;
+		sca = arg;
+		secmodel_jail_fd_set_current(sca->cred, sca->current);
+		return 0;
+	}
+
+	if (strcmp(what, SECMODEL_JAIL_SETINFO_SOCKBUF_UNCHARGE) == 0) {
+		if (arg == NULL)
+			return EINVAL;
+		sba = arg;
+		secmodel_jail_sockbuf_uncharge(sba->cred, sba->bytes);
 		return 0;
 	}
 
@@ -1565,7 +1586,7 @@ secmodel_jail_modcmd(modcmd_t cmd, void *arg)
 	case MODULE_CMD_INIT:
 		error = secmodel_register(&jail_sm,
 		    SECMODEL_JAIL_ID, SECMODEL_JAIL_NAME,
-		    NULL, secmodel_jail_eval, NULL);
+		    NULL, secmodel_jail_eval, secmodel_jail_setinfo);
 		if (error != 0)
 			printf("secmodel_jail_modcmd::init: "
 			    "secmodel_register returned %d\n", error);

--- a/sys/secmodel/secmodel.c
+++ b/sys/secmodel/secmodel.c
@@ -225,12 +225,43 @@ secmodel_unplug(secmodel_t sm)
 	return error;
 }
 
-/* XXX TODO */
+/*
+ * Push runtime information into a security model.
+ *
+ * This complements secmodel_eval(9):
+ * - secmodel_eval() is used for policy decisions ("may I?").
+ * - secmodel_setinfo() is used for state/accounting updates ("FYI: state changed").
+ *
+ * Return values intentionally mirror secmodel_eval() semantics:
+ * framework-level lookup/validation errors are returned as positive errno
+ * values, while callback-local errors are returned as negative errno values.
+ */
 int
-secmodel_setinfo(const char *id, void *v, int *err)
+secmodel_setinfo(const char *id, const char *what, void *arg)
 {
+	secmodel_t sm;
+	int error = 0;
 
-	return EOPNOTSUPP;
+	rw_enter(&secmodels_lock, RW_READER);
+	sm = secmodel_lookup(id);
+	if (sm == NULL) {
+		error = EINVAL;
+		goto out;
+	}
+
+	if (sm->sm_setinfo == NULL) {
+		error = ENOENT;
+		goto out;
+	}
+
+	error = sm->sm_setinfo(what, arg);
+	/* pass error from a secmodel(9) callback as a negative value */
+	error = -error;
+
+ out:
+	rw_exit(&secmodels_lock);
+
+	return error;
 }
 
 int

--- a/sys/secmodel/secmodel.h
+++ b/sys/secmodel/secmodel.h
@@ -40,7 +40,7 @@ void secmodel_init(void);
  * or setting information.
  */
 typedef int (*secmodel_eval_t)(const char *, void *, void *);
-typedef int (*secmodel_setinfo_t)(void *); /* XXX TODO */
+typedef int (*secmodel_setinfo_t)(const char *, void *);
 
 /*
  * Secmodel entry.
@@ -61,5 +61,5 @@ int secmodel_deregister(secmodel_t);
 int secmodel_nsecmodels(void);
 
 int secmodel_eval(const char *, const char *, void *, void *);
-int secmodel_setinfo(const char *, void *, int *); /* XXX TODO */
+int secmodel_setinfo(const char *, const char *, void *);
 #endif /* !_SECMODEL_SECMODEL_H_ */

--- a/sys/uvm/uvm_mmap.c
+++ b/sys/uvm/uvm_mmap.c
@@ -464,11 +464,11 @@ sys_mmap(struct lwp *l, const struct sys_mmap_args *uap, register_t *retval)
 		}
 	}
 	if (error == 0) {
-		struct secmodel_jail_eval_set_current_args sca;
+		struct secmodel_jail_setinfo_set_current_args sca;
 		sca.cred = l->l_cred;
 		sca.current = (uint64_t)p->p_vmspace->vm_map.size;
-		(void)secmodel_eval(SECMODEL_JAIL_ID,
-		    SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT, &sca, NULL);
+		(void)secmodel_setinfo(SECMODEL_JAIL_ID,
+		    SECMODEL_JAIL_SETINFO_MEMORY_SET_CURRENT, &sca);
 	}
 
 	/* remember to add offset */

--- a/sys/uvm/uvm_unix.c
+++ b/sys/uvm/uvm_unix.c
@@ -136,21 +136,21 @@ sys_obreak(struct lwp *l, const struct sys_obreak_args *uap, register_t *retval)
 			return (error);
 		}
 		{
-			struct secmodel_jail_eval_set_current_args sca;
+			struct secmodel_jail_setinfo_set_current_args sca;
 			sca.cred = l->l_cred;
 			sca.current = (uint64_t)vm->vm_map.size;
-			(void)secmodel_eval(SECMODEL_JAIL_ID,
-			    SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT, &sca, NULL);
+			(void)secmodel_setinfo(SECMODEL_JAIL_ID,
+			    SECMODEL_JAIL_SETINFO_MEMORY_SET_CURRENT, &sca);
 		}
 		vm->vm_dsize += atop(nbreak - obreak);
 	} else {
 		uvm_deallocate(&vm->vm_map, nbreak, obreak - nbreak);
 		{
-			struct secmodel_jail_eval_set_current_args sca;
+			struct secmodel_jail_setinfo_set_current_args sca;
 			sca.cred = l->l_cred;
 			sca.current = (uint64_t)vm->vm_map.size;
-			(void)secmodel_eval(SECMODEL_JAIL_ID,
-			    SECMODEL_JAIL_EVAL_MEMORY_SET_CURRENT, &sca, NULL);
+			(void)secmodel_setinfo(SECMODEL_JAIL_ID,
+			    SECMODEL_JAIL_SETINFO_MEMORY_SET_CURRENT, &sca);
 		}
 		vm->vm_dsize -= atop(obreak - nbreak);
 	}


### PR DESCRIPTION
### Motivation
- `secmodel_eval()` was being used both for policy decisions and for write-only accounting updates, which conflates semantics and makes call sites ambiguous.
- Introduce a clear API separation so evaluations (admit/deny) remain synchronous queries while state/accounting updates use a best-effort path.

### Description
- Implemented `secmodel_setinfo(const char *id, const char *what, void *arg)` in `sys/secmodel/secmodel.c` and updated `sys/secmodel/secmodel.h` to expose `secmodel_setinfo_t` and the new prototype.
- Added a `secmodel_jail_setinfo()` dispatcher in `sys/secmodel/jail/secmodel_jail.c` and kept `secmodel_jail_eval()` focused strictly on decision-style queries.
- Introduced/renamed setinfo operation names and argument structs in `sys/secmodel/jail/jail.h` (`SECMODEL_JAIL_SETINFO_*`, `secmodel_jail_setinfo_set_current_args`, `secmodel_jail_setinfo_sockbuf_args`).
- Migrated pure accounting call sites to the new `secmodel_setinfo(...)` path in `sys/kern/kern_descrip.c`, `sys/kern/uipc_socket2.c`, `sys/uvm/uvm_unix.c`, and `sys/uvm/uvm_mmap.c` while keeping admit checks on `secmodel_eval(...)`.

### Testing
- Ran `git diff --check` against modified files, which reported no issues (success).
- Attempted `make -C sys/modules/secmodel_jail` which failed due to the environment using GNU `make` on a BSD-style Makefile (failure unrelated to the patch contents).
- Attempted `bmake -C sys/modules/secmodel_jail` but `bmake` is not available in the test environment (tooling unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a209d22b14832ab14ac452d1040579)