### PR TITLE
introduce cellweb: add a web operations UI for NetBSD Cells

### DIFF
--- a/usr.sbin/cellmgr/cellmgr
+++ b/usr.sbin/cellmgr/cellmgr
@@ -3425,9 +3425,18 @@ runtime_project_fields() {
 	' "${in_file}"
 }
 
+runtime_age_render_mode() {
+	if [ "${CELLMGR_CALL_CONTEXT:-}" = "ipc" ]; then
+		printf 'raw\n'
+		return
+	fi
+	printf 'human\n'
+}
+
 runtime_print_human_table() {
 	in_file=$1
-	awk -F '\t' -v cols="${RUNTIME_OUTPUT_FIELDS}" '
+	runtime_age_mode=$(runtime_age_render_mode)
+	awk -F '\t' -v cols="${RUNTIME_OUTPUT_FIELDS}" -v age_mode="${runtime_age_mode}" '
 		function is_bool_field(f) {
 			return (f == "running" || f == "desired_state" || f == "manifest" ||
 			    f == "rendered" || f == "apply_present")
@@ -3457,7 +3466,7 @@ runtime_print_human_table() {
 			return w "w" d "d"
 		}
 		function humanize(f, v) {
-			if (f == "age")
+			if (f == "age" && age_mode == "human")
 				return humanize_age(v)
 			if (is_bool_field(f)) {
 				if (v == "1")

--- a/usr.sbin/cellmgr/cellmgr.8
+++ b/usr.sbin/cellmgr/cellmgr.8
@@ -223,14 +223,14 @@ as
 Cell runtime and merged views include an
 .Dq age
 field derived from kernel cell creation time.
-In human-readable output,
+For direct CLI human-readable output,
 .Dq age
 is rendered using compact units (for example
 .Dq 42s ,
 .Dq 7m12s ,
 or
 .Dq 3h05m )
-while TSV output emits raw seconds.
+while TSV output and IPC-routed output emit raw seconds for client-side rendering.
 .Pp
 Optional create-time rlimits for supervise workloads can be configured per cell
 using

--- a/usr.sbin/cellmgr/lib/ipc.sh
+++ b/usr.sbin/cellmgr/lib/ipc.sh
@@ -122,13 +122,13 @@ ipc_execute_call() {
 	case "${ipc_mode}" in
 	0)
 		if [ "${ipc_env_enabled}" -eq 1 ]; then
-			if (export "${ipc_env_key}=${ipc_env_val}"; dispatch_command "$@") \
+			if (export "${ipc_env_key}=${ipc_env_val}" CELLMGR_CALL_CONTEXT=ipc; dispatch_command "$@") \
 			    > "${ipc_out_tmp}" 2> "${ipc_err_tmp}"; then
 				ipc_rc=0
 			else
 				ipc_rc=$?
 			fi
-		elif (dispatch_command "$@") > "${ipc_out_tmp}" 2> "${ipc_err_tmp}"; then
+		elif (export CELLMGR_CALL_CONTEXT=ipc; dispatch_command "$@") > "${ipc_out_tmp}" 2> "${ipc_err_tmp}"; then
 			ipc_rc=0
 		else
 			ipc_rc=$?
@@ -142,13 +142,13 @@ ipc_execute_call() {
 			ipc_rc=1
 		else
 			if [ "${ipc_env_enabled}" -eq 1 ]; then
-				if (export "${ipc_env_key}=${ipc_env_val}"; dispatch_command "$@") \
+				if (export "${ipc_env_key}=${ipc_env_val}" CELLMGR_CALL_CONTEXT=ipc; dispatch_command "$@") \
 				    < /dev/tty > /dev/tty 2> /dev/tty; then
 					ipc_rc=0
 				else
 					ipc_rc=$?
 				fi
-			elif (dispatch_command "$@") < /dev/tty > /dev/tty 2> /dev/tty; then
+			elif (export CELLMGR_CALL_CONTEXT=ipc; dispatch_command "$@") < /dev/tty > /dev/tty 2> /dev/tty; then
 				ipc_rc=0
 			else
 				ipc_rc=$?

--- a/usr.sbin/cellui/ui.c
+++ b/usr.sbin/cellui/ui.c
@@ -56,6 +56,81 @@ static void format_age_human(const char *src, char *out, size_t outsz) {
   (void)snprintf(out, outsz, "%lluw%llud", w, d);
 }
 
+static bool parse_u64_strict(const char *src, unsigned long long *out) {
+  char *endp;
+  unsigned long long v;
+
+  if (src == NULL || *src == '\0') {
+    return false;
+  }
+  v = strtoull(src, &endp, 10);
+  if (endp == src || *endp != '\0') {
+    return false;
+  }
+  *out = v;
+  return true;
+}
+
+static void format_bytes_human(const char *src, char *out, size_t outsz) {
+  static const char *units[] = {"KiB", "MiB", "GiB", "TiB"};
+  unsigned long long bytes;
+  double value;
+  int unit_idx = 0;
+
+  if (outsz == 0) {
+    return;
+  }
+  if (is_blank(src) || strcmp(src, "-") == 0) {
+    (void)snprintf(out, outsz, "-");
+    return;
+  }
+  if (!parse_u64_strict(src, &bytes)) {
+    (void)snprintf(out, outsz, "%s", src);
+    return;
+  }
+
+  if (bytes < 1024ULL) {
+    (void)snprintf(out, outsz, "%llu B", bytes);
+    return;
+  }
+
+  value = (double)bytes / 1024.0;
+  while (value >= 1024.0 && unit_idx < 3) {
+    value /= 1024.0;
+    unit_idx++;
+  }
+  (void)snprintf(out, outsz, "%.1f %s", value, units[unit_idx]);
+}
+
+static void format_backup_timestamp_iso(const char *src, char *out,
+                                        size_t outsz) {
+  const char *s;
+  size_t i;
+
+  if (outsz == 0) {
+    return;
+  }
+  s = blank_if(src, "");
+  if (*s == '\0' || strcmp(s, "-") == 0) {
+    (void)snprintf(out, outsz, "-");
+    return;
+  }
+
+  if (strlen(s) == 14) {
+    for (i = 0; i < 14; i++) {
+      if (s[i] < '0' || s[i] > '9') {
+        (void)snprintf(out, outsz, "%s", s);
+        return;
+      }
+    }
+    (void)snprintf(out, outsz, "%.4s-%.2s-%.2sT%.2s:%.2s:%.2s", s, s + 4,
+                   s + 6, s + 8, s + 10, s + 12);
+    return;
+  }
+
+  (void)snprintf(out, outsz, "%s", s);
+}
+
 static void draw_box(int y, int x, int h, int w) {
   int i;
 
@@ -170,7 +245,7 @@ static void table_row_string(const CellRow *row, int name_width, char *out,
   shorten_to(blank_if(row->procs, "0"), 6, procs, sizeof(procs));
   shorten_to(blank_if(row->cpu1s, "-"), 8, cpu1s, sizeof(cpu1s));
   shorten_to(blank_if(row->cpu10s, "-"), 8, cpu10s, sizeof(cpu10s));
-  format_age_human(blank_if(row->age, "0"), age, sizeof(age));
+  format_age_human(blank_if(row->age, ""), age, sizeof(age));
   shorten_to(blank_if(age, "-"), 8, age, sizeof(age));
   shorten_to(blank_if(row->autostart, "NO"), 6, autostart, sizeof(autostart));
   shorten_to(blank_if(row->refs, "-"), 7, refs, sizeof(refs));
@@ -834,6 +909,8 @@ void draw_ui(Model *m) {
       CellRow *row = selected_cell(m);
       char tmp[1024];
       char policy[1024];
+      char as_human[64];
+      char memory_human[64];
 
       if (row == NULL) {
         (void)snprintf(lines[0], sizeof(lines[0]), "No cell selected");
@@ -856,10 +933,12 @@ void draw_ui(Model *m) {
                        blank_if(row->autostart, "NO"));
         (void)snprintf(lines[6], sizeof(lines[6]), "Profile     : %s",
                        blank_if(row->create_profile, "-"));
+        format_bytes_human(blank_if(row->create_rlimit_as, ""), as_human,
+                           sizeof(as_human));
         (void)snprintf(policy, sizeof(policy), "ports=%s nofile=%s as=%s core=%s",
                        blank_if(row->create_reserved_ports, "-"),
                        blank_if(row->create_rlimit_nofile, "unlimited"),
-                       blank_if(row->create_rlimit_as, "unlimited"),
+                       blank_if(as_human, "unlimited"),
                        blank_if(row->create_rlimit_core, "unlimited"));
         shorten_to(policy, value_width, tmp, sizeof(tmp));
         format_prefixed(lines[7], sizeof(lines[7]), "Policy      : ", tmp);
@@ -867,9 +946,11 @@ void draw_ui(Model *m) {
                        blank_if(row->procs, "0"), blank_if(row->refs, "-"));
         (void)snprintf(lines[9], sizeof(lines[9]), "CPU1S/10S   : %s / %s",
                        blank_if(row->cpu1s, "-"), blank_if(row->cpu10s, "-"));
-        format_age_human(blank_if(row->age, "0"), tmp, sizeof(tmp));
+        format_age_human(blank_if(row->age, ""), tmp, sizeof(tmp));
+        format_bytes_human(blank_if(row->memory, ""), memory_human,
+                           sizeof(memory_human));
         (void)snprintf(lines[10], sizeof(lines[10]), "Age/Memory  : %s / %s",
-                       blank_if(tmp, "-"), blank_if(row->memory, "-"));
+                       blank_if(tmp, "-"), blank_if(memory_human, "-"));
         shorten_to(blank_if(row->supervise_cmd, "-"), value_width, tmp,
                    sizeof(tmp));
         format_prefixed(lines[11], sizeof(lines[11]), "Supervise   : ", tmp);
@@ -928,16 +1009,28 @@ void draw_ui(Model *m) {
             const char *base;
             char backup_line[1024];
             char short_name[768];
+            char ts_human[32];
+            char size_human[64];
+            int fixed_w;
+            int name_w;
 
             if ((size_t)idx >= m->backup_row_count || backup_start + i >= DETAIL_CONTENT_LINES) {
               break;
             }
             backup = &m->backup_rows[idx];
             base = archive_basename(backup->archive);
-            shorten_to(base, value_width - 26, short_name, sizeof(short_name));
-            (void)snprintf(backup_line, sizeof(backup_line), "  %s  %sB  %s",
-                           blank_if(backup->timestamp, "-"),
-                           blank_if(backup->size, "0"), short_name);
+            format_backup_timestamp_iso(blank_if(backup->timestamp, ""), ts_human,
+                                        sizeof(ts_human));
+            format_bytes_human(blank_if(backup->size, ""), size_human,
+                               sizeof(size_human));
+            fixed_w = (int)strlen(ts_human) + (int)strlen(size_human) + 6;
+            name_w = value_width - fixed_w;
+            if (name_w < 8) {
+              name_w = 8;
+            }
+            shorten_to(base, name_w, short_name, sizeof(short_name));
+            (void)snprintf(backup_line, sizeof(backup_line), "  %s  %s  %s",
+                           ts_human, size_human, short_name);
             (void)snprintf(lines[backup_start + i], sizeof(lines[backup_start + i]),
                            "%s", backup_line);
             if (idx == m->backup_cursor) {

--- a/usr.sbin/cellweb/Makefile
+++ b/usr.sbin/cellweb/Makefile
@@ -1,0 +1,42 @@
+GO?=go
+PROG?=cellweb
+PKG=./cmd/cellweb
+DISTDIR?=dist
+TARGET_OS?=netbsd
+TARGET_ARCH?=amd64
+CGO?=0
+OUT?=$(DISTDIR)/$(PROG)-$(TARGET_OS)-$(TARGET_ARCH)
+NETBSD_AMD64_BIN?=$(DISTDIR)/$(PROG)-netbsd-amd64
+NETBSD_AMD64_CGO_BIN?=$(DISTDIR)/$(PROG)-netbsd-amd64-cgo
+NETBSD_CC?=x86_64--netbsd-gcc
+
+.PHONY: all build build-host run fmt clean build-netbsd-amd64 build-netbsd-amd64-cgo
+
+all: build
+
+build:
+	mkdir -p $(DISTDIR)
+	@if [ "$(CGO)" = "1" ]; then \
+		GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=1 CC=$(NETBSD_CC) $(GO) build -trimpath -o $(OUT) $(PKG); \
+	else \
+		GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=0 $(GO) build -trimpath -o $(OUT) $(PKG); \
+	fi
+
+build-host:
+	$(GO) build -o $(PROG) $(PKG)
+
+build-netbsd-amd64:
+	$(MAKE) build TARGET_OS=netbsd TARGET_ARCH=amd64 CGO=0 OUT=$(NETBSD_AMD64_BIN)
+
+build-netbsd-amd64-cgo:
+	$(MAKE) build TARGET_OS=netbsd TARGET_ARCH=amd64 CGO=1 OUT=$(NETBSD_AMD64_CGO_BIN)
+
+run: build-host
+	./$(PROG)
+
+fmt:
+	$(GO) fmt $(PKG)
+
+clean:
+	rm -f ./$(PROG) $(NETBSD_AMD64_BIN) $(NETBSD_AMD64_CGO_BIN) $(OUT)
+	rmdir $(DISTDIR) 2>/dev/null || true

--- a/usr.sbin/cellweb/README.md
+++ b/usr.sbin/cellweb/README.md
@@ -1,0 +1,222 @@
+# cellweb
+
+`cellweb` is a standalone Go web server for operating NetBSD Cells through
+`cellmgr`, inspired by `cellui`.
+
+This directory is intentionally **not** wired into the global NetBSD build.
+Use the local `Makefile` only.
+
+## Features
+
+- Login against local users via PAM (NetBSD+cgo build)
+- Session-backed authenticated web UI
+- Persistent per-session `cellmgr ipc serve --stdio` bridge
+- Runs every `cellmgr` command as the authenticated local user
+- Cell operations: start, stop, restart, all-variants, `apply --all`
+- Storage operations: backup create/restore/delete for volumes and overlays
+- System view with NetBSD-native CLI telemetry (FFS filesystems, RAM/swap, interfaces, I/O)
+- Live dashboard with 4s refresh cadence
+
+## Build
+
+```sh
+cd usr.sbin/cellweb
+make build
+```
+
+Default output binary: `usr.sbin/cellweb/dist/cellweb-netbsd-amd64`
+
+If you need a host-native binary for local execution/testing:
+
+```sh
+make build-host
+```
+
+Output binary: `usr.sbin/cellweb/cellweb`
+
+### Cross-build on Linux for NetBSD/amd64
+
+```sh
+cd usr.sbin/cellweb
+make build-netbsd-amd64
+```
+
+Output binary: `usr.sbin/cellweb/dist/cellweb-netbsd-amd64`
+
+This target uses `CGO_ENABLED=0`, so PAM authentication is not available in that
+binary. For a PAM-capable cross build, use `make build-netbsd-amd64-cgo` with a
+working NetBSD cross C toolchain (configurable via `NETBSD_CC`).
+
+## Run
+
+```sh
+./cellweb
+```
+
+Default runtime profile:
+
+- TLS: enabled (`-tls=true`)
+- HTTPS UI bind: `0.0.0.0:18443` (`-https-listen`)
+- HTTP bootstrap/redirect bind: `0.0.0.0:18088` (`-http-listen`)
+- PKI dir: `/var/db/cellweb/pki`
+- Secure cookies mode: `auto`
+
+First-time trust typically starts from the HTTP bootstrap page URL shown in
+startup output (no TLS exception required), then continues on HTTPS.
+
+### Useful flags
+
+- `-tls true|false` (default `true`)
+- `-https-listen <ip:port>` (default `0.0.0.0:18443`)
+- `-http-listen <ip:port>` (default `0.0.0.0:18088`)
+- `-pam-service login` (default from `CELLWEB_PAM_SERVICE` or `login`)
+- `-admin-user <name>` + `-admin-pass <password>` (optional startup fallback credentials)
+- `-secure-cookies-mode auto|on|off` (default `auto`, use `on` to always force)
+- `-command-timeout 35s`
+
+## TLS (self-contained)
+
+`cellweb` can run without a reverse proxy and provide its own local PKI.
+TLS mode is now simple and explicit:
+
+- `-tls=true`: HTTPS is enabled.
+- `-tls=false`: plain HTTP only (main UI listens on `-http-listen`).
+
+### Modes
+
+- `selfsigned` is selected automatically when `-tls=true` and no `-tls-cert/-tls-key` are provided.
+- `manual` is selected automatically when both `-tls-cert` and `-tls-key` are provided.
+- `off` is selected automatically when `-tls=false`.
+
+### Plain HTTP mode
+
+```sh
+./cellweb -tls=false -http-listen 127.0.0.1:18088
+```
+
+In this mode, `-http-listen` is the main UI listener and no HTTPS bootstrap
+redirect listener is started.
+
+### Self-signed mode quick start
+
+```sh
+./cellweb
+```
+
+Equivalent explicit form:
+
+```sh
+./cellweb \
+  -tls true \
+  -https-listen 0.0.0.0:18443 \
+  -http-listen 0.0.0.0:18088 \
+  -pki-dir /var/db/cellweb/pki \
+  -secure-cookies-mode auto
+```
+
+Optional helper flags:
+
+- `-tls-san host.example.net,192.0.2.10`
+- `-tls-export-ca /tmp/cellweb-root-ca.crt`
+- `-http-listen 0.0.0.0:18088`
+
+When TLS is enabled in `selfsigned` mode, the HTTP listener on `-http-listen` serves a
+bootstrap page at `/bootstrap` (also reachable via `/`) with:
+
+- short trust instructions,
+- a Root CA download button (`/.well-known/ca.crt`),
+- and a button to continue to the HTTPS login page.
+
+Other HTTP paths are redirected to HTTPS.
+
+If your browser already cached HSTS for a hostname, use the server IP on the
+same HTTP bootstrap port/path to fetch the CA cert.
+
+When `-tls-san` is omitted, `cellweb` automatically adds `<hostname>.local`
+(short hostname, without domain) to SANs for mDNS-friendly access.
+
+### Hostname/SAN matching
+
+The URL host must be present in the server certificate SAN list.
+
+Example for `https://vhost.local:18443/`:
+
+```sh
+./cellweb \
+  -tls true \
+  -https-listen 127.0.0.1:18443 \
+  -http-listen 127.0.0.1:18088 \
+  -pki-dir /var/db/cellweb/pki \
+  -tls-san vhost.local,localhost,127.0.0.1
+```
+
+If SAN does not match the URL host, browsers show a domain error (for example
+Firefox: `SSL_ERROR_BAD_CERT_DOMAIN`).
+
+The generated root certificate subject is:
+
+- Organization: `Petermann Digital`
+- Common Name: `NetBSD Cells Appliance Local Root CA`
+
+To verify SAN entries:
+
+```sh
+openssl x509 -in /var/db/cellweb/pki/server.crt -noout -ext subjectAltName
+```
+
+### First-time browser trust bootstrap
+
+1. Open the HTTP bootstrap URL from startup output.
+2. Download the Root CA certificate from the bootstrap page.
+3. Compare the downloaded CA fingerprint with the startup fingerprint shown over SSH/console.
+4. Import the Root CA into browser/OS trust store.
+5. Open/reload `https://<host>:<port>/` and continue without warnings.
+
+Do not trust the downloaded CA without an out-of-band fingerprint check.
+
+In `selfsigned` mode, `cellweb` prints a compact startup bootstrap output to
+standard output: Root CA fingerprint + HTTP bootstrap URL.
+
+HSTS is enabled whenever TLS is enabled.
+
+If you only change SANs, `cellweb` can rotate `server.crt` while keeping the same
+`ca.crt`, so browser trust usually remains valid.
+
+If PAM is unavailable in the running binary (for example `CGO_ENABLED=0` cross-build),
+set startup admin credentials to enable login:
+
+```sh
+./cellweb -admin-user root -admin-pass 'strong-secret'
+```
+
+Equivalent env vars are also supported:
+
+- `CELLWEB_TLS`
+- `CELLWEB_HTTPS_LISTEN`
+- `CELLWEB_HTTP_LISTEN`
+- `CELLWEB_PKI_DIR`
+- `CELLWEB_TLS_CERT`
+- `CELLWEB_TLS_KEY`
+- `CELLWEB_TLS_SAN`
+- `CELLWEB_TLS_EXPORT_CA`
+- `CELLWEB_SECURE_COOKIES_MODE`
+- `CELLWEB_ADMIN_USER`
+- `CELLWEB_ADMIN_PASS`
+
+## Security model
+
+- Authentication uses PAM APIs (no direct passwd file parsing)
+- Optional startup admin credentials can be enabled when PAM is unavailable
+- Runtime commands are dispatched over `cellmgr` IPC frames (HELLO/CALL/RET/ERR)
+- Session cookie is `HttpOnly` + `SameSite=Strict`
+- Session `Secure` attribute is managed by `-secure-cookies-mode`
+- CSRF token required for state-changing API calls
+- Commands are executed without shell interpolation (`execve` argument vector)
+- Per-IP login throttling after repeated failures
+
+## Notes
+
+- Interactive `cellmgr cell shell` and `cellmgr cell edit` flows still belong to
+  TTY tooling (`cellui`) and are currently marked as non-HTTP actions.
+- If `cellweb` is not started as root, switching to another authenticated UID/GID
+  for command execution may fail with permission errors.

--- a/usr.sbin/cellweb/cellweb.8
+++ b/usr.sbin/cellweb/cellweb.8
@@ -1,0 +1,213 @@
+." $NetBSD$
+.Dd March 16, 2026
+.Dt CELLWEB 8
+.Os
+.Sh NAME
+.Nm cellweb
+.Nd web control UI for NetBSD Cells managed by cellmgr
+.Sh SYNOPSIS
+.Nm
+.Op Fl tls Ar true|false
+.Op Fl https-listen Ar addr
+.Op Fl http-listen Ar addr
+.Op Fl pki-dir Ar path
+.Op Fl tls-san Ar list
+.Op Fl tls-cert Ar path
+.Op Fl tls-key Ar path
+.Op Fl tls-export-ca Ar path
+.Op Fl secure-cookies-mode Ar mode
+.Op Fl pam-service Ar service
+.Op Fl admin-user Ar name
+.Op Fl admin-pass Ar secret
+.Op Fl command-timeout Ar duration
+.Op Fl refresh-seconds Ar seconds
+.Sh DESCRIPTION
+The
+.Nm
+utility provides a standalone HTTP/HTTPS web interface for operating NetBSD
+Cells through
+.Xr cellmgr 8 .
+It authenticates local users via PAM (when available), keeps per-session
+state, and executes runtime actions through
+.Cm "cellmgr ipc serve --stdio" .
+.Pp
+By default,
+.Nm
+starts with TLS enabled
+.Pq Fl tls=true .
+The main HTTPS listener binds to
+.Pa 0.0.0.0:18443
+.Pq Fl https-listen
+and the HTTP bootstrap/redirect listener binds to
+.Pa 0.0.0.0:18088
+.Pq Fl http-listen .
+When TLS is enabled and no certificate/key paths are provided,
+.Nm
+uses managed self-signed PKI material under
+.Pa /var/db/cellweb/pki .
+In self-signed mode, the HTTP listener serves a bootstrap page on
+.Pa /bootstrap
+.Pq and also .Pa /
+with trust instructions, Root CA download button, and HTTPS login link.
+The Root CA download endpoint is
+.Pa /.well-known/ca.crt .
+Other HTTP requests are redirected to HTTPS.
+.Pp
+In self-signed mode,
+.Nm
+prints compact trust bootstrap output to standard output with the root CA
+fingerprint and HTTP bootstrap URL.
+Operational logs are written to standard error.
+.Sh OPTIONS
+.Bl -tag -width "-secure-cookies-mode mode"
+.It Fl tls Ar true|false
+Enable or disable TLS for the main UI listener.
+Default is
+.Dq true .
+.It Fl https-listen Ar addr
+HTTPS listen address for the main UI when
+.Fl tls=true .
+Default is
+.Pa 0.0.0.0:18443 .
+.It Fl http-listen Ar addr
+HTTP listen address.
+When
+.Fl tls=true ,
+this listener serves bootstrap/redirect traffic.
+When
+.Fl tls=false ,
+this listener is used as the main UI listener.
+Default is
+.Pa 0.0.0.0:18088 .
+.It Fl pki-dir Ar path
+Directory for managed PKI material in
+.Dq selfsigned
+mode (selected automatically when
+.Fl tls=true
+and neither
+.Fl tls-cert
+nor
+.Fl tls-key
+is provided).
+Default is
+.Pa /var/db/cellweb/pki .
+.It Fl tls-san Ar list
+Comma-separated DNS/IP SAN entries for the server certificate.
+If omitted,
+.Nm
+adds
+.Dq localhost
+and, when available,
+.Dq <short-hostname>.local .
+.It Fl tls-cert Ar path
+Certificate file for manual TLS.
+.It Fl tls-key Ar path
+Private key file for manual TLS.
+.It Fl tls-export-ca Ar path
+Export managed root CA certificate to the given path.
+.It Fl secure-cookies-mode Ar auto|on|off
+Session cookie
+.Dq Secure
+policy.
+Default is
+.Dq auto .
+.It Fl pam-service Ar service
+PAM service name for login validation.
+Default is
+.Dq login .
+.It Fl admin-user Ar name
+Optional static fallback username.
+Must be combined with
+.Fl admin-pass .
+.It Fl admin-pass Ar secret
+Optional static fallback password.
+Must be combined with
+.Fl admin-user .
+.It Fl command-timeout Ar duration
+Timeout per
+.Xr cellmgr 8
+command.
+Default is
+.Dq 35s .
+.It Fl refresh-seconds Ar seconds
+Recommended UI refresh interval.
+Default is
+.Dq 4 .
+.El
+.Sh ENVIRONMENT
+The following variables are supported:
+.Bl -tag -width "CELLWEB_SECURE_COOKIES_MODE"
+.It Ev CELLWEB_TLS
+Default value for
+.Fl tls .
+.It Ev CELLWEB_HTTPS_LISTEN
+Default value for
+.Fl https-listen .
+.It Ev CELLWEB_HTTP_LISTEN
+Default value for
+.Fl http-listen .
+.It Ev CELLWEB_PKI_DIR
+Default value for
+.Fl pki-dir .
+.It Ev CELLWEB_TLS_CERT
+Default value for
+.Fl tls-cert .
+.It Ev CELLWEB_TLS_KEY
+Default value for
+.Fl tls-key .
+.It Ev CELLWEB_TLS_SAN
+Default value for
+.Fl tls-san .
+.It Ev CELLWEB_TLS_EXPORT_CA
+Default value for
+.Fl tls-export-ca .
+.It Ev CELLWEB_SECURE_COOKIES_MODE
+Default value for
+.Fl secure-cookies-mode .
+.It Ev CELLWEB_PAM_SERVICE
+Default value for
+.Fl pam-service .
+.It Ev CELLWEB_ADMIN_USER
+Default value for
+.Fl admin-user .
+.It Ev CELLWEB_ADMIN_PASS
+Default value for
+.Fl admin-pass .
+.El
+.Sh FILES
+.Bl -tag -width "/var/db/cellweb/pki/server.crt"
+.It Pa /var/db/cellweb/pki/ca.crt
+Managed root CA certificate.
+.It Pa /var/db/cellweb/pki/ca.key
+Managed root CA private key.
+.It Pa /var/db/cellweb/pki/server.crt
+Managed HTTPS server certificate.
+.It Pa /var/db/cellweb/pki/server.key
+Managed HTTPS server private key.
+.El
+.Sh EXAMPLES
+Default appliance-style startup:
+.Pp
+.Dl CELLWEB_ADMIN_USER=root CELLWEB_ADMIN_PASS=secret cellweb
+.Pp
+Manual TLS mode:
+.Pp
+.Dl cellweb -tls=true -https-listen 0.0.0.0:18443 -http-listen 0.0.0.0:18088 -tls-cert /etc/certs/cellweb.crt -tls-key /etc/certs/cellweb.key
+.Pp
+Plain HTTP mode:
+.Pp
+.Dl cellweb -tls=false -http-listen 127.0.0.1:18088
+.Sh EXIT STATUS
+.Ex -std
+.Sh SEE ALSO
+.Xr cellmgr 8 ,
+.Xr cellui 8 ,
+.Xr httpd 8
+.Sh HISTORY
+The
+.Nm
+utility first appeared in an unofficial patch set for
+.Nx
+11.0 .
+.Sh AUTHORS
+.An Matthias Petermann Aq Mt mp@petermann-digital.de

--- a/usr.sbin/cellweb/cmd/cellweb/auth_pam_netbsd.go
+++ b/usr.sbin/cellweb/cmd/cellweb/auth_pam_netbsd.go
@@ -1,0 +1,116 @@
+//go:build netbsd && cgo
+
+package main
+
+/*
+#cgo LDFLAGS: -lpam
+#include <stdlib.h>
+#include <security/pam_appl.h>
+
+typedef struct {
+	const char *password;
+} cellweb_pam_data;
+
+static int cellweb_pam_conv(int num_msg, const struct pam_message **msg,
+	struct pam_response **resp, void *appdata_ptr)
+{
+	cellweb_pam_data *data = (cellweb_pam_data *)appdata_ptr;
+	struct pam_response *responses = calloc((size_t)num_msg, sizeof(struct pam_response));
+	if (responses == NULL) {
+		return PAM_CONV_ERR;
+	}
+
+	for (int i = 0; i < num_msg; i++) {
+		switch (msg[i]->msg_style) {
+		case PAM_PROMPT_ECHO_OFF:
+		case PAM_PROMPT_ECHO_ON:
+			responses[i].resp = strdup(data->password);
+			if (responses[i].resp == NULL) {
+				for (int j = 0; j < i; j++) {
+					free(responses[j].resp);
+				}
+				free(responses);
+				return PAM_CONV_ERR;
+			}
+			responses[i].resp_retcode = 0;
+			break;
+		case PAM_ERROR_MSG:
+		case PAM_TEXT_INFO:
+			responses[i].resp = NULL;
+			responses[i].resp_retcode = 0;
+			break;
+		default:
+			for (int j = 0; j <= i; j++) {
+				free(responses[j].resp);
+			}
+			free(responses);
+			return PAM_CONV_ERR;
+		}
+	}
+
+	*resp = responses;
+	return PAM_SUCCESS;
+}
+
+static int cellweb_pam_auth(const char *service, const char *username, const char *password)
+{
+	pam_handle_t *pamh = NULL;
+	cellweb_pam_data data = { password };
+	struct pam_conv conv = { cellweb_pam_conv, &data };
+	int rc = pam_start(service, username, &conv, &pamh);
+	if (rc != PAM_SUCCESS) {
+		if (pamh != NULL) {
+			pam_end(pamh, rc);
+		}
+		return rc;
+	}
+
+	rc = pam_authenticate(pamh, 0);
+	if (rc == PAM_SUCCESS) {
+		rc = pam_acct_mgmt(pamh, 0);
+	}
+
+	pam_end(pamh, rc);
+	return rc;
+}
+*/
+import "C"
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"unsafe"
+)
+
+type pamAuthenticator struct {
+	service string
+}
+
+func newPAMAuthenticator(service string) authenticator {
+	if strings.TrimSpace(service) == "" {
+		service = "login"
+	}
+	return pamAuthenticator{service: service}
+}
+
+func (p pamAuthenticator) Authenticate(ctx context.Context, username, password string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	cService := C.CString(p.service)
+	cUser := C.CString(username)
+	cPass := C.CString(password)
+	defer C.free(unsafe.Pointer(cService))
+	defer C.free(unsafe.Pointer(cUser))
+	defer C.free(unsafe.Pointer(cPass))
+
+	rc := C.cellweb_pam_auth(cService, cUser, cPass)
+	if rc != C.PAM_SUCCESS {
+		return fmt.Errorf("pam authentication failed (%d)", int(rc))
+	}
+	return nil
+}

--- a/usr.sbin/cellweb/cmd/cellweb/auth_pam_stub.go
+++ b/usr.sbin/cellweb/cmd/cellweb/auth_pam_stub.go
@@ -1,0 +1,23 @@
+//go:build !netbsd || !cgo
+
+package main
+
+import (
+	"context"
+	"errors"
+)
+
+type unsupportedAuthenticator struct{}
+
+func newPAMAuthenticator(_ string) authenticator {
+	return unsupportedAuthenticator{}
+}
+
+func (unsupportedAuthenticator) Authenticate(ctx context.Context, _, _ string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	return errors.New("PAM authentication is only available on NetBSD builds with cgo enabled")
+}

--- a/usr.sbin/cellweb/cmd/cellweb/main.go
+++ b/usr.sbin/cellweb/cmd/cellweb/main.go
@@ -1,0 +1,2740 @@
+//go:build unix
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"embed"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	sessionCookieName      = "cellweb_session"
+	defaultSessionIdleTTL  = 30 * time.Minute
+	defaultSessionMaxTTL   = 10 * time.Hour
+	defaultCommandTimeout  = 35 * time.Second
+	defaultRefreshInterval = 4
+	trendHistoryPoints     = 72
+	maxJSONBodyBytes       = 1 << 20
+	maxOutputBytes         = 512 * 1024
+	ipcProtocolVersion     = 1
+	ipcMaxPayloadBytes     = 64 * 1024 * 1024
+)
+
+var (
+	namePattern    = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	archivePattern = regexp.MustCompile(`^[A-Za-z0-9._/:-]+$`)
+	ifMTUPattern   = regexp.MustCompile(`\bmtu\s+(\d+)\b`)
+	bootSecPattern = regexp.MustCompile(`sec\s*=\s*([0-9]+)`)
+)
+
+//go:embed web/*
+var webAssets embed.FS
+
+type identity struct {
+	Username string
+	UID      uint32
+	GID      uint32
+	Groups   []uint32
+	HomeDir  string
+}
+
+type session struct {
+	ID        string
+	CSRFToken string
+	Identity  identity
+	CreatedAt time.Time
+	SeenAt    time.Time
+	bridgeMu  sync.Mutex
+	bridge    *ipcBridge
+}
+
+type sessionStore struct {
+	mu      sync.RWMutex
+	idleTTL time.Duration
+	maxTTL  time.Duration
+	items   map[string]*session
+}
+
+func newSessionStore(idleTTL, maxTTL time.Duration) *sessionStore {
+	return &sessionStore{
+		idleTTL: idleTTL,
+		maxTTL:  maxTTL,
+		items:   make(map[string]*session),
+	}
+}
+
+func (s *sessionStore) create(id identity) (*session, error) {
+	sid, err := randomToken(32)
+	if err != nil {
+		return nil, err
+	}
+	csrf, err := randomToken(32)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	sess := &session{
+		ID:        sid,
+		CSRFToken: csrf,
+		Identity:  id,
+		CreatedAt: now,
+		SeenAt:    now,
+	}
+
+	s.mu.Lock()
+	s.items[sid] = sess
+	s.mu.Unlock()
+
+	return sess, nil
+}
+
+func (s *sessionStore) get(sessionID string) (*session, bool) {
+	now := time.Now().UTC()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.items[sessionID]
+	if !ok {
+		return nil, false
+	}
+	if now.Sub(sess.CreatedAt) > s.maxTTL || now.Sub(sess.SeenAt) > s.idleTTL {
+		delete(s.items, sessionID)
+		closeSessionBridge(sess)
+		return nil, false
+	}
+	sess.SeenAt = now
+	return sess, true
+}
+
+func (s *sessionStore) delete(sessionID string) {
+	s.mu.Lock()
+	sess := s.items[sessionID]
+	delete(s.items, sessionID)
+	s.mu.Unlock()
+	closeSessionBridge(sess)
+}
+
+func (s *sessionStore) cleanupExpired() {
+	now := time.Now().UTC()
+	expired := make([]*session, 0)
+	s.mu.Lock()
+	for id, sess := range s.items {
+		if now.Sub(sess.CreatedAt) > s.maxTTL || now.Sub(sess.SeenAt) > s.idleTTL {
+			delete(s.items, id)
+			expired = append(expired, sess)
+		}
+	}
+	s.mu.Unlock()
+
+	for _, sess := range expired {
+		closeSessionBridge(sess)
+	}
+}
+
+type loginAttempt struct {
+	Fails      int
+	BlockedTo  time.Time
+	LastFailed time.Time
+}
+
+type loginGuard struct {
+	mu      sync.Mutex
+	entries map[string]*loginAttempt
+}
+
+func newLoginGuard() *loginGuard {
+	return &loginGuard{entries: make(map[string]*loginAttempt)}
+}
+
+func (l *loginGuard) allow(key string) (bool, time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry := l.entries[key]
+	if entry == nil {
+		return true, 0
+	}
+	now := time.Now().UTC()
+	if now.Before(entry.BlockedTo) {
+		return false, entry.BlockedTo.Sub(now)
+	}
+	return true, 0
+}
+
+func (l *loginGuard) noteFailure(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now().UTC()
+	entry := l.entries[key]
+	if entry == nil {
+		entry = &loginAttempt{}
+		l.entries[key] = entry
+	}
+	if now.Sub(entry.LastFailed) > 2*time.Minute {
+		entry.Fails = 0
+	}
+	entry.Fails++
+	entry.LastFailed = now
+	if entry.Fails >= 5 {
+		entry.BlockedTo = now.Add(90 * time.Second)
+		entry.Fails = 0
+	}
+}
+
+func (l *loginGuard) noteSuccess(key string) {
+	l.mu.Lock()
+	delete(l.entries, key)
+	l.mu.Unlock()
+}
+
+type commandResult struct {
+	Output   string
+	ExitCode int
+}
+
+type bridgeTransportError struct {
+	msg string
+}
+
+func (e bridgeTransportError) Error() string {
+	return e.msg
+}
+
+func isBridgeTransportError(err error) bool {
+	var te bridgeTransportError
+	return errors.As(err, &te)
+}
+
+func newBridgeTransportErrorf(format string, args ...any) error {
+	return bridgeTransportError{msg: fmt.Sprintf(format, args...)}
+}
+
+type ipcHeader struct {
+	Version int
+	Type    string
+	ID      uint64
+	P1      uint64
+	P2      uint64
+	P3      uint64
+	Len     uint64
+}
+
+type ipcBridge struct {
+	id      identity
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	stdoutR io.ReadCloser
+	stdout  *bufio.Reader
+	nextID  uint64
+	mu      sync.Mutex
+	closed  bool
+}
+
+func startIPCBridge(id identity) (*ipcBridge, error) {
+	cmd := exec.Command("cellmgr", "ipc", "serve", "--stdio")
+	cmd.Dir = fallbackDir(id.HomeDir)
+	cmd.Env = []string{
+		"PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/pkg/bin",
+		"HOME=" + id.HomeDir,
+		"USER=" + id.Username,
+		"LOGNAME=" + id.Username,
+		"LC_ALL=C",
+		"TERM=dumb",
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid:    id.UID,
+			Gid:    id.GID,
+			Groups: id.Groups,
+		},
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, err
+	}
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdoutPipe.Close()
+		return nil, err
+	}
+
+	b := &ipcBridge{
+		id:      id,
+		cmd:     cmd,
+		stdin:   stdin,
+		stdoutR: stdoutPipe,
+		stdout:  bufio.NewReader(stdoutPipe),
+		nextID:  1,
+	}
+
+	if err := b.sendFrame("HELLO", 0, 0, 0, 0, nil); err != nil {
+		b.close()
+		return nil, newBridgeTransportErrorf("ipc hello send failed: %v", err)
+	}
+	hdr, _, err := b.readFrame()
+	if err != nil {
+		b.close()
+		return nil, newBridgeTransportErrorf("ipc hello read failed: %v", err)
+	}
+	if hdr.Type != "HELLO" {
+		b.close()
+		return nil, newBridgeTransportErrorf("unexpected ipc handshake response: %s", hdr.Type)
+	}
+
+	return b, nil
+}
+
+func (b *ipcBridge) close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.closeLocked()
+}
+
+func (b *ipcBridge) closeLocked() {
+	if b.closed {
+		return
+	}
+	b.closed = true
+
+	if b.stdin != nil {
+		_, _ = io.WriteString(b.stdin, "M 1 BYE 0 0 0 0 0\n")
+		_ = b.stdin.Close()
+	}
+	if b.stdoutR != nil {
+		_ = b.stdoutR.Close()
+	}
+	if b.cmd != nil && b.cmd.Process != nil {
+		_ = b.cmd.Process.Kill()
+		_, _ = b.cmd.Process.Wait()
+	}
+}
+
+func (b *ipcBridge) callCapture(ctx context.Context, args []string) (commandResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return commandResult{}, newBridgeTransportErrorf("ipc bridge is closed")
+	}
+
+	done := make(chan struct {
+		res commandResult
+		err error
+	}, 1)
+
+	go func() {
+		res, err := b.callCaptureLocked(args)
+		done <- struct {
+			res commandResult
+			err error
+		}{res: res, err: err}
+	}()
+
+	select {
+	case out := <-done:
+		if isBridgeTransportError(out.err) {
+			b.closeLocked()
+		}
+		return out.res, out.err
+	case <-ctx.Done():
+		b.closeLocked()
+		<-done
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return commandResult{}, fmt.Errorf("command timeout")
+		}
+		return commandResult{}, ctx.Err()
+	}
+}
+
+func (b *ipcBridge) callCaptureLocked(args []string) (commandResult, error) {
+	if len(args) == 0 {
+		return commandResult{}, fmt.Errorf("missing command arguments")
+	}
+
+	payload, err := buildCallPayload(args)
+	if err != nil {
+		return commandResult{}, err
+	}
+
+	id := b.nextID
+	b.nextID++
+
+	if err := b.sendFrame("CALL", id, 0, uint64(len(args)), 0, payload); err != nil {
+		return commandResult{}, newBridgeTransportErrorf("ipc call send failed: %v", err)
+	}
+
+	hdr, respPayload, err := b.readFrame()
+	if err != nil {
+		return commandResult{}, newBridgeTransportErrorf("ipc call read failed: %v", err)
+	}
+
+	if hdr.Type == "ERR" {
+		msg := strings.TrimSpace(string(respPayload))
+		if msg == "" {
+			msg = "ipc error"
+		}
+		exit := int(hdr.P1)
+		if exit == 0 {
+			exit = 1
+		}
+		return commandResult{Output: truncateOutput(msg, maxOutputBytes), ExitCode: exit}, fmt.Errorf("exit status %d", exit)
+	}
+
+	if hdr.Type != "RET" || hdr.ID != id {
+		return commandResult{}, newBridgeTransportErrorf("unexpected ipc response: type=%s id=%d", hdr.Type, hdr.ID)
+	}
+
+	stdoutLen := int(hdr.P2)
+	stderrLen := int(hdr.P3)
+	if stdoutLen < 0 || stderrLen < 0 || stdoutLen+stderrLen != len(respPayload) {
+		return commandResult{}, newBridgeTransportErrorf("ipc response length mismatch")
+	}
+
+	combined := strings.TrimSpace(string(respPayload[:stdoutLen]) + string(respPayload[stdoutLen:]))
+	res := commandResult{
+		Output:   truncateOutput(combined, maxOutputBytes),
+		ExitCode: int(hdr.P1),
+	}
+	if hdr.P1 != 0 {
+		return res, fmt.Errorf("exit status %d", int(hdr.P1))
+	}
+	return res, nil
+}
+
+func buildCallPayload(args []string) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, arg := range args {
+		if strings.ContainsRune(arg, '\n') {
+			return nil, fmt.Errorf("argument contains newline: %q", arg)
+		}
+		buf.WriteString(arg)
+		buf.WriteByte('\n')
+	}
+	if buf.Len() > ipcMaxPayloadBytes {
+		return nil, fmt.Errorf("ipc request payload too large")
+	}
+	return buf.Bytes(), nil
+}
+
+func (b *ipcBridge) sendFrame(frameType string, id, p1, p2, p3 uint64, payload []byte) error {
+	if len(payload) > ipcMaxPayloadBytes {
+		return fmt.Errorf("payload too large")
+	}
+
+	header := fmt.Sprintf("M %d %s %d %d %d %d %d\n",
+		ipcProtocolVersion, frameType, id, p1, p2, p3, len(payload))
+	if _, err := io.WriteString(b.stdin, header); err != nil {
+		return err
+	}
+	if len(payload) > 0 {
+		if _, err := b.stdin.Write(payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *ipcBridge) readFrame() (ipcHeader, []byte, error) {
+	line, err := b.stdout.ReadString('\n')
+	if err != nil {
+		return ipcHeader{}, nil, err
+	}
+	line = strings.TrimSuffix(line, "\n")
+
+	hdr, err := parseIPCHeader(line)
+	if err != nil {
+		return ipcHeader{}, nil, err
+	}
+	if hdr.Len > ipcMaxPayloadBytes {
+		return ipcHeader{}, nil, fmt.Errorf("payload too large")
+	}
+
+	payload := make([]byte, hdr.Len)
+	if hdr.Len > 0 {
+		if _, err := io.ReadFull(b.stdout, payload); err != nil {
+			return ipcHeader{}, nil, err
+		}
+	}
+
+	return hdr, payload, nil
+}
+
+func parseIPCHeader(line string) (ipcHeader, error) {
+	var hdr ipcHeader
+	scanned, err := fmt.Sscanf(line, "M %d %15s %d %d %d %d %d",
+		&hdr.Version, &hdr.Type, &hdr.ID, &hdr.P1, &hdr.P2, &hdr.P3, &hdr.Len)
+	if err != nil {
+		return ipcHeader{}, err
+	}
+	if scanned != 7 {
+		return ipcHeader{}, fmt.Errorf("invalid header")
+	}
+	if hdr.Version != ipcProtocolVersion {
+		return ipcHeader{}, fmt.Errorf("unsupported protocol version %d", hdr.Version)
+	}
+	return hdr, nil
+}
+
+func closeSessionBridge(sess *session) {
+	if sess == nil {
+		return
+	}
+	sess.bridgeMu.Lock()
+	bridge := sess.bridge
+	sess.bridge = nil
+	sess.bridgeMu.Unlock()
+	if bridge != nil {
+		bridge.close()
+	}
+}
+
+type appServer struct {
+	log            *log.Logger
+	auth           authenticator
+	sessions       *sessionStore
+	loginGuard     *loginGuard
+	trendStore     *systemTrendStore
+	assetFS        fs.FS
+	trust          trustInfo
+	caCertPEM      []byte
+	secureCookies  bool
+	commandTimeout time.Duration
+	refreshSeconds int
+}
+
+type authenticator interface {
+	Authenticate(ctx context.Context, username, password string) error
+}
+
+type staticAuthenticator struct {
+	username string
+	password string
+}
+
+func (a staticAuthenticator) Authenticate(ctx context.Context, username, password string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	userOK := subtle.ConstantTimeCompare([]byte(username), []byte(a.username)) == 1
+	passOK := subtle.ConstantTimeCompare([]byte(password), []byte(a.password)) == 1
+	if !userOK || !passOK {
+		return errors.New("invalid credentials")
+	}
+	return nil
+}
+
+type multiAuthenticator struct {
+	chain []authenticator
+}
+
+func (m multiAuthenticator) Authenticate(ctx context.Context, username, password string) error {
+	var lastErr error
+	for _, auth := range m.chain {
+		if err := auth.Authenticate(ctx, username, password); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr == nil {
+		return errors.New("authentication failed")
+	}
+	return lastErr
+}
+
+func buildAuthenticator(pamService, adminUser, adminPass string) (authenticator, []string, error) {
+	auths := make([]authenticator, 0, 2)
+	names := make([]string, 0, 2)
+
+	adminUser = strings.TrimSpace(adminUser)
+	if adminUser != "" || adminPass != "" {
+		if adminUser == "" || adminPass == "" {
+			return nil, nil, errors.New("admin auth requires both -admin-user and -admin-pass")
+		}
+		if !namePattern.MatchString(adminUser) {
+			return nil, nil, fmt.Errorf("invalid -admin-user value: %q", adminUser)
+		}
+		auths = append(auths, staticAuthenticator{username: adminUser, password: adminPass})
+		names = append(names, "admin")
+	}
+
+	auths = append(auths, newPAMAuthenticator(pamService))
+	names = append(names, "pam")
+
+	if len(auths) == 1 {
+		return auths[0], names, nil
+	}
+	return multiAuthenticator{chain: auths}, names, nil
+}
+
+func main() {
+	tlsEnabled := flag.Bool("tls", envBoolOrDefault("CELLWEB_TLS", true), "enable TLS for the main web UI")
+	httpsListen := flag.String("https-listen", envOrDefault("CELLWEB_HTTPS_LISTEN", "0.0.0.0:18443"), "HTTPS listen address (used when -tls=true)")
+	httpListen := flag.String("http-listen", envOrDefault("CELLWEB_HTTP_LISTEN", "0.0.0.0:18088"), "HTTP listen address (bootstrap when TLS is on, main listener when TLS is off)")
+	pamService := flag.String("pam-service", envOrDefault("CELLWEB_PAM_SERVICE", "login"), "PAM service name")
+	adminUser := flag.String("admin-user", envOrDefault("CELLWEB_ADMIN_USER", ""), "optional admin username fallback")
+	adminPass := flag.String("admin-pass", envOrDefault("CELLWEB_ADMIN_PASS", ""), "optional admin password fallback")
+	secureCookiesMode := flag.String("secure-cookies-mode", secureCookiesModeFromEnv(), "secure cookies mode: auto|on|off")
+	pkiDir := flag.String("pki-dir", envOrDefault("CELLWEB_PKI_DIR", defaultPKIDir), "PKI directory for selfsigned mode")
+	tlsCert := flag.String("tls-cert", envOrDefault("CELLWEB_TLS_CERT", ""), "certificate path for manual TLS mode")
+	tlsKey := flag.String("tls-key", envOrDefault("CELLWEB_TLS_KEY", ""), "private key path for manual TLS mode")
+	tlsSAN := flag.String("tls-san", envOrDefault("CELLWEB_TLS_SAN", ""), "comma-separated additional TLS SAN entries (DNS names or IPs)")
+	tlsExportCA := flag.String("tls-export-ca", envOrDefault("CELLWEB_TLS_EXPORT_CA", ""), "export root CA certificate to a path (selfsigned mode)")
+	commandTimeout := flag.Duration("command-timeout", defaultCommandTimeout, "timeout for each cellmgr command")
+	refreshSeconds := flag.Int("refresh-seconds", defaultRefreshInterval, "recommended client refresh interval in seconds")
+	flag.Parse()
+
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+
+	sub, err := fs.Sub(webAssets, "web")
+	if err != nil {
+		logger.Fatalf("web assets: %v", err)
+	}
+
+	if *refreshSeconds < 2 {
+		*refreshSeconds = 2
+	}
+
+	httpsListenAddr := strings.TrimSpace(*httpsListen)
+	httpListenAddr := strings.TrimSpace(*httpListen)
+
+	resolvedTLSMode, err := resolveTLSMode(*tlsEnabled, *tlsCert, *tlsKey)
+	if err != nil {
+		logger.Fatalf("tls setup failed: %v", err)
+	}
+
+	mainListenAddr := httpListenAddr
+	if resolvedTLSMode != tlsModeOff {
+		mainListenAddr = httpsListenAddr
+	}
+	if strings.TrimSpace(mainListenAddr) == "" {
+		logger.Fatalf("network setup failed: main listen address is empty")
+	}
+	if resolvedTLSMode != tlsModeOff && strings.TrimSpace(httpsListenAddr) == "" {
+		logger.Fatalf("network setup failed: -https-listen is required when -tls=true")
+	}
+	if resolvedTLSMode != tlsModeOff && httpListenAddr != "" && httpListenAddr == httpsListenAddr {
+		logger.Fatalf("network setup failed: -http-listen and -https-listen must not be the same")
+	}
+
+	tlsRuntime, err := prepareTLSRuntime(
+		mainListenAddr,
+		resolvedTLSMode,
+		*pkiDir,
+		*tlsCert,
+		*tlsKey,
+		*tlsSAN,
+		*tlsExportCA,
+		logger,
+	)
+	if err != nil {
+		logger.Fatalf("tls setup failed: %v", err)
+	}
+
+	httpBootstrapListen := ""
+	if tlsRuntime.Enabled {
+		httpBootstrapListen = httpListenAddr
+	}
+
+	if tlsRuntime.Mode == tlsModeSelfSigned {
+		printTrustBootstrapToStdout(mainListenAddr, tlsRuntime.BootstrapHost, tlsRuntime.Trust.CAFingerprintSHA256, httpBootstrapListen)
+	}
+
+	secureCookies, err := resolveSecureCookieSetting(*secureCookiesMode, false, tlsRuntime.Enabled)
+	if err != nil {
+		logger.Fatalf("cookie setup failed: %v", err)
+	}
+
+	hstsEnabled := tlsRuntime.Enabled
+
+	auth, authModes, err := buildAuthenticator(*pamService, *adminUser, *adminPass)
+	if err != nil {
+		logger.Fatalf("auth setup failed: %v", err)
+	}
+
+	networkConfig := "http-bind=" + configValue(mainListenAddr, "(unset)")
+	tlsConfig := ""
+	if tlsRuntime.Enabled {
+		if httpBootstrapListen != "" {
+			networkConfig = fmt.Sprintf("https-bind=%s http-bootstrap-bind=%s", configValue(mainListenAddr, "(unset)"), httpBootstrapListen)
+		} else {
+			networkConfig = fmt.Sprintf("https-bind=%s http-bootstrap=off", configValue(mainListenAddr, "(unset)"))
+		}
+		if tlsRuntime.Mode == tlsModeManual {
+			tlsConfig = fmt.Sprintf(" cert=%s key=%s", configValue(*tlsCert, "(required)"), configValue(*tlsKey, "(required)"))
+		} else {
+			tlsConfig = fmt.Sprintf(" pki-dir=%s tls-san=%s", configValue(*pkiDir, "(default)"), configValue(*tlsSAN, "(auto)"))
+		}
+	}
+	logger.Printf(
+		"start config: mode=%s %s auth=%s pam-service=%s secure-cookies=%t refresh=%ds timeout=%s%s",
+		tlsRuntime.Mode,
+		networkConfig,
+		strings.Join(authModes, ","),
+		configValue(*pamService, "login"),
+		secureCookies,
+		*refreshSeconds,
+		commandTimeout.String(),
+		tlsConfig,
+	)
+
+	s := &appServer{
+		log:            logger,
+		auth:           auth,
+		sessions:       newSessionStore(defaultSessionIdleTTL, defaultSessionMaxTTL),
+		loginGuard:     newLoginGuard(),
+		trendStore:     newSystemTrendStore(trendHistoryPoints),
+		assetFS:        sub,
+		trust:          tlsRuntime.Trust,
+		caCertPEM:      tlsRuntime.CACertPEM,
+		secureCookies:  secureCookies,
+		commandTimeout: *commandTimeout,
+		refreshSeconds: *refreshSeconds,
+	}
+
+	if id, err := lookupProcessIdentity(); err == nil {
+		s.startSystemTrendSampler(id, time.Duration(s.refreshSeconds)*time.Second)
+	}
+
+	go func() {
+		ticker := time.NewTicker(90 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			s.sessions.cleanupExpired()
+		}
+	}()
+
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	handler := withSecurityHeaders(mux, hstsEnabled)
+	httpServer := &http.Server{
+		Addr:              mainListenAddr,
+		Handler:           handler,
+		ErrorLog:          log.New(filteredHTTPServerErrorWriter{dst: os.Stderr}, "", log.LstdFlags),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	if tlsRuntime.Enabled && httpBootstrapListen != "" {
+		httpBootstrapURL := bootstrapBaseURLWithHost("http", httpBootstrapListen, tlsRuntime.BootstrapHost) + httpBootstrapRoute
+		s.log.Printf("listener started: http bootstrap bind=%s url=%s", httpBootstrapListen, httpBootstrapURL)
+		go startHTTPRedirectServer(s.log, httpBootstrapListen, mainListenAddr, tlsRuntime.CACertPEM)
+	}
+
+	if tlsRuntime.Enabled {
+		httpsURL := bootstrapBaseURLWithHost("https", mainListenAddr, tlsRuntime.BootstrapHost) + "/"
+		s.log.Printf("listener started: https bind=%s url=%s", mainListenAddr, httpsURL)
+	} else {
+		httpURL := bootstrapBaseURLWithHost("http", mainListenAddr, "") + "/"
+		s.log.Printf("listener started: http bind=%s url=%s", mainListenAddr, httpURL)
+	}
+
+	var serveErr error
+	if tlsRuntime.Enabled {
+		serveErr = httpServer.ListenAndServeTLS(tlsRuntime.CertFile, tlsRuntime.KeyFile)
+	} else {
+		serveErr = httpServer.ListenAndServe()
+	}
+	if err := serveErr; err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Fatalf("listen failed: %v", err)
+	}
+}
+
+func (s *appServer) registerRoutes(mux *http.ServeMux) {
+	assets := http.FileServer(http.FS(s.assetFS))
+	mux.Handle("/app.js", assets)
+	mux.Handle("/style.css", assets)
+	mux.HandleFunc("/", s.handleIndex)
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/api/trust", s.handleTrustInfo)
+	mux.HandleFunc(localCACertRoute, s.handleCACert)
+
+	mux.HandleFunc("/api/login", s.handleLogin)
+	mux.HandleFunc("/api/logout", s.handleLogout)
+	mux.HandleFunc("/api/me", s.handleMe)
+	mux.HandleFunc("/api/system", s.handleSystem)
+	mux.HandleFunc("/api/cells", s.handleCells)
+	mux.HandleFunc("/api/cells/action", s.handleCellsAction)
+	mux.HandleFunc("/api/storage", s.handleStorage)
+	mux.HandleFunc("/api/backups", s.handleBackups)
+	mux.HandleFunc("/api/storage/action", s.handleStorageAction)
+}
+
+func (s *appServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	file, err := s.assetFS.Open("index.html")
+	if err != nil {
+		http.Error(w, "index missing", http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if _, err := io.Copy(w, file); err != nil {
+		s.log.Printf("serve index: %v", err)
+	}
+}
+
+func (s *appServer) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+func (s *appServer) handleTrustInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "data": s.trust})
+}
+
+func (s *appServer) handleCACert(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+	if len(s.caCertPEM) == 0 {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-pem-file")
+	w.Header().Set("Content-Disposition", `attachment; filename="cellweb-root-ca.crt"`)
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write(s.caCertPEM)
+}
+
+type loginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func (s *appServer) handleLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	remote := remoteKey(r)
+	if allowed, wait := s.loginGuard.allow(remote); !allowed {
+		writeAPIError(w, http.StatusTooManyRequests,
+			fmt.Sprintf("Too many failed logins. Retry in %ds.", int(wait.Seconds()+0.5)), "")
+		return
+	}
+
+	var req loginRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "Invalid login payload", err.Error())
+		return
+	}
+
+	req.Username = strings.TrimSpace(req.Username)
+	if req.Username == "" || req.Password == "" {
+		writeAPIError(w, http.StatusBadRequest, "Username and password are required", "")
+		return
+	}
+	if !namePattern.MatchString(req.Username) {
+		writeAPIError(w, http.StatusBadRequest, "Invalid username format", "")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	if err := s.auth.Authenticate(ctx, req.Username, req.Password); err != nil {
+		s.loginGuard.noteFailure(remote)
+		writeAPIError(w, http.StatusUnauthorized, "Authentication failed", "invalid credentials")
+		return
+	}
+
+	id, err := lookupIdentity(req.Username)
+	if err != nil {
+		s.loginGuard.noteFailure(remote)
+		writeAPIError(w, http.StatusUnauthorized, "Authentication failed", "local user lookup failed")
+		return
+	}
+
+	sess, err := s.sessions.create(id)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "Session creation failed", err.Error())
+		return
+	}
+
+	s.setSessionCookie(w, sess.ID)
+	s.loginGuard.noteSuccess(remote)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":              true,
+		"username":        id.Username,
+		"refresh_seconds": s.refreshSeconds,
+		"csrf_token":      sess.CSRFToken,
+	})
+}
+
+func (s *appServer) handleLogout(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	sess, ok := s.mustAuth(w, r, true)
+	if !ok {
+		return
+	}
+
+	s.sessions.delete(sess.ID)
+	s.clearSessionCookie(w)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+func (s *appServer) handleMe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	sess, ok := s.mustAuth(w, r, false)
+	if !ok {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":              true,
+		"username":        sess.Identity.Username,
+		"uid":             sess.Identity.UID,
+		"refresh_seconds": s.refreshSeconds,
+		"csrf_token":      sess.CSRFToken,
+	})
+}
+
+type cellRow struct {
+	Name                string `json:"name"`
+	CID                 string `json:"cid"`
+	Running             bool   `json:"running"`
+	Refs                string `json:"refs"`
+	Procs               string `json:"procs"`
+	Root                string `json:"root"`
+	Autostart           string `json:"autostart"`
+	CreateProfile       string `json:"create_profile"`
+	CreateReservedPorts string `json:"create_reserved_ports"`
+	CreateRlimitNofile  string `json:"create_rlimit_nofile"`
+	CreateRlimitAS      string `json:"create_rlimit_as"`
+	CreateRlimitCore    string `json:"create_rlimit_core"`
+	SuperviseCmd        string `json:"supervise_cmd"`
+	CPU1s               string `json:"cpu1s"`
+	CPU10s              string `json:"cpu10s"`
+	Memory              string `json:"memory"`
+	Age                 string `json:"age"`
+	ManifestPresent     bool   `json:"manifest_present"`
+}
+
+func (s *appServer) handleCells(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	sess, ok := s.mustAuth(w, r, false)
+	if !ok {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.commandTimeout)
+	defer cancel()
+
+	rows, err := s.loadCells(ctx, sess)
+	if err != nil {
+		writeAPIError(w, http.StatusBadGateway, "Failed to load cells", err.Error())
+		return
+	}
+
+	runningCount := 0
+	missingManifest := 0
+	for _, row := range rows {
+		if row.Running {
+			runningCount++
+		}
+		if !row.ManifestPresent {
+			missingManifest++
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok": true,
+		"meta": map[string]any{
+			"total":            len(rows),
+			"running":          runningCount,
+			"missing_manifest": missingManifest,
+		},
+		"rows": rows,
+	})
+}
+
+type cellActionRequest struct {
+	Action string `json:"action"`
+	Name   string `json:"name"`
+	All    bool   `json:"all"`
+}
+
+func (s *appServer) handleCellsAction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	sess, ok := s.mustAuth(w, r, true)
+	if !ok {
+		return
+	}
+
+	var req cellActionRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "Invalid action payload", err.Error())
+		return
+	}
+	req.Action = strings.TrimSpace(strings.ToLower(req.Action))
+	req.Name = strings.TrimSpace(req.Name)
+
+	var args []string
+	var title string
+
+	switch req.Action {
+	case "start", "stop", "restart":
+		title = strings.ToUpper(req.Action[:1]) + req.Action[1:]
+		args = []string{"cell", req.Action}
+		if req.All {
+			args = append(args, "--all")
+		} else {
+			if req.Name == "" || !namePattern.MatchString(req.Name) {
+				writeAPIError(w, http.StatusBadRequest, "Invalid cell name", "")
+				return
+			}
+			args = append(args, req.Name)
+		}
+	case "apply":
+		title = "Apply"
+		args = []string{"apply", "--all"}
+	case "shell", "edit":
+		writeAPIError(w, http.StatusNotImplemented,
+			"Interactive actions are not available over HTTP yet",
+			"Use cellui for interactive shell/edit workflows.")
+		return
+	default:
+		writeAPIError(w, http.StatusBadRequest, "Unknown action", req.Action)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.commandTimeout)
+	defer cancel()
+
+	res, err := s.runCellmgr(ctx, sess, args...)
+	if err != nil {
+		writeAPIError(w, http.StatusBadGateway, title+" failed", commandErrorMessage(err, res.Output))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":      true,
+		"message": title + " done",
+		"output":  res.Output,
+	})
+}
+
+type volumeRow struct {
+	Kind            string `json:"kind"`
+	Name            string `json:"name"`
+	ManifestPresent bool   `json:"manifest_present"`
+	RuntimePresent  bool   `json:"runtime_present"`
+	Mounted         bool   `json:"mounted"`
+	Refs            string `json:"refs"`
+	Mode            string `json:"mode"`
+	Path            string `json:"path"`
+	UsedBy          string `json:"used_by"`
+}
+
+type filesystemStat struct {
+	Filesystem string `json:"filesystem"`
+	Mountpoint string `json:"mountpoint"`
+	SizeKB     uint64 `json:"size_kb"`
+	UsedKB     uint64 `json:"used_kb"`
+	AvailKB    uint64 `json:"avail_kb"`
+	Capacity   int    `json:"capacity_percent"`
+}
+
+type memoryStat struct {
+	TotalBytes uint64 `json:"total_bytes"`
+	UsedBytes  uint64 `json:"used_bytes"`
+	FreeBytes  uint64 `json:"free_bytes"`
+	UsedPct    int    `json:"used_percent"`
+}
+
+type swapStat struct {
+	TotalKB  uint64 `json:"total_kb"`
+	UsedKB   uint64 `json:"used_kb"`
+	AvailKB  uint64 `json:"avail_kb"`
+	UsedPct  int    `json:"used_percent"`
+	HasSwap  bool   `json:"has_swap"`
+	Readable bool   `json:"readable"`
+}
+
+type interfaceStat struct {
+	Name      string   `json:"name"`
+	Status    string   `json:"status"`
+	MTU       int      `json:"mtu"`
+	Addresses []string `json:"addresses"`
+	InBytes   uint64   `json:"in_bytes"`
+	OutBytes  uint64   `json:"out_bytes"`
+}
+
+type ioDeviceStat struct {
+	Device  string            `json:"device"`
+	Metrics map[string]string `json:"metrics"`
+}
+
+type cpuTickStat struct {
+	User   uint64 `json:"user"`
+	Nice   uint64 `json:"nice"`
+	System uint64 `json:"system"`
+	Intr   uint64 `json:"intr"`
+	Idle   uint64 `json:"idle"`
+}
+
+type systemTrendSnapshot struct {
+	CPUUserPercent   []float64 `json:"cpu_user_percent"`
+	CPUSystemPercent []float64 `json:"cpu_system_percent"`
+	MemoryUsedPct    []float64 `json:"memory_used_percent"`
+}
+
+type systemTrendStore struct {
+	mu        sync.RWMutex
+	maxPoints int
+	lastCPU   *cpuTickStat
+	cpuUser   []float64
+	cpuSystem []float64
+	memory    []float64
+}
+
+func newSystemTrendStore(maxPoints int) *systemTrendStore {
+	if maxPoints < 1 {
+		maxPoints = 1
+	}
+	return &systemTrendStore{maxPoints: maxPoints}
+}
+
+func clampTrendPercent(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 100 {
+		return 100
+	}
+	return v
+}
+
+func appendTrendValue(series []float64, value float64, max int) []float64 {
+	series = append(series, clampTrendPercent(value))
+	if len(series) <= max {
+		return series
+	}
+	trim := len(series) - max
+	copy(series, series[trim:])
+	return series[:max]
+}
+
+func (s *systemTrendStore) pushMemoryPercent(value int) {
+	s.mu.Lock()
+	s.memory = appendTrendValue(s.memory, float64(value), s.maxPoints)
+	s.mu.Unlock()
+}
+
+func (s *systemTrendStore) pushCPUTicks(ticks cpuTickStat) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.lastCPU != nil {
+		dUser := ticks.User - s.lastCPU.User
+		dNice := ticks.Nice - s.lastCPU.Nice
+		dSystem := ticks.System - s.lastCPU.System
+		dIntr := ticks.Intr - s.lastCPU.Intr
+		dIdle := ticks.Idle - s.lastCPU.Idle
+		total := dUser + dNice + dSystem + dIntr + dIdle
+		if total > 0 {
+			s.cpuUser = appendTrendValue(s.cpuUser, (float64(dUser+dNice)*100)/float64(total), s.maxPoints)
+			s.cpuSystem = appendTrendValue(s.cpuSystem, (float64(dSystem+dIntr)*100)/float64(total), s.maxPoints)
+		}
+	}
+
+	copyTicks := ticks
+	s.lastCPU = &copyTicks
+}
+
+func (s *systemTrendStore) snapshot() *systemTrendSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.cpuUser) == 0 && len(s.cpuSystem) == 0 && len(s.memory) == 0 {
+		return nil
+	}
+
+	out := &systemTrendSnapshot{}
+	if len(s.cpuUser) > 0 {
+		out.CPUUserPercent = append([]float64(nil), s.cpuUser...)
+	}
+	if len(s.cpuSystem) > 0 {
+		out.CPUSystemPercent = append([]float64(nil), s.cpuSystem...)
+	}
+	if len(s.memory) > 0 {
+		out.MemoryUsedPct = append([]float64(nil), s.memory...)
+	}
+	return out
+}
+
+type systemSnapshot struct {
+	Hostname    string               `json:"hostname"`
+	Uptime      string               `json:"uptime"`
+	LoadAverage string               `json:"load_average"`
+	CPUTicks    cpuTickStat          `json:"cpu_ticks"`
+	Trends      *systemTrendSnapshot `json:"trends,omitempty"`
+	Memory      memoryStat           `json:"memory"`
+	Swap        swapStat             `json:"swap"`
+	Filesystems []filesystemStat     `json:"filesystems"`
+	Interfaces  []interfaceStat      `json:"interfaces"`
+	IO          []ioDeviceStat       `json:"io"`
+	Warnings    []string             `json:"warnings"`
+}
+
+func (s *appServer) handleSystem(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	sess, ok := s.mustAuth(w, r, false)
+	if !ok {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.commandTimeout)
+	defer cancel()
+
+	snap := s.collectSystemSnapshot(ctx, sess.Identity)
+	if s.trendStore != nil {
+		snap.Trends = s.trendStore.snapshot()
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok": true,
+		"meta": map[string]any{
+			"filesystems": len(snap.Filesystems),
+			"interfaces":  len(snap.Interfaces),
+			"io_devices":  len(snap.IO),
+			"warnings":    len(snap.Warnings),
+		},
+		"data": snap,
+	})
+}
+
+func (s *appServer) handleStorage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	sess, ok := s.mustAuth(w, r, false)
+	if !ok {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.commandTimeout)
+	defer cancel()
+
+	rows, err := s.loadStorage(ctx, sess)
+	if err != nil {
+		writeAPIError(w, http.StatusBadGateway, "Failed to load storage", err.Error())
+		return
+	}
+
+	volumes := 0
+	overlays := 0
+	backupReady := 0
+	for _, row := range rows {
+		if row.Kind == "overlay" {
+			overlays++
+		} else {
+			volumes++
+		}
+		if row.RuntimePresent && !row.Mounted {
+			backupReady++
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok": true,
+		"meta": map[string]any{
+			"total":        len(rows),
+			"volumes":      volumes,
+			"overlays":     overlays,
+			"backup_ready": backupReady,
+		},
+		"rows": rows,
+	})
+}
+
+type backupRow struct {
+	Volume    string `json:"volume"`
+	Timestamp string `json:"timestamp"`
+	Size      string `json:"size"`
+	Archive   string `json:"archive"`
+}
+
+func (s *appServer) handleBackups(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	sess, ok := s.mustAuth(w, r, false)
+	if !ok {
+		return
+	}
+
+	kind := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("kind")))
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
+	if (kind != "volume" && kind != "overlay") || !namePattern.MatchString(name) {
+		writeAPIError(w, http.StatusBadRequest, "kind must be volume|overlay and name must be valid", "")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.commandTimeout)
+	defer cancel()
+
+	rows, err := s.loadBackups(ctx, sess, kind, name)
+	if err != nil {
+		writeAPIError(w, http.StatusBadGateway, "Failed to load backups", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "rows": rows})
+}
+
+type storageActionRequest struct {
+	Action       string `json:"action"`
+	Kind         string `json:"kind"`
+	Name         string `json:"name"`
+	Archive      string `json:"archive"`
+	WithManifest bool   `json:"with_manifest"`
+}
+
+func (s *appServer) handleStorageAction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	sess, ok := s.mustAuth(w, r, true)
+	if !ok {
+		return
+	}
+
+	var req storageActionRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "Invalid action payload", err.Error())
+		return
+	}
+
+	req.Action = strings.TrimSpace(strings.ToLower(req.Action))
+	req.Kind = strings.TrimSpace(strings.ToLower(req.Kind))
+	req.Name = strings.TrimSpace(req.Name)
+	req.Archive = strings.TrimSpace(req.Archive)
+
+	if (req.Kind != "volume" && req.Kind != "overlay") || !namePattern.MatchString(req.Name) {
+		writeAPIError(w, http.StatusBadRequest, "Invalid storage target", "")
+		return
+	}
+	if req.Archive != "" && !archivePattern.MatchString(req.Archive) {
+		writeAPIError(w, http.StatusBadRequest, "Invalid archive path", "")
+		return
+	}
+
+	targetRes := "volume"
+	if req.Kind == "overlay" {
+		targetRes = "cell"
+	}
+
+	var args []string
+	var title string
+
+	switch req.Action {
+	case "create":
+		title = "Create backup"
+		args = []string{targetRes, "backup", "create", req.Name}
+	case "restore":
+		if req.Archive == "" {
+			writeAPIError(w, http.StatusBadRequest, "Missing archive for restore", "")
+			return
+		}
+		title = "Restore backup"
+		args = []string{targetRes, "backup", "restore", req.Name, "--from", req.Archive}
+		if req.WithManifest {
+			args = append(args, "--manifest")
+		}
+		args = append(args, "--yes")
+	case "delete":
+		if req.Archive == "" {
+			writeAPIError(w, http.StatusBadRequest, "Missing archive for delete", "")
+			return
+		}
+		title = "Delete backup"
+		args = []string{targetRes, "backup", "delete", req.Name, "--from", req.Archive, "--yes"}
+	default:
+		writeAPIError(w, http.StatusBadRequest, "Unknown storage action", req.Action)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.commandTimeout)
+	defer cancel()
+
+	res, err := s.runCellmgr(ctx, sess, args...)
+	if err != nil {
+		writeAPIError(w, http.StatusBadGateway, title+" failed", commandErrorMessage(err, res.Output))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":      true,
+		"message": title + " done",
+		"output":  res.Output,
+	})
+}
+
+func (s *appServer) mustAuth(w http.ResponseWriter, r *http.Request, requireCSRF bool) (*session, bool) {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil || cookie.Value == "" {
+		writeAPIError(w, http.StatusUnauthorized, "Not authenticated", "")
+		return nil, false
+	}
+
+	sess, ok := s.sessions.get(cookie.Value)
+	if !ok {
+		s.clearSessionCookie(w)
+		writeAPIError(w, http.StatusUnauthorized, "Session expired", "")
+		return nil, false
+	}
+
+	if requireCSRF {
+		provided := r.Header.Get("X-CSRF-Token")
+		if subtle.ConstantTimeCompare([]byte(provided), []byte(sess.CSRFToken)) != 1 {
+			writeAPIError(w, http.StatusForbidden, "Bad CSRF token", "")
+			return nil, false
+		}
+	}
+
+	return sess, true
+}
+
+func (s *appServer) setSessionCookie(w http.ResponseWriter, sessionID string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    sessionID,
+		Path:     "/",
+		MaxAge:   int(defaultSessionMaxTTL.Seconds()),
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   s.secureCookies,
+	})
+}
+
+func (s *appServer) clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   s.secureCookies,
+	})
+}
+
+func (s *appServer) runCellmgr(ctx context.Context, sess *session, args ...string) (commandResult, error) {
+	bridge, err := s.getOrCreateBridge(sess)
+	if err != nil {
+		return commandResult{}, err
+	}
+
+	res, err := bridge.callCapture(ctx, args)
+	if !isBridgeTransportError(err) {
+		return res, err
+	}
+
+	s.log.Printf("ipc bridge transport error for user=%s, recreating bridge: %v", sess.Identity.Username, err)
+	closeSessionBridge(sess)
+
+	bridge, createErr := s.getOrCreateBridge(sess)
+	if createErr != nil {
+		return commandResult{}, createErr
+	}
+	return bridge.callCapture(ctx, args)
+}
+
+func (s *appServer) getOrCreateBridge(sess *session) (*ipcBridge, error) {
+	if sess == nil {
+		return nil, fmt.Errorf("missing session")
+	}
+
+	sess.bridgeMu.Lock()
+	defer sess.bridgeMu.Unlock()
+
+	if sess.bridge != nil {
+		return sess.bridge, nil
+	}
+
+	bridge, err := startIPCBridge(sess.Identity)
+	if err != nil {
+		return nil, err
+	}
+	sess.bridge = bridge
+	return bridge, nil
+}
+
+func runHostCommandAsUser(ctx context.Context, id identity, bin string, args ...string) (commandResult, error) {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = fallbackDir(id.HomeDir)
+	cmd.Env = []string{
+		"PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/pkg/bin",
+		"HOME=" + id.HomeDir,
+		"USER=" + id.Username,
+		"LOGNAME=" + id.Username,
+		"LC_ALL=C",
+		"TERM=dumb",
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid:    id.UID,
+			Gid:    id.GID,
+			Groups: id.Groups,
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	combined := truncateOutput(strings.TrimSpace(stdout.String()+stderr.String()), maxOutputBytes)
+
+	if err == nil {
+		return commandResult{Output: combined, ExitCode: 0}, nil
+	}
+
+	exitCode := -1
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return commandResult{Output: combined, ExitCode: exitCode}, err
+	}
+	exitCode = exitErr.ExitCode()
+
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return commandResult{Output: combined, ExitCode: exitCode}, fmt.Errorf("command timeout")
+	}
+
+	return commandResult{Output: combined, ExitCode: exitCode}, fmt.Errorf("exit status %d", exitCode)
+}
+
+func (s *appServer) runHostOutput(ctx context.Context, id identity, bin string, args ...string) (string, error) {
+	res, err := runHostCommandAsUser(ctx, id, bin, args...)
+	if err != nil {
+		cmdText := strings.TrimSpace(strings.Join(append([]string{bin}, args...), " "))
+		return res.Output, fmt.Errorf("%s: %s", cmdText, commandErrorMessage(err, res.Output))
+	}
+	return res.Output, nil
+}
+
+func (s *appServer) collectSystemSnapshot(ctx context.Context, id identity) systemSnapshot {
+	snap := systemSnapshot{Warnings: make([]string, 0, 8)}
+
+	if hostOut, err := s.runHostOutput(ctx, id, "hostname"); err == nil {
+		snap.Hostname = strings.TrimSpace(hostOut)
+	} else {
+		host, hostErr := os.Hostname()
+		if hostErr == nil {
+			snap.Hostname = host
+		} else {
+			snap.Hostname = "-"
+		}
+		snap.Warnings = append(snap.Warnings, "hostname unavailable: "+err.Error())
+	}
+
+	if upOut, err := s.runHostOutput(ctx, id, "uptime"); err == nil {
+		snap.Uptime, snap.LoadAverage = parseUptimeAndLoad(upOut)
+	} else {
+		snap.Uptime = "-"
+		snap.LoadAverage = "-"
+		snap.Warnings = append(snap.Warnings, "uptime unavailable: "+err.Error())
+	}
+
+	if fsRows, err := s.collectFilesystems(ctx, id); err == nil {
+		snap.Filesystems = fsRows
+	} else {
+		snap.Warnings = append(snap.Warnings, err.Error())
+	}
+
+	if cpu, err := s.collectCPUTicks(ctx, id); err == nil {
+		snap.CPUTicks = cpu
+	} else {
+		snap.Warnings = append(snap.Warnings, err.Error())
+	}
+
+	if mem, err := s.collectMemory(ctx, id); err == nil {
+		snap.Memory = mem
+	} else {
+		snap.Warnings = append(snap.Warnings, err.Error())
+	}
+
+	if sw, err := s.collectSwap(ctx, id); err == nil {
+		snap.Swap = sw
+	} else {
+		snap.Warnings = append(snap.Warnings, err.Error())
+	}
+
+	if ifs, err := s.collectInterfaces(ctx, id); err == nil {
+		snap.Interfaces = ifs
+	} else {
+		snap.Warnings = append(snap.Warnings, err.Error())
+	}
+
+	if ioRows, err := s.collectIOStats(ctx, id); err == nil {
+		snap.IO = ioRows
+	} else {
+		snap.Warnings = append(snap.Warnings, err.Error())
+	}
+
+	return snap
+}
+
+func (s *appServer) startSystemTrendSampler(id identity, interval time.Duration) {
+	if s.trendStore == nil {
+		return
+	}
+	if interval < 2*time.Second {
+		interval = 2 * time.Second
+	}
+
+	go func() {
+		s.sampleSystemTrendPoint(id)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			s.sampleSystemTrendPoint(id)
+		}
+	}()
+}
+
+func (s *appServer) sampleSystemTrendPoint(id identity) {
+	ctx, cancel := context.WithTimeout(context.Background(), s.commandTimeout)
+	defer cancel()
+
+	if mem, err := s.collectMemory(ctx, id); err == nil {
+		s.trendStore.pushMemoryPercent(mem.UsedPct)
+	}
+
+	if cpu, err := s.collectCPUTicks(ctx, id); err == nil {
+		s.trendStore.pushCPUTicks(cpu)
+	}
+}
+
+func parseUptimeAndLoad(raw string) (string, string) {
+	line := strings.TrimSpace(raw)
+	if line == "" {
+		return "-", "-"
+	}
+
+	loadLabel := "load averages:"
+	idx := strings.Index(line, loadLabel)
+	if idx < 0 {
+		loadLabel = "load average:"
+		idx = strings.Index(line, loadLabel)
+	}
+
+	uptime := line
+	load := "-"
+	if idx >= 0 {
+		load = strings.TrimSpace(line[idx+len(loadLabel):])
+		uptime = strings.TrimSpace(line[:idx])
+	}
+	if upIdx := strings.Index(uptime, " up "); upIdx >= 0 {
+		uptime = strings.TrimSpace(uptime[upIdx+4:])
+	}
+	if uptime == "" {
+		uptime = "-"
+	}
+	if load == "" {
+		load = "-"
+	}
+	return uptime, load
+}
+
+func (s *appServer) collectFilesystems(ctx context.Context, id identity) ([]filesystemStat, error) {
+	output, err := s.runHostOutput(ctx, id, "df", "-P", "-k", "-t", "ffs")
+	if err != nil {
+		output, err = s.runHostOutput(ctx, id, "df", "-k", "-t", "ffs")
+		if err != nil {
+			return nil, fmt.Errorf("filesystem stats unavailable: %w", err)
+		}
+	}
+
+	rows := make([]filesystemStat, 0, 16)
+	for _, line := range splitLines(output) {
+		if strings.HasPrefix(line, "Filesystem") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		sizeKB, ok1 := parseUint(fields[1])
+		usedKB, ok2 := parseUint(fields[2])
+		availKB, ok3 := parseUint(fields[3])
+		capPct, ok4 := parsePercent(fields[4])
+		if !ok1 || !ok2 || !ok3 || !ok4 {
+			continue
+		}
+		rows = append(rows, filesystemStat{
+			Filesystem: fields[0],
+			SizeKB:     sizeKB,
+			UsedKB:     usedKB,
+			AvailKB:    availKB,
+			Capacity:   capPct,
+			Mountpoint: strings.Join(fields[5:], " "),
+		})
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].Mountpoint < rows[j].Mountpoint
+	})
+
+	return rows, nil
+}
+
+func (s *appServer) collectMemory(ctx context.Context, id identity) (memoryStat, error) {
+	total, err := s.sysctlUint(ctx, id, "hw.physmem64")
+	if err != nil {
+		total, err = s.sysctlUint(ctx, id, "hw.physmem")
+		if err != nil {
+			return memoryStat{}, fmt.Errorf("memory stats unavailable: %w", err)
+		}
+	}
+
+	pageSize, pageErr := s.sysctlUint(ctx, id, "hw.pagesize")
+	freePages, freeErr := s.collectFreePages(ctx, id)
+
+	if pageErr != nil || freeErr != nil {
+		summary, vmErr := s.collectVMStatSummary(ctx, id)
+		if vmErr == nil {
+			if pageErr != nil && summary.HasPageSize {
+				pageSize = summary.PageSize
+				pageErr = nil
+			}
+			if freeErr != nil && summary.HasFreePages {
+				freePages = summary.FreePages
+				freeErr = nil
+			}
+		}
+
+		if pageErr != nil {
+			if vmErr != nil {
+				pageErr = fmt.Errorf("%w; vmstat fallback failed: %v", pageErr, vmErr)
+			}
+			return memoryStat{}, fmt.Errorf("memory page size unavailable: %w", pageErr)
+		}
+		if freeErr != nil {
+			if vmErr != nil {
+				freeErr = fmt.Errorf("%w; vmstat fallback failed: %v", freeErr, vmErr)
+			}
+			return memoryStat{}, fmt.Errorf("memory free pages unavailable: %w", freeErr)
+		}
+	}
+
+	free := freePages * pageSize
+	if free > total {
+		free = total
+	}
+	used := total - free
+	pct := 0
+	if total > 0 {
+		pct = int((used * 100) / total)
+	}
+
+	return memoryStat{
+		TotalBytes: total,
+		UsedBytes:  used,
+		FreeBytes:  free,
+		UsedPct:    pct,
+	}, nil
+}
+
+type vmstatSummary struct {
+	FreePages    uint64
+	PageSize     uint64
+	HasFreePages bool
+	HasPageSize  bool
+}
+
+func (s *appServer) collectFreePages(ctx context.Context, id identity) (uint64, error) {
+	freePages, err := s.sysctlUint(ctx, id, "vm.uvmexp.free")
+	if err == nil {
+		return freePages, nil
+	}
+
+	freePages, err = s.sysctlStructUint(ctx, id, "vm.uvmexp2", "free")
+	if err == nil {
+		return freePages, nil
+	}
+
+	freePages, err = s.sysctlStructUint(ctx, id, "vm.uvmexp", "free")
+	if err == nil {
+		return freePages, nil
+	}
+
+	return 0, err
+}
+
+func (s *appServer) collectVMStatSummary(ctx context.Context, id identity) (vmstatSummary, error) {
+	output, err := s.runHostOutput(ctx, id, "vmstat", "-s")
+	if err != nil {
+		return vmstatSummary{}, err
+	}
+	return parseVMStatSummary(output), nil
+}
+
+func parseVMStatSummary(raw string) vmstatSummary {
+	summary := vmstatSummary{}
+
+	for _, line := range splitLines(raw) {
+		fields := strings.Fields(strings.ReplaceAll(line, ",", ""))
+		if len(fields) == 0 {
+			continue
+		}
+
+		value, ok := parseUint(fields[0])
+		if !ok {
+			continue
+		}
+
+		lower := strings.ToLower(line)
+		if !summary.HasFreePages && strings.Contains(lower, "pages free") {
+			summary.FreePages = value
+			summary.HasFreePages = true
+		}
+		if !summary.HasPageSize && (strings.Contains(lower, "bytes per page") || strings.Contains(lower, "page size")) {
+			summary.PageSize = value
+			summary.HasPageSize = true
+		}
+
+		if summary.HasFreePages && summary.HasPageSize {
+			break
+		}
+	}
+
+	return summary
+}
+
+func (s *appServer) collectSwap(ctx context.Context, id identity) (swapStat, error) {
+	output, err := s.runHostOutput(ctx, id, "swapctl", "-lk")
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "not configured") || strings.Contains(lower, "no swap") {
+			return swapStat{HasSwap: false, Readable: true}, nil
+		}
+		return swapStat{}, fmt.Errorf("swap stats unavailable: %w", err)
+	}
+
+	total := uint64(0)
+	used := uint64(0)
+	avail := uint64(0)
+	found := false
+
+	for _, line := range splitLines(output) {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		if strings.EqualFold(fields[0], "device") {
+			continue
+		}
+		if strings.EqualFold(fields[0], "total") {
+			t, ok1 := parseUint(fields[1])
+			u, ok2 := parseUint(fields[2])
+			a, ok3 := parseUint(fields[3])
+			if ok1 && ok2 && ok3 {
+				total, used, avail = t, u, a
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		for _, line := range splitLines(output) {
+			fields := strings.Fields(line)
+			if len(fields) < 4 || strings.EqualFold(fields[0], "device") {
+				continue
+			}
+			t, ok1 := parseUint(fields[1])
+			u, ok2 := parseUint(fields[2])
+			a, ok3 := parseUint(fields[3])
+			if ok1 && ok2 && ok3 {
+				total += t
+				used += u
+				avail += a
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		return swapStat{HasSwap: false, Readable: true}, nil
+	}
+
+	pct := 0
+	if total > 0 {
+		pct = int((used * 100) / total)
+	}
+
+	return swapStat{
+		TotalKB:  total,
+		UsedKB:   used,
+		AvailKB:  avail,
+		UsedPct:  pct,
+		HasSwap:  total > 0,
+		Readable: true,
+	}, nil
+}
+
+func (s *appServer) collectInterfaces(ctx context.Context, id identity) ([]interfaceStat, error) {
+	ifconfigOut, err := s.runHostOutput(ctx, id, "ifconfig", "-a")
+	if err != nil {
+		return nil, fmt.Errorf("ifconfig stats unavailable: %w", err)
+	}
+
+	interfaces := parseIfconfig(ifconfigOut)
+	if len(interfaces) == 0 {
+		return interfaces, nil
+	}
+
+	counterByName := map[string][2]uint64{}
+	netstatOut, err := s.runHostOutput(ctx, id, "netstat", "-inb")
+	if err == nil {
+		counterByName = parseNetstatInterfaceBytes(netstatOut)
+	}
+
+	for i := range interfaces {
+		if counters, ok := counterByName[interfaces[i].Name]; ok {
+			interfaces[i].InBytes = counters[0]
+			interfaces[i].OutBytes = counters[1]
+		}
+	}
+
+	sort.Slice(interfaces, func(i, j int) bool { return interfaces[i].Name < interfaces[j].Name })
+	return interfaces, nil
+}
+
+func parseIfconfig(output string) []interfaceStat {
+	rows := make([]interfaceStat, 0, 16)
+	byName := map[string]int{}
+
+	for _, raw := range strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n") {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+
+		if len(raw) > 0 && raw[0] != ' ' && raw[0] != '\t' {
+			idx := strings.Index(raw, ":")
+			if idx <= 0 {
+				continue
+			}
+			name := strings.TrimSpace(raw[:idx])
+			row := interfaceStat{Name: name, Status: "unknown", MTU: -1}
+			if m := ifMTUPattern.FindStringSubmatch(raw); len(m) == 2 {
+				if mtu, err := strconv.Atoi(m[1]); err == nil {
+					row.MTU = mtu
+				}
+			}
+			rows = append(rows, row)
+			byName[name] = len(rows) - 1
+			continue
+		}
+
+		if len(rows) == 0 {
+			continue
+		}
+
+		row := &rows[len(rows)-1]
+		line := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(line, "status:"):
+			row.Status = strings.TrimSpace(strings.TrimPrefix(line, "status:"))
+		case strings.HasPrefix(line, "inet "):
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				row.Addresses = appendIfMissing(row.Addresses, fields[1])
+			}
+		case strings.HasPrefix(line, "inet6 "):
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				row.Addresses = appendIfMissing(row.Addresses, fields[1])
+			}
+		}
+	}
+
+	_ = byName
+	return rows
+}
+
+func parseNetstatInterfaceBytes(output string) map[string][2]uint64 {
+	out := map[string][2]uint64{}
+	for _, line := range splitLines(output) {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		name := fields[0]
+		if strings.EqualFold(name, "name") || strings.EqualFold(name, "kernel") {
+			continue
+		}
+		inB, outB, ok := parseLastTwoUint(fields)
+		if !ok {
+			continue
+		}
+		curr := out[name]
+		curr[0] += inB
+		curr[1] += outB
+		out[name] = curr
+	}
+	return out
+}
+
+func parseLastTwoUint(fields []string) (uint64, uint64, bool) {
+	nums := make([]uint64, 0, 2)
+	for i := len(fields) - 1; i >= 0 && len(nums) < 2; i-- {
+		if v, ok := parseUint(fields[i]); ok {
+			nums = append(nums, v)
+		}
+	}
+	if len(nums) < 2 {
+		return 0, 0, false
+	}
+	return nums[1], nums[0], true
+}
+
+func appendIfMissing(in []string, value string) []string {
+	for _, v := range in {
+		if v == value {
+			return in
+		}
+	}
+	return append(in, value)
+}
+
+func (s *appServer) collectIOStats(ctx context.Context, id identity) ([]ioDeviceStat, error) {
+	output, err := s.runHostOutput(ctx, id, "iostat", "-dx", "1", "2")
+	if err != nil {
+		output, err = s.runHostOutput(ctx, id, "iostat", "-x")
+		if err != nil {
+			return nil, fmt.Errorf("i/o stats unavailable: %w", err)
+		}
+	}
+
+	rows := parseIostat(output)
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Device < rows[j].Device })
+	return rows, nil
+}
+
+func parseIostat(output string) []ioDeviceStat {
+	lines := strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n")
+	if len(lines) == 0 {
+		return nil
+	}
+
+	headerIdx := -1
+	var headerFields []string
+	for i := len(lines) - 1; i >= 0; i-- {
+		f := strings.Fields(strings.TrimSpace(lines[i]))
+		if len(f) < 2 {
+			continue
+		}
+		first := strings.ToLower(f[0])
+		if first == "device" || first == "disk" {
+			headerIdx = i
+			headerFields = f
+			break
+		}
+	}
+	if headerIdx < 0 {
+		return nil
+	}
+
+	rows := make([]ioDeviceStat, 0, 16)
+	byDevice := map[string]int{}
+	for i := headerIdx + 1; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			if len(rows) > 0 {
+				break
+			}
+			continue
+		}
+		f := strings.Fields(line)
+		if len(f) < 2 {
+			continue
+		}
+		name := strings.ToLower(f[0])
+		if name == "tty" || name == "cpu" || name == "device" {
+			continue
+		}
+
+		metrics := make(map[string]string, len(headerFields)-1)
+		for h := 1; h < len(headerFields) && h < len(f); h++ {
+			metrics[strings.ToLower(headerFields[h])] = f[h]
+		}
+
+		key := normalizeIODeviceName(f[0])
+		if idx, ok := byDevice[key]; ok {
+			for metric, value := range metrics {
+				rows[idx].Metrics[metric] = value
+			}
+			continue
+		}
+
+		rows = append(rows, ioDeviceStat{Device: f[0], Metrics: metrics})
+		byDevice[key] = len(rows) - 1
+	}
+
+	return rows
+}
+
+func normalizeIODeviceName(name string) string {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	normalized = strings.TrimSuffix(normalized, ":")
+	return normalized
+}
+
+func (s *appServer) collectCPUTicks(ctx context.Context, id identity) (cpuTickStat, error) {
+	output, err := s.runHostOutput(ctx, id, "sysctl", "-n", "kern.cp_time")
+	if err != nil {
+		return cpuTickStat{}, fmt.Errorf("cpu stats unavailable: %w", err)
+	}
+
+	ticks, ok := parseCPUTicks(output)
+	if !ok {
+		return cpuTickStat{}, fmt.Errorf("cpu stats unavailable: cannot parse kern.cp_time")
+	}
+	return ticks, nil
+}
+
+func parseCPUTicks(raw string) (cpuTickStat, bool) {
+	tokens := strings.FieldsFunc(strings.TrimSpace(raw), func(r rune) bool {
+		return r < '0' || r > '9'
+	})
+
+	vals := make([]uint64, 0, 5)
+	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
+		if v, ok := parseUint(token); ok {
+			vals = append(vals, v)
+			if len(vals) == 5 {
+				break
+			}
+		}
+	}
+
+	if len(vals) < 5 {
+		return cpuTickStat{}, false
+	}
+
+	return cpuTickStat{
+		User:   vals[0],
+		Nice:   vals[1],
+		System: vals[2],
+		Intr:   vals[3],
+		Idle:   vals[4],
+	}, true
+}
+
+func (s *appServer) sysctlUint(ctx context.Context, id identity, key string) (uint64, error) {
+	output, err := s.runHostOutput(ctx, id, "sysctl", "-n", key)
+	if err != nil {
+		return 0, err
+	}
+	line := strings.TrimSpace(output)
+	if line == "" {
+		return 0, fmt.Errorf("empty sysctl output for %s", key)
+	}
+
+	if v, ok := parseUint(line); ok {
+		return v, nil
+	}
+	if m := bootSecPattern.FindStringSubmatch(line); len(m) == 2 {
+		if v, ok := parseUint(m[1]); ok {
+			return v, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot parse sysctl %s value: %q", key, line)
+}
+
+func (s *appServer) sysctlStructUint(ctx context.Context, id identity, key, field string) (uint64, error) {
+	output, err := s.runHostOutput(ctx, id, "sysctl", "-n", key)
+	if err != nil {
+		return 0, err
+	}
+	if v, ok := parseSysctlStructUintField(output, field); ok {
+		return v, nil
+	}
+	return 0, fmt.Errorf("cannot parse sysctl %s field %s", key, field)
+}
+
+func parseSysctlStructUintField(raw, field string) (uint64, bool) {
+	target := strings.ToLower(strings.TrimSpace(field))
+	if target == "" {
+		return 0, false
+	}
+
+	normalized := strings.NewReplacer("{", "", "}", "", "\n", ",", "\r", ",").Replace(raw)
+	for _, segment := range strings.Split(normalized, ",") {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+		parts := strings.SplitN(segment, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		if key != target {
+			continue
+		}
+		value := strings.TrimSpace(parts[1])
+		for _, token := range strings.Fields(value) {
+			token = strings.Trim(token, ",")
+			if v, ok := parseUint(token); ok {
+				return v, true
+			}
+		}
+		if v, ok := parseUint(strings.Trim(value, ",")); ok {
+			return v, true
+		}
+		return 0, false
+	}
+
+	return 0, false
+}
+
+func parseUint(s string) (uint64, bool) {
+	if s == "" || s == "-" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+func parsePercent(s string) (int, bool) {
+	s = strings.TrimSuffix(strings.TrimSpace(s), "%")
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	if v < 0 {
+		v = 0
+	}
+	if v > 100 {
+		v = 100
+	}
+	return v, true
+}
+
+func (s *appServer) loadCells(ctx context.Context, sess *session) ([]cellRow, error) {
+	res, err := s.runCellmgr(ctx, sess,
+		"cell", "list", "--view", "merged", "-T", "-H", "-o",
+		"name,cid,refs,procs,root,autostart,create_profile,create_reserved_ports,create_rlimit_nofile,create_rlimit_as,create_rlimit_core,supervise_cmd,cpu1s,cpu10s,memory,age,running,manifest",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cell list failed: %s", commandErrorMessage(err, res.Output))
+	}
+
+	var rows []cellRow
+	for _, line := range splitLines(res.Output) {
+		fields, ok := splitTSVFixed(line, 18)
+		if !ok {
+			continue
+		}
+		running, err := parseTSVBool(fields[16])
+		if err != nil {
+			continue
+		}
+		manifest, err := parseTSVBool(fields[17])
+		if err != nil {
+			continue
+		}
+		rows = append(rows, cellRow{
+			Name:                fields[0],
+			CID:                 fields[1],
+			Refs:                fields[2],
+			Procs:               fields[3],
+			Root:                fields[4],
+			Autostart:           fallback(fields[5], "NO"),
+			CreateProfile:       fields[6],
+			CreateReservedPorts: fields[7],
+			CreateRlimitNofile:  fields[8],
+			CreateRlimitAS:      fields[9],
+			CreateRlimitCore:    fields[10],
+			SuperviseCmd:        fields[11],
+			CPU1s:               fields[12],
+			CPU10s:              fields[13],
+			Memory:              fields[14],
+			Age:                 fields[15],
+			Running:             running,
+			ManifestPresent:     manifest,
+		})
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+	return rows, nil
+}
+
+func (s *appServer) loadStorage(ctx context.Context, sess *session) ([]volumeRow, error) {
+	volRes, err := s.runCellmgr(ctx, sess,
+		"volume", "list", "--view", "merged", "-T", "-H", "-o",
+		"name,manifest,runtime,mounted,refs,mode,path,used_by",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("volume list failed: %s", commandErrorMessage(err, volRes.Output))
+	}
+
+	cellRes, err := s.runCellmgr(ctx, sess,
+		"cell", "list", "--view", "merged", "-T", "-H", "-o",
+		"name,manifest,running,root",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cell list for overlays failed: %s", commandErrorMessage(err, cellRes.Output))
+	}
+
+	rows := make([]volumeRow, 0, 64)
+	for _, line := range splitLines(volRes.Output) {
+		fields, ok := splitTSVFixed(line, 8)
+		if !ok {
+			continue
+		}
+		manifest, err1 := parseTSVBool(fields[1])
+		runtime, err2 := parseTSVBool(fields[2])
+		mounted, err3 := parseTSVBool(fields[3])
+		if err1 != nil || err2 != nil || err3 != nil {
+			continue
+		}
+		rows = append(rows, volumeRow{
+			Kind:            "volume",
+			Name:            fields[0],
+			ManifestPresent: manifest,
+			RuntimePresent:  runtime,
+			Mounted:         mounted,
+			Refs:            fields[4],
+			Mode:            fields[5],
+			Path:            fields[6],
+			UsedBy:          fields[7],
+		})
+	}
+
+	for _, line := range splitLines(cellRes.Output) {
+		fields, ok := splitTSVFixed(line, 4)
+		if !ok {
+			continue
+		}
+		manifest, err1 := parseTSVBool(fields[1])
+		mounted, err2 := parseTSVBool(fields[2])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		root := strings.TrimSpace(fields[3])
+		runtime := root != "" && root != "-"
+		rows = append(rows, volumeRow{
+			Kind:            "overlay",
+			Name:            fields[0],
+			ManifestPresent: manifest,
+			RuntimePresent:  runtime,
+			Mounted:         mounted,
+			Refs:            "-",
+			Mode:            "-",
+			Path:            overlayPath(root),
+			UsedBy:          fields[0],
+		})
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Kind != rows[j].Kind {
+			return rows[i].Kind < rows[j].Kind
+		}
+		return rows[i].Name < rows[j].Name
+	})
+
+	return rows, nil
+}
+
+func (s *appServer) loadBackups(ctx context.Context, sess *session, kind, name string) ([]backupRow, error) {
+	resource := "volume"
+	if kind == "overlay" {
+		resource = "cell"
+	}
+
+	res, err := s.runCellmgr(ctx, sess, resource, "backup", "list", name, "-T", "-H")
+	if err != nil {
+		return nil, fmt.Errorf("backup list failed: %s", commandErrorMessage(err, res.Output))
+	}
+
+	rows := make([]backupRow, 0, 32)
+	for _, line := range splitLines(res.Output) {
+		fields, ok := splitTSVFixed(line, 4)
+		if !ok {
+			continue
+		}
+		rows = append(rows, backupRow{
+			Volume:    fields[0],
+			Timestamp: fields[1],
+			Size:      fields[2],
+			Archive:   fields[3],
+		})
+	}
+
+	return rows, nil
+}
+
+func parseTSVBool(v string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "yes", "true":
+		return true, nil
+	case "0", "no", "false", "":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid bool value %q", v)
+	}
+}
+
+func splitTSVFixed(line string, expected int) ([]string, bool) {
+	if strings.TrimSpace(line) == "" {
+		return nil, false
+	}
+	parts := strings.Split(line, "\t")
+	if len(parts) != expected {
+		return nil, false
+	}
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts, true
+}
+
+func splitLines(s string) []string {
+	raw := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func overlayPath(root string) string {
+	if root == "" || root == "-" {
+		return ""
+	}
+	if strings.HasSuffix(root, "/root") {
+		return strings.TrimSuffix(root, "/root") + "/.overlay"
+	}
+	return root + "/.overlay"
+}
+
+func commandErrorMessage(err error, output string) string {
+	msg := strings.TrimSpace(err.Error())
+	if output == "" {
+		return msg
+	}
+	return msg + ": " + output
+}
+
+func truncateOutput(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max < 6 {
+		return s[:max]
+	}
+	return s[:max-6] + "\n[...]"
+}
+
+func lookupIdentity(username string) (identity, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return identity{}, err
+	}
+	return buildIdentityFromUser(u)
+}
+
+func lookupProcessIdentity() (identity, error) {
+	euid := strconv.Itoa(os.Geteuid())
+	u, err := user.LookupId(euid)
+	if err != nil {
+		return identity{}, err
+	}
+	return buildIdentityFromUser(u)
+}
+
+func buildIdentityFromUser(u *user.User) (identity, error) {
+	if u == nil {
+		return identity{}, fmt.Errorf("nil user")
+	}
+
+	uid64, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return identity{}, fmt.Errorf("parse uid: %w", err)
+	}
+	gid64, err := strconv.ParseUint(u.Gid, 10, 32)
+	if err != nil {
+		return identity{}, fmt.Errorf("parse gid: %w", err)
+	}
+
+	gidStrs, err := u.GroupIds()
+	if err != nil {
+		return identity{}, fmt.Errorf("lookup groups: %w", err)
+	}
+
+	groups := make([]uint32, 0, len(gidStrs))
+	for _, gs := range gidStrs {
+		g, err := strconv.ParseUint(gs, 10, 32)
+		if err != nil {
+			continue
+		}
+		groups = append(groups, uint32(g))
+	}
+	if len(groups) == 0 {
+		groups = []uint32{uint32(gid64)}
+	}
+
+	return identity{
+		Username: u.Username,
+		UID:      uint32(uid64),
+		GID:      uint32(gid64),
+		Groups:   groups,
+		HomeDir:  fallback(u.HomeDir, "/"),
+	}, nil
+}
+
+func fallback(value, alt string) string {
+	if strings.TrimSpace(value) == "" {
+		return alt
+	}
+	return value
+}
+
+func configValue(value, alt string) string {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return alt
+	}
+	return v
+}
+
+func resolveTLSMode(enabled bool, certFile, keyFile string) (string, error) {
+	if !enabled {
+		if strings.TrimSpace(certFile) != "" || strings.TrimSpace(keyFile) != "" {
+			return "", errors.New("-tls=false cannot be combined with -tls-cert or -tls-key")
+		}
+		return tlsModeOff, nil
+	}
+
+	hasCert := strings.TrimSpace(certFile) != ""
+	hasKey := strings.TrimSpace(keyFile) != ""
+	if hasCert != hasKey {
+		return "", errors.New("manual TLS requires both -tls-cert and -tls-key")
+	}
+	if hasCert {
+		return tlsModeManual, nil
+	}
+	return tlsModeSelfSigned, nil
+}
+
+type filteredHTTPServerErrorWriter struct {
+	dst io.Writer
+}
+
+func (w filteredHTTPServerErrorWriter) Write(p []byte) (int, error) {
+	line := strings.TrimSpace(string(p))
+	if strings.Contains(line, "http: TLS handshake error") {
+		return len(p), nil
+	}
+	if w.dst == nil {
+		return len(p), nil
+	}
+	if _, err := w.dst.Write(p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func fallbackDir(home string) string {
+	if home == "" {
+		return "/"
+	}
+	if st, err := os.Stat(home); err == nil && st.IsDir() {
+		return home
+	}
+	return "/"
+}
+
+func randomToken(size int) (string, error) {
+	buf := make([]byte, size)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func decodeJSON(r *http.Request, dst any) error {
+	defer r.Body.Close()
+
+	limited := io.LimitReader(r.Body, maxJSONBodyBytes)
+	dec := json.NewDecoder(limited)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	if dec.More() {
+		return fmt.Errorf("multiple JSON values in body")
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeAPIError(w http.ResponseWriter, status int, message, detail string) {
+	writeJSON(w, status, map[string]any{
+		"ok":      false,
+		"error":   message,
+		"details": detail,
+	})
+}
+
+func methodNotAllowed(w http.ResponseWriter, allowed ...string) {
+	w.Header().Set("Allow", strings.Join(allowed, ", "))
+	writeAPIError(w, http.StatusMethodNotAllowed, "Method not allowed", "")
+}
+
+func remoteKey(r *http.Request) string {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+func envOrDefault(key, fallback string) string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+func envBoolOrDefault(key string, fallback bool) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if v == "" {
+		return fallback
+	}
+	switch v {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
+}
+
+func withSecurityHeaders(next http.Handler, enableHSTS bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Referrer-Policy", "same-origin")
+		if enableHSTS && r.TLS != nil {
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+		}
+		w.Header().Set("Content-Security-Policy",
+			"default-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'; base-uri 'none'; frame-ancestors 'none'")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/usr.sbin/cellweb/cmd/cellweb/main_test.go
+++ b/usr.sbin/cellweb/cmd/cellweb/main_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseVMStatSummary(t *testing.T) {
+	raw := `
+4096 bytes per page
+1,234 pages free
+`
+
+	summary := parseVMStatSummary(raw)
+	if !summary.HasPageSize {
+		t.Fatalf("expected page size to be detected")
+	}
+	if !summary.HasFreePages {
+		t.Fatalf("expected free pages to be detected")
+	}
+	if summary.PageSize != 4096 {
+		t.Fatalf("unexpected page size: got %d want %d", summary.PageSize, 4096)
+	}
+	if summary.FreePages != 1234 {
+		t.Fatalf("unexpected free pages: got %d want %d", summary.FreePages, 1234)
+	}
+}
+
+func TestParseIostatDeduplicatesDevices(t *testing.T) {
+	raw := `
+disk xfer read write
+sd0 1 2 3
+sd1 4 5 6
+sd0: 7 8 9
+`
+
+	rows := parseIostat(raw)
+	if len(rows) != 2 {
+		t.Fatalf("unexpected row count: got %d want %d", len(rows), 2)
+	}
+
+	row := findIODeviceRow(rows, "sd0")
+	if row == nil {
+		t.Fatalf("expected sd0 row to exist")
+	}
+	if got := row.Metrics["xfer"]; got != "7" {
+		t.Fatalf("unexpected xfer value: got %q want %q", got, "7")
+	}
+	if got := row.Metrics["read"]; got != "8" {
+		t.Fatalf("unexpected read value: got %q want %q", got, "8")
+	}
+	if got := row.Metrics["write"]; got != "9" {
+		t.Fatalf("unexpected write value: got %q want %q", got, "9")
+	}
+}
+
+func TestParseCPUTicks(t *testing.T) {
+	ticks, ok := parseCPUTicks("123 45 67 8 910")
+	if !ok {
+		t.Fatalf("expected cpu ticks to parse")
+	}
+	if ticks.User != 123 || ticks.Nice != 45 || ticks.System != 67 || ticks.Intr != 8 || ticks.Idle != 910 {
+		t.Fatalf("unexpected cpu ticks: %+v", ticks)
+	}
+
+	ticks, ok = parseCPUTicks("kern.cp_time = { 500, 40, 70, 10, 900 }")
+	if !ok {
+		t.Fatalf("expected cpu ticks to parse with labels/braces")
+	}
+	if ticks.User != 500 || ticks.Nice != 40 || ticks.System != 70 || ticks.Intr != 10 || ticks.Idle != 900 {
+		t.Fatalf("unexpected cpu ticks from labeled input: %+v", ticks)
+	}
+}
+
+func TestParseCPUTicksRejectsInvalidInput(t *testing.T) {
+	if _, ok := parseCPUTicks("12 34"); ok {
+		t.Fatalf("expected parse failure for short input")
+	}
+	if _, ok := parseCPUTicks("12 xx 34 56 78"); ok {
+		t.Fatalf("expected parse failure for non-numeric input")
+	}
+}
+
+func TestSystemTrendStoreKeepsRecentSeries(t *testing.T) {
+	store := newSystemTrendStore(3)
+
+	store.pushMemoryPercent(10)
+	store.pushMemoryPercent(20)
+	store.pushMemoryPercent(30)
+	store.pushMemoryPercent(40)
+
+	store.pushCPUTicks(cpuTickStat{User: 100, Nice: 0, System: 50, Intr: 0, Idle: 850})
+	store.pushCPUTicks(cpuTickStat{User: 200, Nice: 0, System: 100, Intr: 0, Idle: 900})
+	store.pushCPUTicks(cpuTickStat{User: 220, Nice: 0, System: 140, Intr: 0, Idle: 940})
+
+	snap := store.snapshot()
+	if snap == nil {
+		t.Fatalf("expected trend snapshot")
+	}
+
+	if len(snap.MemoryUsedPct) != 3 {
+		t.Fatalf("unexpected memory series length: got %d want 3", len(snap.MemoryUsedPct))
+	}
+	if snap.MemoryUsedPct[0] != 20 || snap.MemoryUsedPct[1] != 30 || snap.MemoryUsedPct[2] != 40 {
+		t.Fatalf("unexpected memory series: %+v", snap.MemoryUsedPct)
+	}
+
+	if len(snap.CPUUserPercent) != 2 {
+		t.Fatalf("unexpected cpu user series length: got %d want 2", len(snap.CPUUserPercent))
+	}
+	if len(snap.CPUSystemPercent) != 2 {
+		t.Fatalf("unexpected cpu system series length: got %d want 2", len(snap.CPUSystemPercent))
+	}
+
+	if math.Abs(snap.CPUUserPercent[0]-50.0) > 0.001 || math.Abs(snap.CPUSystemPercent[0]-25.0) > 0.001 {
+		t.Fatalf("unexpected first cpu sample: user=%f system=%f", snap.CPUUserPercent[0], snap.CPUSystemPercent[0])
+	}
+	if math.Abs(snap.CPUUserPercent[1]-20.0) > 0.001 || math.Abs(snap.CPUSystemPercent[1]-40.0) > 0.001 {
+		t.Fatalf("unexpected second cpu sample: user=%f system=%f", snap.CPUUserPercent[1], snap.CPUSystemPercent[1])
+	}
+}
+
+func TestResolveTLSMode(t *testing.T) {
+	mode, err := resolveTLSMode(false, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != tlsModeOff {
+		t.Fatalf("unexpected mode: got %q want %q", mode, tlsModeOff)
+	}
+
+	mode, err = resolveTLSMode(true, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != tlsModeSelfSigned {
+		t.Fatalf("unexpected mode: got %q want %q", mode, tlsModeSelfSigned)
+	}
+
+	mode, err = resolveTLSMode(true, "/tmp/cert.pem", "/tmp/key.pem")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != tlsModeManual {
+		t.Fatalf("unexpected mode: got %q want %q", mode, tlsModeManual)
+	}
+}
+
+func TestResolveTLSModeRejectsInvalidCombinations(t *testing.T) {
+	if _, err := resolveTLSMode(false, "/tmp/cert.pem", ""); err == nil {
+		t.Fatalf("expected error when tls is disabled but cert/key are provided")
+	}
+	if _, err := resolveTLSMode(true, "/tmp/cert.pem", ""); err == nil {
+		t.Fatalf("expected error when only cert is provided")
+	}
+	if _, err := resolveTLSMode(true, "", "/tmp/key.pem"); err == nil {
+		t.Fatalf("expected error when only key is provided")
+	}
+}
+
+func findIODeviceRow(rows []ioDeviceStat, name string) *ioDeviceStat {
+	target := normalizeIODeviceName(name)
+	for i := range rows {
+		if normalizeIODeviceName(rows[i].Device) == target {
+			return &rows[i]
+		}
+	}
+	return nil
+}

--- a/usr.sbin/cellweb/cmd/cellweb/security_headers_test.go
+++ b/usr.sbin/cellweb/cmd/cellweb/security_headers_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWithSecurityHeadersSetsHSTSWhenEnabledAndTLS(t *testing.T) {
+	h := withSecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}), true)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.local/", nil)
+	req.TLS = &tls.ConnectionState{}
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Strict-Transport-Security"); got == "" {
+		t.Fatalf("expected HSTS header when enabled over TLS")
+	}
+}
+
+func TestWithSecurityHeadersSkipsHSTSWhenDisabled(t *testing.T) {
+	h := withSecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}), false)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.local/", nil)
+	req.TLS = &tls.ConnectionState{}
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Fatalf("expected no HSTS header when disabled, got %q", got)
+	}
+}

--- a/usr.sbin/cellweb/cmd/cellweb/tls_localca.go
+++ b/usr.sbin/cellweb/cmd/cellweb/tls_localca.go
@@ -1,0 +1,955 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"html"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	tlsModeOff        = "off"
+	tlsModeSelfSigned = "selfsigned"
+	tlsModeManual     = "manual"
+
+	secureCookiesModeAuto = "auto"
+	secureCookiesModeOn   = "on"
+	secureCookiesModeOff  = "off"
+
+	defaultPKIDir      = "/var/db/cellweb/pki"
+	localCACertRoute   = "/.well-known/ca.crt"
+	httpBootstrapRoute = "/bootstrap"
+
+	rootCAOrganization = "Petermann Digital"
+	rootCACommonName   = "NetBSD Cells Appliance Local Root CA"
+)
+
+type trustInfo struct {
+	TLS                 bool   `json:"tls"`
+	Mode                string `json:"mode"`
+	CADownloadPath      string `json:"ca_download_path,omitempty"`
+	CAFingerprintSHA256 string `json:"ca_fingerprint_sha256,omitempty"`
+	CASubject           string `json:"ca_subject,omitempty"`
+	CANotAfter          string `json:"ca_not_after,omitempty"`
+	BootstrapHint       string `json:"bootstrap_hint,omitempty"`
+}
+
+type tlsRuntime struct {
+	Enabled       bool
+	Mode          string
+	CertFile      string
+	KeyFile       string
+	CACertPEM     []byte
+	BootstrapHost string
+	Trust         trustInfo
+}
+
+type certSANs struct {
+	DNS []string
+	IPs []net.IP
+}
+
+func normalizeTLSMode(raw string) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(raw))
+	if mode == "" {
+		mode = tlsModeOff
+	}
+	switch mode {
+	case tlsModeOff, tlsModeSelfSigned, tlsModeManual:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid TLS mode %q (expected off|selfsigned|manual)", raw)
+	}
+}
+
+func resolveSecureCookieSetting(rawMode string, legacyEnable, tlsEnabled bool) (bool, error) {
+	if legacyEnable {
+		return true, nil
+	}
+	mode := strings.ToLower(strings.TrimSpace(rawMode))
+	if mode == "" {
+		mode = secureCookiesModeAuto
+	}
+	switch mode {
+	case secureCookiesModeAuto:
+		return tlsEnabled, nil
+	case secureCookiesModeOn:
+		return true, nil
+	case secureCookiesModeOff:
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid -secure-cookies-mode %q (expected auto|on|off)", rawMode)
+	}
+}
+
+func secureCookiesModeFromEnv() string {
+	if mode := strings.ToLower(strings.TrimSpace(os.Getenv("CELLWEB_SECURE_COOKIES_MODE"))); mode != "" {
+		return mode
+	}
+	return secureCookiesModeAuto
+}
+
+func prepareTLSRuntime(
+	listenAddr, modeRaw, pkiDir, certFile, keyFile, sanCSV, exportCA string,
+	logger *log.Logger,
+) (tlsRuntime, error) {
+	mode, err := normalizeTLSMode(modeRaw)
+	if err != nil {
+		return tlsRuntime{}, err
+	}
+
+	runtime := tlsRuntime{Mode: mode, Trust: trustInfo{TLS: mode != tlsModeOff, Mode: mode}}
+
+	switch mode {
+	case tlsModeOff:
+		if strings.TrimSpace(exportCA) != "" {
+			return tlsRuntime{}, errors.New("-tls-export-ca requires TLS selfsigned mode")
+		}
+		return runtime, nil
+
+	case tlsModeManual:
+		certFile = strings.TrimSpace(certFile)
+		keyFile = strings.TrimSpace(keyFile)
+		if certFile == "" || keyFile == "" {
+			return tlsRuntime{}, errors.New("manual TLS mode requires both -tls-cert and -tls-key")
+		}
+		if strings.TrimSpace(exportCA) != "" {
+			return tlsRuntime{}, errors.New("-tls-export-ca is only supported in selfsigned mode")
+		}
+		runtime.Enabled = true
+		runtime.CertFile = certFile
+		runtime.KeyFile = keyFile
+		runtime.Trust.BootstrapHint = "TLS is active with manual certificate files. Verify your certificate chain in the browser/OS trust store."
+		return runtime, nil
+
+	case tlsModeSelfSigned:
+		pkiDir = strings.TrimSpace(pkiDir)
+		if pkiDir == "" {
+			pkiDir = defaultPKIDir
+		}
+
+		sans, err := buildRequiredSANs(listenAddr, sanCSV)
+		if err != nil {
+			return tlsRuntime{}, err
+		}
+		runtime.BootstrapHost = preferredBootstrapHost(sans)
+
+		caCert, caKey, caPEM, caCreated, err := loadOrCreateRootCA(pkiDir, logger)
+		if err != nil {
+			return tlsRuntime{}, err
+		}
+		if logger != nil && caCreated {
+			logger.Printf("created files: %s, %s", filepath.Join(pkiDir, "ca.crt"), filepath.Join(pkiDir, "ca.key"))
+		}
+
+		serverCertFile := filepath.Join(pkiDir, "server.crt")
+		serverKeyFile := filepath.Join(pkiDir, "server.key")
+		serverCreated, err := loadOrCreateServerCert(serverCertFile, serverKeyFile, caCert, caKey, sans, logger)
+		if err != nil {
+			return tlsRuntime{}, err
+		}
+		if logger != nil && serverCreated {
+			logger.Printf("created files: %s, %s", serverCertFile, serverKeyFile)
+		}
+
+		if exportCA = strings.TrimSpace(exportCA); exportCA != "" {
+			if err := exportCACertificate(exportCA, caPEM); err != nil {
+				return tlsRuntime{}, fmt.Errorf("export root CA: %w", err)
+			}
+			if logger != nil {
+				logger.Printf("created file: %s", exportCA)
+			}
+		}
+
+		fp := certificateSHA256Fingerprint(caCert.Raw)
+		runtime.Enabled = true
+		runtime.CertFile = serverCertFile
+		runtime.KeyFile = serverKeyFile
+		runtime.CACertPEM = caPEM
+		runtime.Trust = trustInfo{
+			TLS:                 true,
+			Mode:                mode,
+			CADownloadPath:      localCACertRoute,
+			CAFingerprintSHA256: fp,
+			CASubject:           caCert.Subject.String(),
+			CANotAfter:          caCert.NotAfter.UTC().Format(time.RFC3339),
+			BootstrapHint:       "Download the Root CA, then verify this fingerprint against SSH/console output before importing into your browser or OS trust store.",
+		}
+		return runtime, nil
+
+	default:
+		return tlsRuntime{}, fmt.Errorf("unsupported tls mode: %s", mode)
+	}
+}
+
+func buildRequiredSANs(listenAddr, sanCSV string) (certSANs, error) {
+	dnsSet := map[string]struct{}{}
+	ipSet := map[string]net.IP{}
+
+	addDNS := func(name string) {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name == "" {
+			return
+		}
+		dnsSet[name] = struct{}{}
+	}
+	addIP := func(ip net.IP) {
+		if ip == nil {
+			return
+		}
+		ip = normalizeIP(ip)
+		ipSet[ip.String()] = ip
+	}
+
+	addDNS("localhost")
+	addIP(net.ParseIP("127.0.0.1"))
+	addIP(net.ParseIP("::1"))
+
+	host := extractListenHost(listenAddr)
+	if ip := net.ParseIP(host); ip != nil {
+		if !ip.IsUnspecified() {
+			addIP(ip)
+		}
+	} else if host != "" && host != "*" {
+		addDNS(host)
+	}
+
+	if strings.TrimSpace(sanCSV) == "" {
+		if mdnsName, ok := defaultMDNSSAN(); ok {
+			addDNS(mdnsName)
+		}
+	}
+
+	for _, token := range strings.Split(sanCSV, ",") {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if ip := net.ParseIP(token); ip != nil {
+			addIP(ip)
+			continue
+		}
+		if !isLikelyDNSName(token) {
+			return certSANs{}, fmt.Errorf("invalid -tls-san entry %q", token)
+		}
+		addDNS(token)
+	}
+
+	dns := make([]string, 0, len(dnsSet))
+	for name := range dnsSet {
+		dns = append(dns, name)
+	}
+	sort.Strings(dns)
+
+	ipKeys := make([]string, 0, len(ipSet))
+	for key := range ipSet {
+		ipKeys = append(ipKeys, key)
+	}
+	sort.Strings(ipKeys)
+	ips := make([]net.IP, 0, len(ipKeys))
+	for _, key := range ipKeys {
+		ips = append(ips, ipSet[key])
+	}
+
+	return certSANs{DNS: dns, IPs: ips}, nil
+}
+
+func loadOrCreateRootCA(pkiDir string, logger *log.Logger) (*x509.Certificate, *ecdsa.PrivateKey, []byte, bool, error) {
+	if err := ensureDirSecure(pkiDir); err != nil {
+		return nil, nil, nil, false, fmt.Errorf("prepare pki dir: %w", err)
+	}
+
+	caCertPath := filepath.Join(pkiDir, "ca.crt")
+	caKeyPath := filepath.Join(pkiDir, "ca.key")
+
+	caCert, caPEM, certErr := loadCertificateFromPEMFile(caCertPath)
+	caKey, keyErr := loadECDSAPrivateKeyFile(caKeyPath)
+	if certErr == nil && keyErr == nil {
+		if caCert.IsCA && rootCASubjectMatches(caCert) && time.Until(caCert.NotAfter) > 45*24*time.Hour {
+			return caCert, caKey, caPEM, false, nil
+		}
+	}
+
+	if (certErr == nil) != (keyErr == nil) {
+		return nil, nil, nil, false, errors.New("incomplete root CA files: need both ca.crt and ca.key")
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("generate root CA key: %w", err)
+	}
+
+	now := time.Now().UTC()
+	tmpl := &x509.Certificate{
+		SerialNumber:          randomSerialNumber(),
+		Subject:               pkix.Name{CommonName: rootCACommonName, Organization: []string{rootCAOrganization}},
+		NotBefore:             now.Add(-5 * time.Minute),
+		NotAfter:              now.AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		MaxPathLenZero:        true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("create root CA cert: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("marshal root CA key: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	if err := writeFileAtomicWithMode(caCertPath, certPEM, 0644); err != nil {
+		return nil, nil, nil, false, fmt.Errorf("write root CA cert: %w", err)
+	}
+	if err := writeFileAtomicWithMode(caKeyPath, keyPEM, 0600); err != nil {
+		return nil, nil, nil, false, fmt.Errorf("write root CA key: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("parse generated root CA cert: %w", err)
+	}
+
+	return cert, key, certPEM, true, nil
+}
+
+func loadOrCreateServerCert(certPath, keyPath string, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, sans certSANs, logger *log.Logger) (bool, error) {
+	existingCert, _, certErr := loadCertificateFromPEMFile(certPath)
+	existingKey, keyErr := loadECDSAPrivateKeyFile(keyPath)
+	if certErr == nil && keyErr == nil {
+		if serverCertMatches(existingCert, caCert, sans) && existingKey != nil {
+			return false, nil
+		}
+	}
+
+	if (certErr == nil) != (keyErr == nil) {
+		return false, errors.New("incomplete server certificate files: need both server.crt and server.key")
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return false, fmt.Errorf("generate server key: %w", err)
+	}
+
+	cn := "localhost"
+	if len(sans.DNS) > 0 {
+		cn = sans.DNS[0]
+	} else if len(sans.IPs) > 0 {
+		cn = sans.IPs[0].String()
+	}
+
+	now := time.Now().UTC()
+	tmpl := &x509.Certificate{
+		SerialNumber: randomSerialNumber(),
+		Subject:      pkix.Name{CommonName: cn, Organization: []string{rootCAOrganization}},
+		NotBefore:    now.Add(-5 * time.Minute),
+		NotAfter:     now.AddDate(0, 0, 90),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     append([]string(nil), sans.DNS...),
+		IPAddresses:  append([]net.IP(nil), sans.IPs...),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return false, fmt.Errorf("create server cert: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return false, fmt.Errorf("marshal server key: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	if err := writeFileAtomicWithMode(certPath, certPEM, 0644); err != nil {
+		return false, fmt.Errorf("write server cert: %w", err)
+	}
+	if err := writeFileAtomicWithMode(keyPath, keyPEM, 0600); err != nil {
+		return false, fmt.Errorf("write server key: %w", err)
+	}
+
+	return true, nil
+}
+
+func exportCACertificate(path string, certPEM []byte) error {
+	if len(certPEM) == 0 {
+		return errors.New("missing CA certificate data")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return writeFileAtomicWithMode(path, certPEM, 0644)
+}
+
+func loadCertificateFromPEMFile(path string) (*x509.Certificate, []byte, error) {
+	pemData, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	block, _ := pem.Decode(pemData)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, nil, fmt.Errorf("%s does not contain a certificate PEM block", path)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, pemData, nil
+}
+
+func loadECDSAPrivateKeyFile(path string) (*ecdsa.PrivateKey, error) {
+	pemData, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("%s does not contain a PEM block", path)
+	}
+
+	if block.Type == "EC PRIVATE KEY" {
+		return x509.ParseECPrivateKey(block.Bytes)
+	}
+
+	if block.Type == "PRIVATE KEY" {
+		keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		ecdsaKey, ok := keyAny.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("%s private key is not ECDSA", path)
+		}
+		return ecdsaKey, nil
+	}
+
+	return nil, fmt.Errorf("unsupported private key type %q in %s", block.Type, path)
+}
+
+func serverCertMatches(cert, caCert *x509.Certificate, sans certSANs) bool {
+	if cert == nil || caCert == nil {
+		return false
+	}
+	if time.Until(cert.NotAfter) <= 7*24*time.Hour {
+		return false
+	}
+	if err := cert.CheckSignatureFrom(caCert); err != nil {
+		return false
+	}
+
+	certDNS := map[string]struct{}{}
+	for _, name := range cert.DNSNames {
+		certDNS[strings.ToLower(strings.TrimSpace(name))] = struct{}{}
+	}
+	for _, requiredName := range sans.DNS {
+		if _, ok := certDNS[strings.ToLower(requiredName)]; !ok {
+			return false
+		}
+	}
+
+	certIPs := map[string]struct{}{}
+	for _, ip := range cert.IPAddresses {
+		certIPs[normalizeIP(ip).String()] = struct{}{}
+	}
+	for _, requiredIP := range sans.IPs {
+		if _, ok := certIPs[normalizeIP(requiredIP).String()]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func ensureDirSecure(path string) error {
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0700)
+}
+
+func writeFileAtomicWithMode(path string, data []byte, mode os.FileMode) error {
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, mode); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func extractListenHost(listenAddr string) string {
+	listenAddr = strings.TrimSpace(listenAddr)
+	if listenAddr == "" {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(listenAddr)
+	if err == nil {
+		return strings.Trim(host, "[]")
+	}
+	if strings.HasPrefix(listenAddr, ":") {
+		return ""
+	}
+	return strings.Trim(listenAddr, "[]")
+}
+
+func isLikelyDNSName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" || len(name) > 253 || strings.HasPrefix(name, ".") || strings.HasSuffix(name, ".") {
+		return false
+	}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	for _, label := range strings.Split(name, ".") {
+		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeIP(ip net.IP) net.IP {
+	if ip == nil {
+		return nil
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip.To16()
+}
+
+func randomSerialNumber() *big.Int {
+	max := new(big.Int).Lsh(big.NewInt(1), 128)
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil || n.Sign() <= 0 {
+		return big.NewInt(time.Now().UnixNano())
+	}
+	return n
+}
+
+func certificateSHA256Fingerprint(certDER []byte) string {
+	sum := sha256.Sum256(certDER)
+	hexUpper := strings.ToUpper(hex.EncodeToString(sum[:]))
+	parts := make([]string, 0, len(hexUpper)/2)
+	for i := 0; i < len(hexUpper); i += 2 {
+		parts = append(parts, hexUpper[i:i+2])
+	}
+	return strings.Join(parts, ":")
+}
+
+func startHTTPRedirectServer(logger *log.Logger, listenAddr, tlsAddr string, caCertPEM []byte) {
+	handler := newHTTPBootstrapHandler(tlsAddr, caCertPEM)
+
+	srv := &http.Server{
+		Addr:              listenAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if logger != nil {
+			logger.Printf("http listener failed: %v", err)
+		}
+	}
+}
+
+func newHTTPBootstrapHandler(tlsAddr string, caCertPEM []byte) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(caCertPEM) > 0 {
+			switch r.URL.Path {
+			case localCACertRoute:
+				if r.Method != http.MethodGet {
+					w.Header().Set("Allow", http.MethodGet)
+					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+					return
+				}
+				w.Header().Set("Content-Type", "application/x-pem-file")
+				w.Header().Set("Content-Disposition", `attachment; filename="cellweb-root-ca.crt"`)
+				w.Header().Set("Cache-Control", "no-store")
+				_, _ = w.Write(caCertPEM)
+				return
+			case "/style.css":
+				if r.Method != http.MethodGet {
+					w.Header().Set("Allow", http.MethodGet)
+					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+					return
+				}
+				css, err := webAssets.ReadFile("web/style.css")
+				if err != nil {
+					http.Error(w, "style missing", http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "text/css; charset=utf-8")
+				w.Header().Set("Cache-Control", "no-store")
+				_, _ = w.Write(css)
+				return
+			case "/", httpBootstrapRoute:
+				if r.Method != http.MethodGet {
+					w.Header().Set("Allow", http.MethodGet)
+					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+					return
+				}
+				httpsURL := (&url.URL{Scheme: "https", Host: buildHTTPSRedirectHost(r.Host, tlsAddr), Path: "/"}).String()
+				page := buildHTTPBootstrapPageHTML(httpsURL)
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.Header().Set("Cache-Control", "no-store")
+				_, _ = w.Write([]byte(page))
+				return
+			}
+		}
+
+		host := buildHTTPSRedirectHost(r.Host, tlsAddr)
+		target := &url.URL{
+			Scheme:   "https",
+			Host:     host,
+			Path:     r.URL.Path,
+			RawQuery: r.URL.RawQuery,
+		}
+		http.Redirect(w, r, target.String(), http.StatusMovedPermanently)
+	})
+}
+
+func buildHTTPBootstrapPageHTML(httpsURL string) string {
+	return fmt.Sprintf(`<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>cellweb bootstrap</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <div class="bg-orb orb-1"></div>
+  <div class="bg-orb orb-2"></div>
+  <div class="bg-grid"></div>
+
+  <main class="layout">
+    <section class="card login-card bootstrap-card reveal">
+      <div class="card-header">
+        <div class="brand">cellweb</div>
+      </div>
+
+      <h1>Browser trust bootstrap</h1>
+      <p>Download the Root CA certificate, compare the fingerprint with your SSH/console output, then import it into your browser or OS trust store.</p>
+
+      <ol class="bootstrap-help">
+        <li>Download the Root CA certificate with the button below.</li>
+        <li>Compare the certificate fingerprint with the one printed on startup.</li>
+        <li>Import the certificate into your trust store.</li>
+        <li>Continue to the HTTPS login page.</li>
+      </ol>
+
+      <div class="bootstrap-actions">
+        <a class="btn action-default" href="%s" download="cellweb-root-ca.crt">Download Root CA certificate</a>
+        <a class="btn ghost" href="%s">Continue to HTTPS login</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>
+`, localCACertRoute, html.EscapeString(httpsURL))
+}
+
+func buildHTTPSRedirectHost(requestHost, tlsListenAddr string) string {
+	tlsHost, tlsPort := splitListenAddress(tlsListenAddr)
+	host := strings.TrimSpace(requestHost)
+	if host == "" {
+		host = tlsHost
+	}
+
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	host = strings.Trim(host, "[]")
+
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		if tlsHost != "" && tlsHost != "0.0.0.0" && tlsHost != "::" {
+			host = tlsHost
+		} else {
+			host = "localhost"
+		}
+	}
+
+	if tlsPort == "" || tlsPort == "443" {
+		return host
+	}
+	return net.JoinHostPort(host, tlsPort)
+}
+
+func splitListenAddress(addr string) (string, string) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "", ""
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err == nil {
+		return strings.Trim(host, "[]"), port
+	}
+	if strings.HasPrefix(addr, ":") {
+		return "", strings.TrimPrefix(addr, ":")
+	}
+	return strings.Trim(addr, "[]"), ""
+}
+
+func joinIPsForLog(values []net.IP) string {
+	if len(values) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, 0, len(values))
+	for _, ip := range values {
+		parts = append(parts, normalizeIP(ip).String())
+	}
+	return strings.Join(parts, ", ")
+}
+
+func defaultMDNSSAN() (string, bool) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", false
+	}
+	return mdnsSANFromHostname(hostname)
+}
+
+func mdnsSANFromHostname(hostname string) (string, bool) {
+	h := strings.ToLower(strings.TrimSpace(hostname))
+	h = strings.Trim(h, ".")
+	if h == "" {
+		return "", false
+	}
+	if idx := strings.IndexByte(h, '.'); idx > 0 {
+		h = h[:idx]
+	}
+	if h == "" || strings.Contains(h, ".") || !isLikelyDNSName(h) {
+		return "", false
+	}
+	return h + ".local", true
+}
+
+func rootCASubjectMatches(cert *x509.Certificate) bool {
+	if cert == nil {
+		return false
+	}
+	if cert.Subject.CommonName != rootCACommonName {
+		return false
+	}
+	if len(cert.Subject.Organization) == 0 {
+		return false
+	}
+	return cert.Subject.Organization[0] == rootCAOrganization
+}
+
+func rootCARotationReason(cert *x509.Certificate) string {
+	if cert == nil {
+		return "existing root CA is missing or unreadable"
+	}
+	if !cert.IsCA {
+		return "existing ca.crt is not a CA certificate"
+	}
+	if !rootCASubjectMatches(cert) {
+		return "existing root CA subject does not match appliance defaults"
+	}
+	if time.Until(cert.NotAfter) <= 45*24*time.Hour {
+		return "existing root CA expires in less than 45 days"
+	}
+	return "existing root CA requires refresh"
+}
+
+func printTrustBootstrapToStdout(tlsListenAddr, bootstrapHost, fingerprint, httpBootstrapListen string) {
+	fp := strings.TrimSpace(fingerprint)
+	if fp == "" {
+		fp = "(fingerprint unavailable)"
+	}
+
+	bootstrapURL := bootstrapBaseURLWithHost("https", tlsListenAddr, bootstrapHost) + "/"
+	if strings.TrimSpace(httpBootstrapListen) != "" {
+		bootstrapURL = bootstrapBaseURLWithHost("http", httpBootstrapListen, bootstrapHost) + httpBootstrapRoute
+	}
+
+	fmt.Fprintf(os.Stdout, "Root CA SHA-256 fingerprint: %s\n", fp)
+	fmt.Fprintf(os.Stdout, "Bootstrap URL: %s\n", bootstrapURL)
+}
+
+func buildTrustBootstrapLines(tlsListenAddr, bootstrapHost, fingerprint, httpBootstrapListen string, maxWidth int) []string {
+	if maxWidth < 40 {
+		maxWidth = 40
+	}
+
+	httpsBaseURL := bootstrapBaseURLWithHost("https", tlsListenAddr, bootstrapHost)
+	httpBootstrapURL := ""
+	if strings.TrimSpace(httpBootstrapListen) != "" {
+		httpBootstrapURL = bootstrapBaseURLWithHost("http", httpBootstrapListen, bootstrapHost) + localCACertRoute
+	}
+
+	separator := strings.Repeat("-", maxWidth)
+	lines := []string{
+		separator,
+		"CELLWEB TRUST BOOTSTRAP",
+		separator,
+		"Root CA SHA-256 fingerprint:",
+	}
+
+	lines = append(lines, formatFingerprintForDisplay(fingerprint, "  ", maxWidth)...)
+	lines = append(lines, "")
+
+	if httpBootstrapURL != "" {
+		lines = append(lines, "1) Download the Root CA certificate (no browser exception required):")
+		lines = append(lines, wrapWithIndent(httpBootstrapURL, "   ", maxWidth)...)
+		lines = append(lines, "   If HSTS is cached for that hostname, use server IP with same path.")
+		lines = append(lines, "2) Verify the downloaded certificate fingerprint against the value above.")
+		lines = append(lines, "3) Import the Root CA certificate into your browser or OS trust store.")
+		lines = append(lines, "4) Open your browser at:")
+		lines = append(lines, wrapWithIndent(httpsBaseURL+"/", "   ", maxWidth)...)
+		lines = append(lines, "5) Reload the page and continue with normal trusted HTTPS access.")
+	} else {
+		lines = append(lines, "1) Open your browser at:")
+		lines = append(lines, wrapWithIndent(httpsBaseURL+"/", "   ", maxWidth)...)
+		lines = append(lines, "2) Allow the one-time security exception for this first connection.")
+		lines = append(lines, "3) Download the Root CA certificate from:")
+		lines = append(lines, wrapWithIndent(httpsBaseURL+localCACertRoute, "   ", maxWidth)...)
+		lines = append(lines, "4) Verify the downloaded certificate fingerprint against the value above.")
+		lines = append(lines, "5) Import the Root CA certificate into your browser or OS trust store.")
+		lines = append(lines, "6) Reload the page and continue with normal trusted HTTPS access.")
+	}
+	lines = append(lines, separator)
+
+	return enforceLineWidth(lines, maxWidth)
+}
+
+func formatFingerprintForDisplay(fingerprint, indent string, maxWidth int) []string {
+	parts := strings.Split(strings.TrimSpace(fingerprint), ":")
+	if len(parts) == 0 {
+		return wrapWithIndent(strings.TrimSpace(fingerprint), indent, maxWidth)
+	}
+
+	bytesPerLine := 8
+	lines := make([]string, 0, (len(parts)+bytesPerLine-1)/bytesPerLine)
+	for i := 0; i < len(parts); i += bytesPerLine {
+		end := i + bytesPerLine
+		if end > len(parts) {
+			end = len(parts)
+		}
+		chunk := strings.Join(parts[i:end], ":")
+		lines = append(lines, wrapWithIndent(chunk, indent, maxWidth)...)
+	}
+	return lines
+}
+
+func wrapWithIndent(text, indent string, maxWidth int) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return []string{indent}
+	}
+
+	available := maxWidth - len(indent)
+	if available < 8 {
+		available = 8
+	}
+
+	lines := make([]string, 0, 4)
+	remaining := text
+	for len(remaining) > available {
+		segment := remaining[:available]
+		split := strings.LastIndex(segment, " ")
+		if split <= 0 {
+			lines = append(lines, indent+segment)
+			remaining = strings.TrimLeft(remaining[available:], " ")
+			continue
+		}
+		lines = append(lines, indent+strings.TrimSpace(remaining[:split]))
+		remaining = strings.TrimLeft(remaining[split+1:], " ")
+	}
+	if remaining != "" {
+		lines = append(lines, indent+remaining)
+	}
+	return lines
+}
+
+func enforceLineWidth(lines []string, maxWidth int) []string {
+	if maxWidth < 8 {
+		return lines
+	}
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if len(line) <= maxWidth {
+			out = append(out, line)
+			continue
+		}
+		for len(line) > maxWidth {
+			out = append(out, line[:maxWidth])
+			line = line[maxWidth:]
+		}
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func bootstrapBaseURLWithHost(scheme, listenAddr, preferredHost string) string {
+	host := strings.TrimSpace(preferredHost)
+	listenHost, listenPort := splitListenAddress(listenAddr)
+	if host == "" {
+		host = strings.TrimSpace(listenHost)
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+
+	authority := host
+	if listenPort != "" {
+		authority = net.JoinHostPort(host, listenPort)
+	}
+	return scheme + "://" + authority
+}
+
+func preferredBootstrapHost(sans certSANs) string {
+	for _, name := range sans.DNS {
+		if strings.HasSuffix(name, ".local") {
+			return name
+		}
+	}
+	for _, name := range sans.DNS {
+		if name != "localhost" {
+			return name
+		}
+	}
+	if len(sans.IPs) > 0 {
+		return normalizeIP(sans.IPs[0]).String()
+	}
+	return ""
+}

--- a/usr.sbin/cellweb/cmd/cellweb/tls_localca_test.go
+++ b/usr.sbin/cellweb/cmd/cellweb/tls_localca_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"crypto/x509"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResolveSecureCookieSetting(t *testing.T) {
+	secure, err := resolveSecureCookieSetting("auto", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !secure {
+		t.Fatalf("expected secure cookies in auto mode when tls is enabled")
+	}
+
+	secure, err = resolveSecureCookieSetting("auto", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secure {
+		t.Fatalf("expected insecure cookies in auto mode when tls is disabled")
+	}
+
+	secure, err = resolveSecureCookieSetting("off", true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !secure {
+		t.Fatalf("legacy secure cookies flag should force secure cookies")
+	}
+}
+
+func TestBuildRequiredSANs(t *testing.T) {
+	sans, err := buildRequiredSANs("127.0.0.1:18443", "cellweb.local,192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !containsString(sans.DNS, "localhost") {
+		t.Fatalf("expected localhost in DNS SANs")
+	}
+	if !containsString(sans.DNS, "cellweb.local") {
+		t.Fatalf("expected configured DNS SAN")
+	}
+	if !containsIP(sans.IPs, net.ParseIP("127.0.0.1")) {
+		t.Fatalf("expected listen host IP in SANs")
+	}
+	if !containsIP(sans.IPs, net.ParseIP("192.0.2.10")) {
+		t.Fatalf("expected configured IP SAN")
+	}
+}
+
+func TestBuildRequiredSANsRejectsInvalidEntry(t *testing.T) {
+	_, err := buildRequiredSANs("127.0.0.1:18443", "bad name")
+	if err == nil {
+		t.Fatalf("expected error for invalid SAN")
+	}
+}
+
+func TestMDNSSANFromHostname(t *testing.T) {
+	mdns, ok := mdnsSANFromHostname("cells-gw.prod.example")
+	if !ok {
+		t.Fatalf("expected valid mDNS SAN")
+	}
+	if mdns != "cells-gw.local" {
+		t.Fatalf("unexpected mDNS SAN: %q", mdns)
+	}
+}
+
+func TestMDNSSANFromHostnameRejectsInvalid(t *testing.T) {
+	if _, ok := mdnsSANFromHostname("bad_name"); ok {
+		t.Fatalf("expected invalid hostname to be rejected")
+	}
+}
+
+func TestRootCASubjectMatchesDefaults(t *testing.T) {
+	cert := &x509.Certificate{}
+	cert.Subject.CommonName = rootCACommonName
+	cert.Subject.Organization = []string{rootCAOrganization}
+	if !rootCASubjectMatches(cert) {
+		t.Fatalf("expected root CA subject to match defaults")
+	}
+}
+
+func TestPreferredBootstrapHostPrefersLocalDomain(t *testing.T) {
+	host := preferredBootstrapHost(certSANs{
+		DNS: []string{"localhost", "appliance.local", "example.net"},
+	})
+	if host != "appliance.local" {
+		t.Fatalf("unexpected host: %q", host)
+	}
+}
+
+func TestBootstrapBaseURLWithHostUsesPort(t *testing.T) {
+	url := bootstrapBaseURLWithHost("https", "0.0.0.0:18443", "appliance.local")
+	if url != "https://appliance.local:18443" {
+		t.Fatalf("unexpected bootstrap URL: %q", url)
+	}
+}
+
+func TestBuildTrustBootstrapLinesMaxWidth(t *testing.T) {
+	fingerprint := "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
+	lines := buildTrustBootstrapLines("0.0.0.0:18443", "very-long-hostname-for-bootstrap.local", fingerprint, "", 80)
+
+	if len(lines) == 0 {
+		t.Fatalf("expected bootstrap lines")
+	}
+	for i, line := range lines {
+		if len(line) > 80 {
+			t.Fatalf("line %d exceeds width: len=%d text=%q", i, len(line), line)
+		}
+	}
+}
+
+func TestFormatFingerprintForDisplayBreaksIntoMultipleLines(t *testing.T) {
+	fingerprint := "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
+	lines := formatFingerprintForDisplay(fingerprint, "  ", 80)
+	if len(lines) < 2 {
+		t.Fatalf("expected multi-line fingerprint output")
+	}
+}
+
+func TestBuildTrustBootstrapLinesIncludesHTTPDownloadPathWhenConfigured(t *testing.T) {
+	fingerprint := "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
+	lines := buildTrustBootstrapLines("0.0.0.0:18443", "appliance.local", fingerprint, "0.0.0.0:18088", 80)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "http://appliance.local:18088"+localCACertRoute) {
+		t.Fatalf("expected HTTP bootstrap download URL in output")
+	}
+	if strings.Contains(joined, "one-time security exception") {
+		t.Fatalf("did not expect exception step when HTTP bootstrap is configured")
+	}
+}
+
+func TestCertificateSHA256FingerprintFormat(t *testing.T) {
+	fp := certificateSHA256Fingerprint([]byte("cellweb"))
+	parts := strings.Split(fp, ":")
+	if len(parts) != 32 {
+		t.Fatalf("unexpected fingerprint segments: got %d want 32", len(parts))
+	}
+	for _, p := range parts {
+		if len(p) != 2 {
+			t.Fatalf("unexpected fingerprint segment %q", p)
+		}
+	}
+}
+
+func TestHTTPBootstrapHandlerServesBootstrapPageAndCACert(t *testing.T) {
+	caPEM := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n")
+	h := newHTTPBootstrapHandler("0.0.0.0:18443", caPEM)
+
+	pageReq := httptest.NewRequest(http.MethodGet, "http://appliance.local:18088/bootstrap", nil)
+	pageRec := httptest.NewRecorder()
+	h.ServeHTTP(pageRec, pageReq)
+
+	if pageRec.Code != http.StatusOK {
+		t.Fatalf("unexpected bootstrap page status: got %d want %d", pageRec.Code, http.StatusOK)
+	}
+	body := pageRec.Body.String()
+	if !strings.Contains(body, "Download Root CA certificate") {
+		t.Fatalf("expected bootstrap page to include download button")
+	}
+	if strings.Contains(body, "Root CA SHA-256 fingerprint") {
+		t.Fatalf("did not expect fingerprint to be shown on bootstrap page")
+	}
+	if strings.Contains(body, "Bootstrap URL") {
+		t.Fatalf("did not expect bootstrap URL text on bootstrap page")
+	}
+	if !strings.Contains(body, "https://appliance.local:18443/") {
+		t.Fatalf("expected bootstrap page to include https login URL")
+	}
+
+	caReq := httptest.NewRequest(http.MethodGet, "http://appliance.local:18088"+localCACertRoute, nil)
+	caRec := httptest.NewRecorder()
+	h.ServeHTTP(caRec, caReq)
+
+	if caRec.Code != http.StatusOK {
+		t.Fatalf("unexpected ca cert status: got %d want %d", caRec.Code, http.StatusOK)
+	}
+	if got := caRec.Body.String(); got != string(caPEM) {
+		t.Fatalf("unexpected CA cert payload: got %q want %q", got, string(caPEM))
+	}
+}
+
+func TestHTTPBootstrapHandlerRedirectsUnknownPathToHTTPS(t *testing.T) {
+	h := newHTTPBootstrapHandler("0.0.0.0:18443", []byte("pem"))
+	req := httptest.NewRequest(http.MethodGet, "http://appliance.local:18088/api/me", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMovedPermanently {
+		t.Fatalf("unexpected status: got %d want %d", rec.Code, http.StatusMovedPermanently)
+	}
+	if got := rec.Header().Get("Location"); got != "https://appliance.local:18443/api/me" {
+		t.Fatalf("unexpected redirect target: got %q", got)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsIP(values []net.IP, target net.IP) bool {
+	want := normalizeIP(target)
+	for _, value := range values {
+		if normalizeIP(value).Equal(want) {
+			return true
+		}
+	}
+	return false
+}

--- a/usr.sbin/cellweb/cmd/cellweb/web/app.js
+++ b/usr.sbin/cellweb/cmd/cellweb/web/app.js
@@ -1,0 +1,1395 @@
+const state = {
+  loggedIn: false,
+  csrf: "",
+  username: "",
+  theme: "dark",
+  mode: "cells",
+  filter: "all",
+  refreshSeconds: 4,
+  system: null,
+  cells: [],
+  storage: [],
+  backups: [],
+  selectedCellName: "",
+  selectedStorage: 0,
+  selectedBackup: 0,
+  lastStatus: "Ready.",
+  statusLines: ["Ready."],
+  statusOpen: false,
+  cpuUserSeries: [],
+  cpuSystemSeries: [],
+  memoryUsedSeries: [],
+  lastCPUTicks: null,
+  actionModalDepth: 0,
+  confirmResolver: null,
+  confirmRestoreFocus: null,
+  pollTimer: null,
+};
+
+const els = {
+  loginCard: document.getElementById("loginCard"),
+  app: document.getElementById("app"),
+  loginForm: document.getElementById("loginForm"),
+  loginStatus: document.getElementById("loginStatus"),
+  sessionInfo: document.getElementById("sessionInfo"),
+  modeSystem: document.getElementById("modeSystem"),
+  modeCells: document.getElementById("modeCells"),
+  modeStorage: document.getElementById("modeStorage"),
+  cellFilterGroup: document.getElementById("cellFilterGroup"),
+  refreshBtn: document.getElementById("refreshBtn"),
+  logoutBtn: document.getElementById("logoutBtn"),
+  metaPanel: document.getElementById("metaPanel"),
+  systemView: document.getElementById("systemView"),
+  cellsView: document.getElementById("cellsView"),
+  storageView: document.getElementById("storageView"),
+  systemSummary: document.getElementById("systemSummary"),
+  cpuTrendUserPath: document.getElementById("cpuTrendUserPath"),
+  cpuTrendSystemPath: document.getElementById("cpuTrendSystemPath"),
+  cpuTrendLegend: document.getElementById("cpuTrendLegend"),
+  memoryTrendAreaPath: document.getElementById("memoryTrendAreaPath"),
+  memoryTrendLinePath: document.getElementById("memoryTrendLinePath"),
+  memoryTrendLegend: document.getElementById("memoryTrendLegend"),
+  fsBody: document.getElementById("fsBody"),
+  ifaceBody: document.getElementById("ifaceBody"),
+  ioHead: document.getElementById("ioHead"),
+  ioBody: document.getElementById("ioBody"),
+  cellsBody: document.getElementById("cellsBody"),
+  storageBody: document.getElementById("storageBody"),
+  backupsBody: document.getElementById("backupsBody"),
+  cellDetails: document.getElementById("cellDetails"),
+  storageDetails: document.getElementById("storageDetails"),
+  statusPane: document.querySelector(".status-pane"),
+  statusBox: document.getElementById("statusBox"),
+  statusToggleBtn: document.getElementById("statusToggleBtn"),
+  actionModal: document.getElementById("actionModal"),
+  actionModalText: document.getElementById("actionModalText"),
+  confirmModal: document.getElementById("confirmModal"),
+  confirmModalTitle: document.getElementById("confirmModalTitle"),
+  confirmModalMessage: document.getElementById("confirmModalMessage"),
+  confirmModalMeta: document.getElementById("confirmModalMeta"),
+  confirmModalCancelBtn: document.getElementById("confirmModalCancelBtn"),
+  confirmModalConfirmBtn: document.getElementById("confirmModalConfirmBtn"),
+  startBtn: document.getElementById("startBtn"),
+  stopBtn: document.getElementById("stopBtn"),
+  restartBtn: document.getElementById("restartBtn"),
+  startAllBtn: document.getElementById("startAllBtn"),
+  stopAllBtn: document.getElementById("stopAllBtn"),
+  restartAllBtn: document.getElementById("restartAllBtn"),
+  applyAllBtn: document.getElementById("applyAllBtn"),
+  backupCreateBtn: document.getElementById("backupCreateBtn"),
+  backupRestoreBtn: document.getElementById("backupRestoreBtn"),
+  backupRestoreManifestBtn: document.getElementById("backupRestoreManifestBtn"),
+  backupDeleteBtn: document.getElementById("backupDeleteBtn"),
+  themeToggles: Array.from(document.querySelectorAll("[data-theme-toggle]")),
+};
+
+const themeStorageKey = "cellweb.theme";
+const statusPanelStorageKey = "cellweb.status.open";
+const chartHistorySize = 72;
+const supportedThemes = ["dark", "light", "retro"];
+
+function normalizeTheme(theme) {
+  return supportedThemes.includes(theme) ? theme : "dark";
+}
+
+function nextTheme(theme) {
+  const active = normalizeTheme(theme);
+  const idx = supportedThemes.indexOf(active);
+  return supportedThemes[(idx + 1) % supportedThemes.length];
+}
+
+function themeToggleConfig(theme) {
+  if (theme === "light") {
+    return { label: "Light mode", iconRef: "#i-sun" };
+  }
+  if (theme === "retro") {
+    return { label: "Retro mode", iconRef: "#i-retro" };
+  }
+  return { label: "Dark mode", iconRef: "#i-moon" };
+}
+
+function ensureSystemTrendElements() {
+  const hasAllTrendEls = Boolean(
+    els.cpuTrendUserPath
+    && els.cpuTrendSystemPath
+    && els.cpuTrendLegend
+    && els.memoryTrendAreaPath
+    && els.memoryTrendLinePath
+    && els.memoryTrendLegend,
+  );
+  if (hasAllTrendEls) {
+    return;
+  }
+
+  const summary = document.getElementById("systemSummary");
+  if (!summary) {
+    return;
+  }
+
+  let trendGrid = document.getElementById("systemTrendGrid");
+  if (!trendGrid) {
+    trendGrid = document.createElement("div");
+    trendGrid.id = "systemTrendGrid";
+    trendGrid.className = "trend-grid";
+    trendGrid.setAttribute("aria-label", "System trends");
+    trendGrid.innerHTML = `<section class="trend-card" aria-live="polite">
+      <div class="trend-head">
+        <div class="trend-title">CPU user/system</div>
+        <div id="cpuTrendLegend" class="trend-legend">Waiting for samples ...</div>
+      </div>
+      <div class="trend-canvas">
+        <svg class="trend-svg" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+          <path id="cpuTrendUserPath" class="trend-line trend-line-user" d=""></path>
+          <path id="cpuTrendSystemPath" class="trend-line trend-line-system" d=""></path>
+        </svg>
+      </div>
+    </section>
+    <section class="trend-card" aria-live="polite">
+      <div class="trend-head">
+        <div class="trend-title">Memory used</div>
+        <div id="memoryTrendLegend" class="trend-legend">Waiting for samples ...</div>
+      </div>
+      <div class="trend-canvas">
+        <svg class="trend-svg" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+          <path id="memoryTrendAreaPath" class="trend-area" d=""></path>
+          <path id="memoryTrendLinePath" class="trend-line trend-line-memory" d=""></path>
+        </svg>
+      </div>
+    </section>`;
+    summary.insertAdjacentElement("afterend", trendGrid);
+  }
+
+  els.cpuTrendUserPath = document.getElementById("cpuTrendUserPath");
+  els.cpuTrendSystemPath = document.getElementById("cpuTrendSystemPath");
+  els.cpuTrendLegend = document.getElementById("cpuTrendLegend");
+  els.memoryTrendAreaPath = document.getElementById("memoryTrendAreaPath");
+  els.memoryTrendLinePath = document.getElementById("memoryTrendLinePath");
+  els.memoryTrendLegend = document.getElementById("memoryTrendLegend");
+}
+
+function setStatus(text, level = "") {
+  const ts = new Date().toLocaleTimeString();
+  const prefix = level ? `[${level.toUpperCase()}] ` : "";
+  const line = `${ts} ${prefix}${text}`;
+  state.lastStatus = line;
+  state.statusLines.push(line);
+  if (state.statusLines.length > 80) {
+    state.statusLines.shift();
+  }
+  els.statusBox.textContent = state.statusLines.join("\n");
+  els.statusBox.scrollTop = els.statusBox.scrollHeight;
+}
+
+function setLoginStatus(text, level = "") {
+  els.loginStatus.textContent = text;
+  els.loginStatus.className = "status";
+  if (level) {
+    els.loginStatus.classList.add(level);
+  }
+}
+
+function showActionModal(text) {
+  if (!els.actionModal) return;
+  state.actionModalDepth += 1;
+  if (text && els.actionModalText) {
+    els.actionModalText.textContent = text;
+  }
+  els.actionModal.classList.add("open");
+  els.actionModal.setAttribute("aria-hidden", "false");
+}
+
+function hideActionModal() {
+  if (!els.actionModal) return;
+  state.actionModalDepth = Math.max(0, state.actionModalDepth - 1);
+  if (state.actionModalDepth > 0) return;
+  els.actionModal.classList.remove("open");
+  els.actionModal.setAttribute("aria-hidden", "true");
+}
+
+async function withActionModal(text, fn) {
+  showActionModal(text || "Action in progress ...");
+  try {
+    return await fn();
+  } finally {
+    hideActionModal();
+  }
+}
+
+function isConfirmModalOpen() {
+  return Boolean(els.confirmModal && els.confirmModal.classList.contains("open"));
+}
+
+function closeConfirmModal(answer) {
+  if (!isConfirmModalOpen() || !els.confirmModal) return;
+
+  els.confirmModal.classList.remove("open");
+  els.confirmModal.setAttribute("aria-hidden", "true");
+
+  if (state.confirmRestoreFocus && typeof state.confirmRestoreFocus.focus === "function") {
+    state.confirmRestoreFocus.focus();
+  }
+  state.confirmRestoreFocus = null;
+
+  const resolve = state.confirmResolver;
+  state.confirmResolver = null;
+  if (resolve) {
+    resolve(Boolean(answer));
+  }
+}
+
+async function confirmAction(options = {}) {
+  const title = options.title || "Confirm action";
+  const message = options.message || "Are you sure?";
+  const detail = options.detail || "";
+  const confirmLabel = options.confirmLabel || "Confirm";
+  const danger = options.danger !== false;
+
+  if (
+    !els.confirmModal
+    || !els.confirmModalTitle
+    || !els.confirmModalMessage
+    || !els.confirmModalMeta
+    || !els.confirmModalCancelBtn
+    || !els.confirmModalConfirmBtn
+  ) {
+    const fallbackText = [title, message, detail].filter(Boolean).join("\n");
+    return confirm(fallbackText);
+  }
+
+  if (state.confirmResolver) {
+    closeConfirmModal(false);
+  }
+
+  els.confirmModalTitle.textContent = title;
+  els.confirmModalMessage.textContent = message;
+  els.confirmModalMeta.textContent = detail;
+  els.confirmModalMeta.classList.toggle("hidden", !detail);
+  els.confirmModalConfirmBtn.textContent = confirmLabel;
+  els.confirmModalConfirmBtn.classList.toggle("danger", danger);
+
+  state.confirmRestoreFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  els.confirmModal.classList.add("open");
+  els.confirmModal.setAttribute("aria-hidden", "false");
+  els.confirmModalCancelBtn.focus();
+
+  return new Promise((resolve) => {
+    state.confirmResolver = resolve;
+  });
+}
+
+async function api(path, options = {}) {
+  const init = {
+    method: options.method || "GET",
+    headers: {
+      "Accept": "application/json",
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...(state.csrf && initMethodNeedsCSRF(options.method || "GET")
+        ? { "X-CSRF-Token": state.csrf }
+        : {}),
+      ...(options.headers || {}),
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+    credentials: "same-origin",
+  };
+
+  const res = await fetch(path, init);
+  const payload = await res.json().catch(() => ({}));
+
+  if (!res.ok || payload.ok === false) {
+    const err = new Error(payload.error || `HTTP ${res.status}`);
+    err.details = payload.details || "";
+    err.status = res.status;
+    throw err;
+  }
+
+  return payload;
+}
+
+function initMethodNeedsCSRF(method) {
+  const m = method.toUpperCase();
+  return m !== "GET" && m !== "HEAD" && m !== "OPTIONS";
+}
+
+function showApp(loggedIn) {
+  state.loggedIn = loggedIn;
+  els.loginCard.hidden = loggedIn;
+  els.app.hidden = !loggedIn;
+  els.loginCard.classList.toggle("hidden", loggedIn);
+  els.app.classList.toggle("hidden", !loggedIn);
+  if (els.statusPane) {
+    els.statusPane.hidden = !loggedIn;
+  }
+  if (els.statusToggleBtn) {
+    els.statusToggleBtn.hidden = !loggedIn;
+  }
+  if (!loggedIn) {
+    state.lastCPUTicks = null;
+  }
+  applyStatusPanel(state.statusOpen, false);
+}
+
+function detectInitialStatusPanel() {
+  try {
+    return localStorage.getItem(statusPanelStorageKey) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function applyStatusPanel(open, persist = false) {
+  state.statusOpen = Boolean(open);
+  const active = state.loggedIn && state.statusOpen;
+
+  if (els.statusPane) {
+    els.statusPane.classList.toggle("open", active);
+  }
+  els.app.classList.toggle("status-open", active);
+
+  const label = active ? "Hide console" : "Show console";
+  if (els.statusToggleBtn) {
+    els.statusToggleBtn.classList.toggle("active", active);
+    els.statusToggleBtn.setAttribute("aria-pressed", active ? "true" : "false");
+    els.statusToggleBtn.setAttribute("aria-label", label);
+    els.statusToggleBtn.title = label;
+  }
+
+  if (active) {
+    els.statusBox.scrollTop = els.statusBox.scrollHeight;
+  }
+
+  if (persist) {
+    try {
+      localStorage.setItem(statusPanelStorageKey, state.statusOpen ? "1" : "0");
+    } catch {
+      // ignore localStorage access errors
+    }
+  }
+}
+
+function toggleStatusPanel() {
+  applyStatusPanel(!state.statusOpen, true);
+}
+
+function detectInitialTheme() {
+  try {
+    const stored = localStorage.getItem(themeStorageKey);
+    if (supportedThemes.includes(stored)) {
+      return stored;
+    }
+  } catch {
+    // ignore localStorage access errors
+  }
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches) {
+    return "light";
+  }
+  return "dark";
+}
+
+function applyTheme(theme, persist = false) {
+  state.theme = normalizeTheme(theme);
+  document.documentElement.setAttribute("data-theme", state.theme);
+
+  const targetTheme = nextTheme(state.theme);
+  const target = themeToggleConfig(targetTheme);
+
+  els.themeToggles.forEach((btn) => {
+    const labelEl = btn.querySelector(".theme-toggle-label");
+    if (labelEl) {
+      labelEl.textContent = target.label;
+    }
+    const iconUse = btn.querySelector("svg use");
+    if (iconUse) {
+      iconUse.setAttribute("href", target.iconRef);
+    }
+    btn.setAttribute("aria-label", `Enable ${target.label.toLowerCase()}`);
+    btn.title = `Enable ${target.label.toLowerCase()}`;
+  });
+
+  if (persist) {
+    try {
+      localStorage.setItem(themeStorageKey, state.theme);
+    } catch {
+      // ignore localStorage access errors
+    }
+  }
+}
+
+function toggleTheme() {
+  applyTheme(nextTheme(state.theme), true);
+}
+
+function selectedCell() {
+  if (state.selectedCellName) {
+    const found = state.cells.find((row) => row.name === state.selectedCellName);
+    if (found) {
+      return found;
+    }
+  }
+  return state.cells[0] || null;
+}
+
+function selectedStorage() {
+  return state.storage[state.selectedStorage] || null;
+}
+
+function selectedBackup() {
+  return state.backups[state.selectedBackup] || null;
+}
+
+function clampPercent(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  if (n < 0) return 0;
+  if (n > 100) return 100;
+  return n;
+}
+
+function pushTrendPoint(series, value) {
+  if (value === null) return;
+  series.push(value);
+  if (series.length > chartHistorySize) {
+    series.shift();
+  }
+}
+
+function normalizeTrendSeries(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values
+    .map((v) => clampPercent(v))
+    .filter((v) => v !== null)
+    .slice(-chartHistorySize);
+}
+
+function parseCPUTicks(raw) {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+
+  const user = Number(raw.user);
+  const nice = Number(raw.nice);
+  const system = Number(raw.system);
+  const intr = Number(raw.intr);
+  const idle = Number(raw.idle);
+
+  if (![user, nice, system, intr, idle].every((v) => Number.isFinite(v) && v >= 0)) {
+    return null;
+  }
+
+  return { user, nice, system, intr, idle };
+}
+
+function buildTrendPoints(series) {
+  const values = series.slice(-chartHistorySize);
+  if (values.length === 0) {
+    return [];
+  }
+
+  const startSlot = chartHistorySize - values.length;
+  const denom = Math.max(1, chartHistorySize - 1);
+  return values.map((value, idx) => {
+    const slot = startSlot + idx;
+    const x = (slot / denom) * 100;
+    const y = 100 - ((clampPercent(value) || 0) / 100) * 100;
+    return { x, y };
+  });
+}
+
+function buildTrendLinePath(points) {
+  if (!points.length) return "";
+  return points.map((p, idx) => `${idx === 0 ? "M" : "L"} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`).join(" ");
+}
+
+function buildTrendAreaPath(points) {
+  if (!points.length) return "";
+  const line = buildTrendLinePath(points);
+  const first = points[0];
+  const last = points[points.length - 1];
+  return `${line} L ${last.x.toFixed(2)} 100 L ${first.x.toFixed(2)} 100 Z`;
+}
+
+function formatPercentCompact(value) {
+  const n = clampPercent(value);
+  if (n === null) return "-";
+  return `${n.toFixed(1)}%`;
+}
+
+function renderSystemTrends() {
+  ensureSystemTrendElements();
+
+  const cpuUserPoints = buildTrendPoints(state.cpuUserSeries);
+  const cpuSystemPoints = buildTrendPoints(state.cpuSystemSeries);
+  const memoryPoints = buildTrendPoints(state.memoryUsedSeries);
+
+  if (els.cpuTrendUserPath) {
+    els.cpuTrendUserPath.setAttribute("d", buildTrendLinePath(cpuUserPoints));
+  }
+  if (els.cpuTrendSystemPath) {
+    els.cpuTrendSystemPath.setAttribute("d", buildTrendLinePath(cpuSystemPoints));
+  }
+  if (els.memoryTrendAreaPath) {
+    els.memoryTrendAreaPath.setAttribute("d", buildTrendAreaPath(memoryPoints));
+  }
+  if (els.memoryTrendLinePath) {
+    els.memoryTrendLinePath.setAttribute("d", buildTrendLinePath(memoryPoints));
+  }
+
+  const latestCPUUser = state.cpuUserSeries.length ? state.cpuUserSeries[state.cpuUserSeries.length - 1] : null;
+  const latestCPUSystem = state.cpuSystemSeries.length ? state.cpuSystemSeries[state.cpuSystemSeries.length - 1] : null;
+  if (els.cpuTrendLegend) {
+    if (latestCPUUser === null || latestCPUSystem === null) {
+      els.cpuTrendLegend.textContent = "Waiting for samples ...";
+    } else {
+      els.cpuTrendLegend.textContent = `U ${formatPercentCompact(latestCPUUser)} | S ${formatPercentCompact(latestCPUSystem)}`;
+    }
+  }
+
+  const latestMem = state.memoryUsedSeries.length ? state.memoryUsedSeries[state.memoryUsedSeries.length - 1] : null;
+  if (els.memoryTrendLegend) {
+    els.memoryTrendLegend.textContent = latestMem === null
+      ? "Waiting for samples ..."
+      : `Used ${formatPercentCompact(latestMem)}`;
+  }
+}
+
+function updateSystemTrends(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    return;
+  }
+
+  if (snapshot.trends && typeof snapshot.trends === "object") {
+    if (state.cpuUserSeries.length === 0) {
+      state.cpuUserSeries = normalizeTrendSeries(snapshot.trends.cpu_user_percent);
+    }
+    if (state.cpuSystemSeries.length === 0) {
+      state.cpuSystemSeries = normalizeTrendSeries(snapshot.trends.cpu_system_percent);
+    }
+    if (state.memoryUsedSeries.length === 0) {
+      state.memoryUsedSeries = normalizeTrendSeries(snapshot.trends.memory_used_percent);
+    }
+  }
+
+  const memUsed = clampPercent(snapshot.memory && snapshot.memory.used_percent);
+  pushTrendPoint(state.memoryUsedSeries, memUsed);
+
+  const ticks = parseCPUTicks(snapshot.cpu_ticks);
+  if (ticks) {
+    if (state.lastCPUTicks) {
+      const dUser = Math.max(0, ticks.user - state.lastCPUTicks.user);
+      const dNice = Math.max(0, ticks.nice - state.lastCPUTicks.nice);
+      const dSystem = Math.max(0, ticks.system - state.lastCPUTicks.system);
+      const dIntr = Math.max(0, ticks.intr - state.lastCPUTicks.intr);
+      const dIdle = Math.max(0, ticks.idle - state.lastCPUTicks.idle);
+      const total = dUser + dNice + dSystem + dIntr + dIdle;
+
+      if (total > 0) {
+        pushTrendPoint(state.cpuUserSeries, ((dUser + dNice) * 100) / total);
+        pushTrendPoint(state.cpuSystemSeries, ((dSystem + dIntr) * 100) / total);
+      }
+    }
+    state.lastCPUTicks = ticks;
+  }
+
+  renderSystemTrends();
+}
+
+function applyModeUI() {
+  const isSystem = state.mode === "system";
+  const isCells = state.mode === "cells";
+  const isStorage = state.mode === "storage";
+
+  els.modeSystem.classList.toggle("active", isSystem);
+  els.modeCells.classList.toggle("active", isCells);
+  els.modeStorage.classList.toggle("active", isStorage);
+
+  els.systemView.classList.toggle("hidden", !isSystem);
+  els.cellsView.classList.toggle("hidden", !isCells);
+  els.storageView.classList.toggle("hidden", !isStorage);
+  els.cellFilterGroup.classList.toggle("hidden", !isCells);
+}
+
+function renderMetrics(meta) {
+  const blocks = [];
+  if (state.mode === "system") {
+    blocks.push(metric("FFS", meta.filesystems || 0));
+    blocks.push(metric("IF", meta.interfaces || 0));
+    blocks.push(metric("I/O", meta.io_devices || 0));
+    blocks.push(metric("Warn", meta.warnings || 0));
+  } else if (state.mode === "cells") {
+    blocks.push(metric("Cells", meta.total || 0));
+    blocks.push(metric("Running", meta.running || 0));
+    blocks.push(metric("Orphans", meta.missing_manifest || 0));
+    blocks.push(metric("Filter", state.filter));
+  } else {
+    blocks.push(metric("Targets", meta.total || 0));
+    blocks.push(metric("Volumes", meta.volumes || 0));
+    blocks.push(metric("Overlays", meta.overlays || 0));
+    blocks.push(metric("Ready", meta.backup_ready || 0));
+  }
+  els.metaPanel.innerHTML = blocks.join("");
+}
+
+function metric(label, value) {
+  return `<div class="metric"><span class="label">${escapeHtml(label)}</span><span class="value">${escapeHtml(String(value))}</span></div>`;
+}
+
+function renderCells() {
+  const filtered = state.cells.filter((row) => {
+    if (state.filter === "running") return row.running;
+    if (state.filter === "stopped") return !row.running;
+    return true;
+  });
+
+  if (!state.selectedCellName && filtered.length > 0) {
+    state.selectedCellName = filtered[0].name;
+  }
+  if (state.selectedCellName && !filtered.some((row) => row.name === state.selectedCellName)) {
+    state.selectedCellName = filtered.length > 0 ? filtered[0].name : "";
+  }
+
+  els.cellsBody.innerHTML = filtered.map((row, idx) => {
+    const rowClass = row.name === state.selectedCellName ? "selected" : "";
+    const stateClass = row.running ? "state-running" : "state-stopped";
+    const name = row.manifest_present ? row.name : `!${row.name}`;
+    return `<tr class="${rowClass}" data-row="${idx}">
+      <td>${escapeHtml(name)}</td>
+      <td class="${stateClass}">${row.running ? "running" : "stopped"}</td>
+      <td>${escapeHtml(row.cid || "-")}</td>
+      <td>${escapeHtml(row.cpu10s || "-")}</td>
+      <td>${escapeHtml(humanAge(row.age))}</td>
+    </tr>`;
+  }).join("");
+
+  els.cellsBody.querySelectorAll("tr").forEach((tr) => {
+    tr.addEventListener("click", () => {
+      const idx = Number(tr.dataset.row);
+      const picked = filtered[idx];
+      state.selectedCellName = picked ? picked.name : "";
+      renderCells();
+    });
+  });
+
+  const row = state.selectedCellName ? filtered.find((c) => c.name === state.selectedCellName) || null : null;
+  renderCellDetails(row);
+}
+
+function renderCellDetails(row) {
+  if (!row) {
+    els.cellDetails.innerHTML = detail("Info", "No cell selected.", "span-3");
+    setCellActionButtons(false);
+    return;
+  }
+
+  els.cellDetails.innerHTML = [
+    detail("Name", row.name),
+    detail("State", row.running ? "running" : "stopped"),
+    detail("CID", row.cid || "-"),
+    detail("Procs", row.procs || "0"),
+    detail("Refs", row.refs || "-"),
+    detail("Age", humanAge(row.age)),
+    detail("CPU 1s", row.cpu1s || "-"),
+    detail("CPU 10s", row.cpu10s || "-"),
+    detail("Memory", formatMaybeBytes(row.memory)),
+    detail("Manifest", row.manifest_present ? "present" : "missing (ORPHAN)"),
+    detail("Profile", row.create_profile || "-"),
+    detail("Reserved Ports", row.create_reserved_ports || "-"),
+    detail("Rlimit nofile", row.create_rlimit_nofile || "-"),
+    detail("Rlimit as", formatMaybeBytes(row.create_rlimit_as)),
+    detail("Rlimit core", row.create_rlimit_core || "-"),
+    detail("Autostart", row.autostart || "NO"),
+    detail("Root", row.root || "-", "span-2"),
+    detail("Supervise Cmd", row.supervise_cmd || "-", "span-3"),
+  ].join("");
+
+  setCellActionButtons(true, row);
+}
+
+function setCellActionButtons(enabled, row = null) {
+  [els.startBtn, els.stopBtn, els.restartBtn].forEach((btn) => {
+    btn.disabled = !enabled;
+  });
+  if (!enabled || !row) {
+    return;
+  }
+  els.startBtn.disabled = row.running;
+  els.stopBtn.disabled = !row.running;
+}
+
+function renderStorage() {
+  if (state.selectedStorage >= state.storage.length) {
+    state.selectedStorage = Math.max(0, state.storage.length - 1);
+  }
+
+  els.storageBody.innerHTML = state.storage.map((row, idx) => {
+    const selected = idx === state.selectedStorage ? "selected" : "";
+    const runtime = row.runtime_present ? "yes" : "no";
+    const mountedClass = row.mounted ? "state-warn" : "";
+    return `<tr class="${selected}" data-row="${idx}">
+      <td>${escapeHtml(row.kind)}</td>
+      <td>${escapeHtml(row.name)}</td>
+      <td>${escapeHtml(runtime)}</td>
+      <td class="${mountedClass}">${row.mounted ? "yes" : "no"}</td>
+      <td>${escapeHtml(row.refs || "-")}</td>
+      <td>${escapeHtml(row.mode || "-")}</td>
+    </tr>`;
+  }).join("");
+
+  els.storageBody.querySelectorAll("tr").forEach((tr) => {
+    tr.addEventListener("click", async () => {
+      state.selectedStorage = Number(tr.dataset.row);
+      state.selectedBackup = 0;
+      renderStorage();
+      await refreshBackups();
+    });
+  });
+
+  renderStorageDetails(selectedStorage());
+}
+
+function renderStorageDetails(row) {
+  if (!row) {
+    els.storageDetails.innerHTML = "<div class='detail-item'><div class='k'>Info</div><div class='v'>No storage target selected.</div></div>";
+    setStorageActionButtons(false);
+    return;
+  }
+
+  els.storageDetails.innerHTML = [
+    detail("Kind", row.kind),
+    detail("Name", row.name),
+    detail("Runtime", row.runtime_present ? "present" : "missing"),
+    detail("Mounted", row.mounted ? "yes" : "no"),
+    detail("Path", row.path || "-"),
+    detail("Used By", row.used_by || "-"),
+  ].join("");
+
+  setStorageActionButtons(true, row);
+}
+
+function setStorageActionButtons(enabled, row = null) {
+  [
+    els.backupCreateBtn,
+    els.backupRestoreBtn,
+    els.backupRestoreManifestBtn,
+    els.backupDeleteBtn,
+  ].forEach((btn) => {
+    btn.disabled = !enabled;
+  });
+
+  if (!enabled || !row) {
+    return;
+  }
+
+  const backup = selectedBackup();
+  const hasBackup = Boolean(backup && backup.archive);
+  els.backupRestoreBtn.disabled = row.mounted || !hasBackup;
+  els.backupRestoreManifestBtn.disabled = row.mounted || !hasBackup;
+  els.backupDeleteBtn.disabled = !hasBackup;
+}
+
+function renderBackups() {
+  if (state.selectedBackup >= state.backups.length) {
+    state.selectedBackup = Math.max(0, state.backups.length - 1);
+  }
+
+  els.backupsBody.innerHTML = state.backups.map((row, idx) => {
+    const selected = idx === state.selectedBackup ? "selected" : "";
+    return `<tr class="${selected}" data-row="${idx}">
+      <td>${escapeHtml(formatBackupTimestamp(row.timestamp))}</td>
+      <td>${escapeHtml(formatMaybeBytes(row.size))}</td>
+      <td>${escapeHtml(row.archive || "-")}</td>
+    </tr>`;
+  }).join("");
+
+  els.backupsBody.querySelectorAll("tr").forEach((tr) => {
+    tr.addEventListener("click", () => {
+      state.selectedBackup = Number(tr.dataset.row);
+      renderBackups();
+      setStorageActionButtons(Boolean(selectedStorage()), selectedStorage());
+    });
+  });
+
+  setStorageActionButtons(Boolean(selectedStorage()), selectedStorage());
+}
+
+function renderSystem() {
+  const data = state.system;
+  if (!data) {
+    els.systemSummary.innerHTML = "<div class='detail-item'><div class='k'>Info</div><div class='v'>No data.</div></div>";
+    els.fsBody.innerHTML = "";
+    els.ifaceBody.innerHTML = "";
+    els.ioHead.innerHTML = "";
+    els.ioBody.innerHTML = "";
+    renderSystemTrends();
+    return;
+  }
+
+  els.systemSummary.innerHTML = [
+    detail("Host", data.hostname || "-"),
+    detail("Uptime", data.uptime || "-"),
+    detail("Load", data.load_average || "-"),
+    detail("RAM", formatMemory(data.memory)),
+    detail("Swap", formatSwap(data.swap)),
+    detail("Warnings", (data.warnings || []).length ? data.warnings.join(" | ") : "none"),
+  ].join("");
+
+  const filesystems = data.filesystems || [];
+  els.fsBody.innerHTML = filesystems.map((row) => `<tr>
+    <td>${escapeHtml(row.filesystem || "-")}</td>
+    <td>${escapeHtml(row.mountpoint || "-")}</td>
+    <td>${escapeHtml(formatKB(row.size_kb))}</td>
+    <td>${escapeHtml(formatKB(row.used_kb))}</td>
+    <td>${escapeHtml(formatKB(row.avail_kb))}</td>
+    <td>${escapeHtml(String(row.capacity_percent ?? 0))}%</td>
+  </tr>`).join("");
+
+  const interfaces = data.interfaces || [];
+  els.ifaceBody.innerHTML = interfaces.map((row) => `<tr>
+    <td>${escapeHtml(row.name || "-")}</td>
+    <td>${escapeHtml(row.status || "-")}</td>
+    <td>${escapeHtml(row.mtu >= 0 ? String(row.mtu) : "-")}</td>
+    <td>${escapeHtml((row.addresses || []).join(", ") || "-")}</td>
+    <td>${escapeHtml(formatBytes(row.in_bytes || 0))}</td>
+    <td>${escapeHtml(formatBytes(row.out_bytes || 0))}</td>
+  </tr>`).join("");
+
+  const ioRows = data.io || [];
+  const metricKeys = new Set();
+  ioRows.forEach((row) => Object.keys(row.metrics || {}).forEach((k) => metricKeys.add(k)));
+  const columns = ["device", ...Array.from(metricKeys).sort()];
+  els.ioHead.innerHTML = columns.map((c) => `<th>${escapeHtml(c)}</th>`).join("");
+  els.ioBody.innerHTML = ioRows.map((row) => {
+    const cols = [`<td>${escapeHtml(row.device || "-")}</td>`];
+    columns.slice(1).forEach((k) => cols.push(`<td>${escapeHtml((row.metrics && row.metrics[k]) || "-")}</td>`));
+    return `<tr>${cols.join("")}</tr>`;
+  }).join("");
+
+  renderSystemTrends();
+}
+
+function detail(key, value, className = "") {
+  const classes = className ? `detail-item ${className}` : "detail-item";
+  return `<div class="${classes}"><div class="k">${escapeHtml(key)}</div><div class="v">${escapeHtml(value || "-")}</div></div>`;
+}
+
+async function refreshCells() {
+  const payload = await api("/api/cells");
+  state.cells = payload.rows || [];
+  renderMetrics(payload.meta || {});
+  renderCells();
+}
+
+async function refreshSystem() {
+  const payload = await api("/api/system");
+  state.system = payload.data || null;
+  updateSystemTrends(state.system);
+  renderMetrics(payload.meta || {});
+  renderSystem();
+}
+
+async function refreshStorage() {
+  const payload = await api("/api/storage");
+  state.storage = payload.rows || [];
+  renderMetrics(payload.meta || {});
+  renderStorage();
+}
+
+async function refreshBackups() {
+  const row = selectedStorage();
+  if (!row) {
+    state.backups = [];
+    renderBackups();
+    return;
+  }
+  const payload = await api(`/api/backups?kind=${encodeURIComponent(row.kind)}&name=${encodeURIComponent(row.name)}`);
+  state.backups = payload.rows || [];
+  renderBackups();
+}
+
+async function refreshCurrentMode() {
+  if (!state.loggedIn) return;
+
+  if (state.mode === "system") {
+    await refreshSystem();
+  } else if (state.mode === "cells") {
+    await refreshCells();
+  } else {
+    await refreshStorage();
+    await refreshBackups();
+  }
+}
+
+async function runCellAction(action, all = false) {
+  const row = selectedCell();
+  const body = { action, all };
+  if (!all && row) {
+    body.name = row.name;
+  }
+  const payload = await api("/api/cells/action", { method: "POST", body });
+  setStatus(payload.message || "Cell action executed.", "success");
+  if (payload.output) {
+    setStatus(payload.output, "success");
+  }
+  await refreshCells();
+}
+
+async function runStorageAction(action, withManifest = false) {
+  const row = selectedStorage();
+  if (!row) {
+    throw new Error("No storage target selected.");
+  }
+
+  const body = {
+    action,
+    kind: row.kind,
+    name: row.name,
+    with_manifest: withManifest,
+  };
+
+  if (action === "restore" || action === "delete") {
+    const backup = selectedBackup();
+    if (!backup || !backup.archive) {
+      throw new Error("No backup selected.");
+    }
+    body.archive = backup.archive;
+  }
+
+  const payload = await api("/api/storage/action", { method: "POST", body });
+  setStatus(payload.message || "Storage action executed.", "success");
+  if (payload.output) {
+    setStatus(payload.output, "success");
+  }
+  await refreshStorage();
+  await refreshBackups();
+}
+
+function bindEvents() {
+  els.themeToggles.forEach((btn) => {
+    btn.addEventListener("click", toggleTheme);
+  });
+
+  if (els.statusToggleBtn) {
+    els.statusToggleBtn.addEventListener("click", toggleStatusPanel);
+  }
+
+  if (els.confirmModalCancelBtn) {
+    els.confirmModalCancelBtn.addEventListener("click", () => {
+      closeConfirmModal(false);
+    });
+  }
+
+  if (els.confirmModalConfirmBtn) {
+    els.confirmModalConfirmBtn.addEventListener("click", () => {
+      closeConfirmModal(true);
+    });
+  }
+
+  if (els.confirmModal) {
+    els.confirmModal.addEventListener("click", (ev) => {
+      if (ev.target === els.confirmModal) {
+        closeConfirmModal(false);
+      }
+    });
+  }
+
+  document.addEventListener("keydown", (ev) => {
+    if (!isConfirmModalOpen()) return;
+    if (ev.key === "Escape") {
+      ev.preventDefault();
+      closeConfirmModal(false);
+    }
+  });
+
+  els.loginForm.addEventListener("submit", async (ev) => {
+    ev.preventDefault();
+    const data = new FormData(els.loginForm);
+    const username = String(data.get("username") || "").trim();
+    const password = String(data.get("password") || "");
+
+    setLoginStatus("Authenticating ...");
+    try {
+      await withActionModal("Checking credentials ...", async () => {
+        const payload = await api("/api/login", {
+          method: "POST",
+          body: { username, password },
+        });
+        state.csrf = payload.csrf_token;
+        state.username = payload.username;
+        state.refreshSeconds = payload.refresh_seconds || 4;
+        state.mode = "cells";
+        showApp(true);
+        applyModeUI();
+        schedulePolling();
+        els.sessionInfo.textContent = `${state.username} on netbsd`;
+        setStatus("Login successful.", "success");
+        setLoginStatus("", "");
+        await refreshCurrentMode();
+      });
+    } catch (err) {
+      setLoginStatus(err.details || err.message || "Login failed.", "error");
+    }
+  });
+
+  els.logoutBtn.addEventListener("click", () => guarded(async () => {
+    try {
+      await api("/api/logout", { method: "POST" });
+    } catch {
+      // ignore logout errors
+    }
+    clearPolling();
+    state.csrf = "";
+    state.username = "";
+    state.mode = "cells";
+    applyModeUI();
+    showApp(false);
+    setStatus("Signed out.");
+  }, { progressText: "Signing out ..." }));
+
+  els.modeCells.addEventListener("click", async () => {
+    state.mode = "cells";
+    applyModeUI();
+    await refreshCells();
+  });
+
+  els.modeSystem.addEventListener("click", async () => {
+    state.mode = "system";
+    applyModeUI();
+    await refreshSystem();
+  });
+
+  els.modeStorage.addEventListener("click", async () => {
+    state.mode = "storage";
+    applyModeUI();
+    await refreshStorage();
+    await refreshBackups();
+  });
+
+  els.cellFilterGroup.querySelectorAll(".filter").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      state.filter = btn.dataset.filter;
+      els.cellFilterGroup.querySelectorAll(".filter").forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      renderCells();
+    });
+  });
+
+  els.refreshBtn.addEventListener("click", () => guarded(async () => {
+      setStatus("Refreshing ...");
+      await refreshCurrentMode();
+      setStatus("Refreshed.", "success");
+  }, { progressText: "Refreshing view ..." }));
+
+  els.startBtn.addEventListener("click", async () => {
+    const row = selectedCell();
+    if (!row) {
+      setStatus("No cell selected.", "error");
+      return;
+    }
+    const approved = await confirmAction({
+      title: "Confirm start",
+      message: "The selected cell will be started.",
+      detail: row.name,
+      confirmLabel: "Start",
+      danger: false,
+    });
+    if (!approved) return;
+    guarded(() => runCellAction("start"), { progressText: "Starting cell ..." });
+  });
+
+  els.stopBtn.addEventListener("click", async () => {
+    const row = selectedCell();
+    if (!row) {
+      setStatus("No cell selected.", "error");
+      return;
+    }
+    const approved = await confirmAction({
+      title: "Confirm stop",
+      message: "The selected cell will be stopped.",
+      detail: row.name,
+      confirmLabel: "Stop",
+      danger: false,
+    });
+    if (!approved) return;
+    guarded(() => runCellAction("stop"), { progressText: "Stopping cell ..." });
+  });
+
+  els.restartBtn.addEventListener("click", async () => {
+    const row = selectedCell();
+    if (!row) {
+      setStatus("No cell selected.", "error");
+      return;
+    }
+    const approved = await confirmAction({
+      title: "Confirm restart",
+      message: "The selected cell will be restarted.",
+      detail: row.name,
+      confirmLabel: "Restart",
+      danger: false,
+    });
+    if (!approved) return;
+    guarded(() => runCellAction("restart"), { progressText: "Restarting cell ..." });
+  });
+
+  els.startAllBtn.addEventListener("click", async () => {
+    const approved = await confirmAction({
+      title: "Confirm start all",
+      message: "All cells will be started.",
+      detail: `${state.cells.length} Targets`,
+      confirmLabel: "Start all",
+      danger: false,
+    });
+    if (!approved) return;
+    guarded(() => runCellAction("start", true), { progressText: "Starting all cells ..." });
+  });
+
+  els.stopAllBtn.addEventListener("click", async () => {
+    const approved = await confirmAction({
+      title: "Confirm stop all",
+      message: "All cells will be stopped.",
+      detail: `${state.cells.length} Targets`,
+      confirmLabel: "Stop all",
+      danger: false,
+    });
+    if (!approved) return;
+    guarded(() => runCellAction("stop", true), { progressText: "Stopping all cells ..." });
+  });
+
+  els.restartAllBtn.addEventListener("click", async () => {
+    const approved = await confirmAction({
+      title: "Confirm restart all",
+      message: "All cells will be restarted.",
+      detail: `${state.cells.length} Targets`,
+      confirmLabel: "Restart all",
+      danger: false,
+    });
+    if (!approved) return;
+    guarded(() => runCellAction("restart", true), { progressText: "Restarting all cells ..." });
+  });
+
+  els.applyAllBtn.addEventListener("click", () => guarded(() => runCellAction("apply", true), { progressText: "Applying changes to all cells ..." }));
+
+  els.backupCreateBtn.addEventListener("click", () => guarded(() => runStorageAction("create"), { progressText: "Creating backup ..." }));
+  els.backupRestoreBtn.addEventListener("click", async () => {
+    const row = selectedStorage();
+    const backup = selectedBackup();
+    if (!row || !backup) {
+      setStatus("No target/backup selected.", "error");
+      return;
+    }
+    const approved = await confirmAction({
+      title: "Confirm restore",
+      message: "The selected backup will be restored.",
+      detail: `${row.kind}:${row.name}\n${backup.archive}`,
+      confirmLabel: "Restore",
+      danger: true,
+    });
+    if (!approved) return;
+    guarded(() => runStorageAction("restore", false), { progressText: "Restoring backup ..." });
+  });
+
+  els.backupRestoreManifestBtn.addEventListener("click", async () => {
+    const row = selectedStorage();
+    const backup = selectedBackup();
+    if (!row || !backup) {
+      setStatus("No target/backup selected.", "error");
+      return;
+    }
+    const approved = await confirmAction({
+      title: "Confirm restore + manifest",
+      message: "Backup and manifest will be restored.",
+      detail: `${row.kind}:${row.name}\n${backup.archive}`,
+      confirmLabel: "Restore + manifest",
+      danger: true,
+    });
+    if (!approved) return;
+    guarded(() => runStorageAction("restore", true), { progressText: "Restoring backup and manifest ..." });
+  });
+
+  els.backupDeleteBtn.addEventListener("click", async () => {
+    const row = selectedStorage();
+    const backup = selectedBackup();
+    if (!row || !backup) {
+      setStatus("No target/backup selected.", "error");
+      return;
+    }
+    const approved = await confirmAction({
+      title: "Confirm backup deletion",
+      message: "The selected backup will be permanently deleted.",
+      detail: `${row.kind}:${row.name}\n${backup.archive}`,
+      confirmLabel: "Delete",
+      danger: true,
+    });
+    if (!approved) return;
+    guarded(() => runStorageAction("delete", false), { progressText: "Deleting backup ..." });
+  });
+}
+
+async function guarded(fn, options = {}) {
+  const progressText = options.progressText || "";
+  try {
+    if (progressText) {
+      await withActionModal(progressText, fn);
+    } else {
+      await fn();
+    }
+  } catch (err) {
+    if (err.status === 401) {
+      clearPolling();
+      showApp(false);
+      setLoginStatus("Session expired. Please sign in again.", "error");
+      return;
+    }
+    setStatus(err.details || err.message || "Action failed", "error");
+  }
+}
+
+function schedulePolling() {
+  clearPolling();
+  state.pollTimer = setInterval(() => {
+    guarded(async () => {
+      await refreshCurrentMode();
+    });
+  }, Math.max(2, state.refreshSeconds) * 1000);
+}
+
+function clearPolling() {
+  if (state.pollTimer) {
+    clearInterval(state.pollTimer);
+    state.pollTimer = null;
+  }
+}
+
+function formatBytes(bytes) {
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n < 0) return "-";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)} KiB`;
+  if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)} MiB`;
+  if (n < 1024 ** 4) return `${(n / 1024 ** 3).toFixed(1)} GiB`;
+  return `${(n / 1024 ** 4).toFixed(1)} TiB`;
+}
+
+function parseLooseBytes(value) {
+  if (value === null || value === undefined) return null;
+  const raw = String(value).trim();
+  if (raw === "" || raw === "-") return null;
+
+  const compact = raw.replaceAll(",", "");
+  if (/^\d+$/.test(compact)) {
+    const bytes = Number(compact);
+    return Number.isFinite(bytes) && bytes >= 0 ? bytes : null;
+  }
+
+  const m = compact.match(/^(\d+(?:\.\d+)?)\s*(b|bytes?|k|kb|kib|m|mb|mib|g|gb|gib|t|tb|tib)$/i);
+  if (!m) return null;
+
+  const amount = Number(m[1]);
+  if (!Number.isFinite(amount) || amount < 0) return null;
+
+  const unit = m[2].toLowerCase();
+  const factor = {
+    b: 1,
+    byte: 1,
+    bytes: 1,
+    k: 1024,
+    kb: 1024,
+    kib: 1024,
+    m: 1024 ** 2,
+    mb: 1024 ** 2,
+    mib: 1024 ** 2,
+    g: 1024 ** 3,
+    gb: 1024 ** 3,
+    gib: 1024 ** 3,
+    t: 1024 ** 4,
+    tb: 1024 ** 4,
+    tib: 1024 ** 4,
+  }[unit];
+
+  if (!factor) return null;
+  return amount * factor;
+}
+
+function formatMaybeBytes(value) {
+  const bytes = parseLooseBytes(value);
+  if (bytes === null) {
+    const raw = String(value ?? "").trim();
+    return raw === "" ? "-" : raw;
+  }
+  return formatBytes(bytes);
+}
+
+function formatBackupTimestamp(value) {
+  const raw = String(value ?? "").trim();
+  if (raw === "" || raw === "-") return "-";
+  const m = raw.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/);
+  if (!m) return raw;
+  return `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}`;
+}
+
+function formatKB(kb) {
+  const n = Number(kb);
+  if (!Number.isFinite(n) || n < 0) return "-";
+  return formatBytes(n * 1024);
+}
+
+function formatMemory(mem) {
+  if (!mem || !Number.isFinite(Number(mem.total_bytes))) return "-";
+  return `${formatBytes(mem.used_bytes || 0)} / ${formatBytes(mem.total_bytes || 0)} (${mem.used_percent || 0}%)`;
+}
+
+function formatSwap(swap) {
+  if (!swap || !swap.readable) return "n/a";
+  if (!swap.has_swap) return "no swap";
+  return `${formatKB(swap.used_kb || 0)} / ${formatKB(swap.total_kb || 0)} (${swap.used_percent || 0}%)`;
+}
+
+function humanAge(raw) {
+  const value = String(raw ?? "").trim();
+  if (value === "") return "-";
+  if (!/^\d+$/.test(value)) return value;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return value;
+  if (n < 60) return `${n}s`;
+  if (n < 3600) return `${Math.floor(n / 60)}m${n % 60}s`;
+  if (n < 86400) return `${Math.floor(n / 3600)}h${Math.floor((n % 3600) / 60)}m`;
+  if (n < 604800) return `${Math.floor(n / 86400)}d${Math.floor((n % 86400) / 3600)}h`;
+  return `${Math.floor(n / 604800)}w${Math.floor((n % 604800) / 86400)}d`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+async function bootstrap() {
+  ensureSystemTrendElements();
+  applyTheme(detectInitialTheme());
+  state.statusOpen = detectInitialStatusPanel();
+  bindEvents();
+  applyModeUI();
+  applyStatusPanel(state.statusOpen, false);
+  setStatus("Checking session ...");
+  try {
+    const me = await api("/api/me");
+    state.csrf = me.csrf_token;
+    state.username = me.username;
+    state.refreshSeconds = me.refresh_seconds || 4;
+    state.mode = "cells";
+    showApp(true);
+    applyModeUI();
+    els.sessionInfo.textContent = `${state.username} on netbsd`;
+    schedulePolling();
+    await refreshCurrentMode();
+    setStatus("Connected.", "success");
+  } catch {
+    showApp(false);
+    setStatus("Please sign in.");
+  }
+}
+
+bootstrap();

--- a/usr.sbin/cellweb/cmd/cellweb/web/index.html
+++ b/usr.sbin/cellweb/cmd/cellweb/web/index.html
@@ -1,0 +1,370 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>cellweb</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <svg class="icon-sprite" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" width="0" height="0" hidden>
+    <symbol id="i-sun" viewBox="0 0 24 24">
+      <path d="M12 4V2m0 20v-2m8-8h2M2 12h2m12.95 4.95 1.41 1.41M3.64 3.64l1.41 1.41m11.9-1.41-1.41 1.41M5.05 16.95l-1.41 1.41M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="i-moon" viewBox="0 0 24 24">
+      <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4 7 7 0 0 0 20 14.5Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="i-retro" viewBox="0 0 24 24">
+      <rect x="3" y="6" width="18" height="12" rx="2" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <path d="M7 10h.01M10 10h.01M13 10h.01M16 10h.01M19 10h.01" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <path d="M8 14h8" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="i-server" viewBox="0 0 24 24">
+      <rect x="3" y="4" width="18" height="6" rx="1" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <rect x="3" y="14" width="18" height="6" rx="1" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <path d="M7 7h.01M7 17h.01" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="i-grid" viewBox="0 0 24 24">
+      <rect x="3" y="3" width="8" height="8" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <rect x="13" y="3" width="8" height="8" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <rect x="3" y="13" width="8" height="8" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <rect x="13" y="13" width="8" height="8" fill="none" stroke="currentColor" stroke-width="1.8"/>
+    </symbol>
+    <symbol id="i-storage" viewBox="0 0 24 24">
+      <ellipse cx="12" cy="5" rx="8" ry="3" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <path d="M4 5v6c0 1.7 3.6 3 8 3s8-1.3 8-3V5" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <path d="M4 11v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6" fill="none" stroke="currentColor" stroke-width="1.8"/>
+    </symbol>
+    <symbol id="i-refresh" viewBox="0 0 24 24">
+      <path d="M20 11a8 8 0 1 0 2 5.3" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+      <path d="M20 4v7h-7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="i-logout" viewBox="0 0 24 24">
+      <path d="M10 4H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h5" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <path d="M14 16l4-4-4-4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M18 12H8" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="i-play" viewBox="0 0 24 24">
+      <path d="M8 6v12l10-6Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="i-stop" viewBox="0 0 24 24">
+      <rect x="7" y="7" width="10" height="10" rx="1" fill="none" stroke="currentColor" stroke-width="1.8"/>
+    </symbol>
+    <symbol id="i-wrench" viewBox="0 0 24 24">
+      <path d="M14.2 4.9a4.4 4.4 0 0 0 4.9 5.9l-8.2 8.2a1.9 1.9 0 0 1-2.7 0l-.2-.2a1.9 1.9 0 0 1 0-2.7l8.2-8.2a4.4 4.4 0 0 0-2-3Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M9 19l-4 1 1-4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="i-archive" viewBox="0 0 24 24">
+      <rect x="4" y="4" width="16" height="4" rx="1" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <path d="M5 8h14v10a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V8Z" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <path d="M10 12h4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="i-download" viewBox="0 0 24 24">
+      <path d="M12 4v10" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+      <path d="m8.5 10.5 3.5 3.5 3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M5 19h14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="i-trash" viewBox="0 0 24 24">
+      <path d="M4 7h16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+      <path d="M9 4h6l1 3H8l1-3Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+      <path d="M7 7l1 12h8l1-12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+      <path d="M10 11v5M14 11v5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24">
+      <rect x="3" y="4" width="18" height="16" rx="2" fill="none" stroke="currentColor" stroke-width="1.8"/>
+      <path d="m7 10 3 2-3 2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M12 15h5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+    </symbol>
+  </svg>
+
+  <div class="bg-orb orb-1"></div>
+  <div class="bg-orb orb-2"></div>
+  <div class="bg-grid"></div>
+
+  <main class="layout">
+    <section id="loginCard" class="card login-card reveal">
+      <div class="card-header">
+        <div class="brand"><svg class="icon" aria-hidden="true"><use href="#i-server"></use></svg>cellweb</div>
+        <button type="button" class="btn ghost theme-toggle icon-only" data-theme-toggle>
+          <svg class="icon" aria-hidden="true"><use href="#i-moon"></use></svg>
+          <span class="sr-only theme-toggle-label">Light mode</span>
+        </button>
+      </div>
+      <h1>NetBSD Cells in your browser</h1>
+      <p>Sign in with your local system user.</p>
+      <form id="loginForm" autocomplete="off">
+        <label>
+          Username
+          <input name="username" type="text" required>
+        </label>
+        <label>
+          Password
+          <input name="password" type="password" required>
+        </label>
+        <button id="loginButton" class="btn action-default" type="submit">Sign in</button>
+      </form>
+      <div id="loginStatus" class="status"></div>
+    </section>
+
+    <section id="app" class="app hidden">
+      <section class="commandbar reveal">
+        <div class="commandbar-primary">
+          <div class="identity-block">
+            <div class="brand"><svg class="icon" aria-hidden="true"><use href="#i-server"></use></svg>cellweb</div>
+            <div class="subtitle">Web Operations Surface for cellmgr</div>
+          </div>
+          <div id="sessionInfo" class="session-inline"></div>
+          <div class="commandbar-icons">
+            <button id="refreshBtn" class="btn ghost icon-btn chrome-btn" type="button" aria-label="Refresh" title="Refresh">
+              <svg class="icon" aria-hidden="true"><use href="#i-refresh"></use></svg>
+              <span class="sr-only">Refresh</span>
+            </button>
+            <button type="button" class="btn ghost icon-btn chrome-btn theme-toggle icon-only" data-theme-toggle>
+              <svg class="icon" aria-hidden="true"><use href="#i-moon"></use></svg>
+              <span class="sr-only theme-toggle-label">Light mode</span>
+            </button>
+            <button id="logoutBtn" class="btn ghost icon-btn chrome-btn" type="button" aria-label="Logout" title="Logout">
+              <svg class="icon" aria-hidden="true"><use href="#i-logout"></use></svg>
+              <span class="sr-only">Logout</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="commandbar-secondary">
+          <div class="segmented">
+            <button id="modeSystem" class="seg"><svg class="icon" aria-hidden="true"><use href="#i-server"></use></svg>System</button>
+            <button id="modeCells" class="seg active"><svg class="icon" aria-hidden="true"><use href="#i-grid"></use></svg>Cells</button>
+            <button id="modeStorage" class="seg"><svg class="icon" aria-hidden="true"><use href="#i-storage"></use></svg>Storage</button>
+          </div>
+
+          <div id="cellFilterGroup" class="segmented">
+            <button data-filter="all" class="seg filter active">All</button>
+            <button data-filter="running" class="seg filter">Running</button>
+            <button data-filter="stopped" class="seg filter">Stopped</button>
+          </div>
+
+          <div class="push-right toolbar-right">
+            <section id="metaPanel" class="metrics" aria-live="polite"></section>
+          </div>
+        </div>
+      </section>
+
+      <section id="systemView" class="view hidden reveal">
+        <div class="pane table-pane">
+          <div class="pane-title">Server Overview</div>
+          <div id="systemSummary" class="summary-grid"></div>
+
+          <div id="systemTrendGrid" class="trend-grid" aria-label="System trends">
+            <section class="trend-card" aria-live="polite">
+              <div class="trend-head">
+                <div class="trend-title">CPU user/system</div>
+                <div id="cpuTrendLegend" class="trend-legend">Waiting for samples ...</div>
+              </div>
+              <div class="trend-canvas">
+                <svg class="trend-svg" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+                  <path id="cpuTrendUserPath" class="trend-line trend-line-user" d=""></path>
+                  <path id="cpuTrendSystemPath" class="trend-line trend-line-system" d=""></path>
+                </svg>
+              </div>
+            </section>
+
+            <section class="trend-card" aria-live="polite">
+              <div class="trend-head">
+                <div class="trend-title">Memory used</div>
+                <div id="memoryTrendLegend" class="trend-legend">Waiting for samples ...</div>
+              </div>
+              <div class="trend-canvas">
+                <svg class="trend-svg" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+                  <path id="memoryTrendAreaPath" class="trend-area" d=""></path>
+                  <path id="memoryTrendLinePath" class="trend-line trend-line-memory" d=""></path>
+                </svg>
+              </div>
+            </section>
+          </div>
+
+          <div class="sub-title">FFS Filesystems</div>
+          <div class="table-wrap slim">
+            <table>
+              <thead>
+                <tr>
+                  <th>Filesystem</th>
+                  <th>Mountpoint</th>
+                  <th>Size</th>
+                  <th>Used</th>
+                  <th>Avail</th>
+                  <th>Use%</th>
+                </tr>
+              </thead>
+              <tbody id="fsBody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="pane detail-pane">
+          <div class="pane-title">Network & I/O</div>
+
+          <div class="sub-title">Interfaces</div>
+          <div class="table-wrap slim">
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Status</th>
+                  <th>MTU</th>
+                  <th>Addresses</th>
+                  <th>In</th>
+                  <th>Out</th>
+                </tr>
+              </thead>
+              <tbody id="ifaceBody"></tbody>
+            </table>
+          </div>
+
+          <div class="sub-title">Disk I/O</div>
+          <div class="table-wrap slim">
+            <table>
+              <thead>
+                <tr id="ioHead"></tr>
+              </thead>
+              <tbody id="ioBody"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section id="cellsView" class="view reveal">
+        <div class="pane table-pane">
+          <div class="pane-header">
+            <div class="pane-title">Cell List</div>
+            <div class="bulk-actions" aria-label="All cells actions">
+              <div class="bulk-label">All Cells</div>
+              <button id="startAllBtn" class="btn icon-btn action-start" type="button" aria-label="Start all cells" title="Start all cells"><svg class="icon" aria-hidden="true"><use href="#i-play"></use></svg></button>
+              <button id="stopAllBtn" class="btn icon-btn action-stop" type="button" aria-label="Stop all cells" title="Stop all cells"><svg class="icon" aria-hidden="true"><use href="#i-stop"></use></svg></button>
+              <button id="restartAllBtn" class="btn icon-btn action-restart" type="button" aria-label="Restart all cells" title="Restart all cells"><svg class="icon" aria-hidden="true"><use href="#i-refresh"></use></svg></button>
+              <button id="applyAllBtn" class="btn icon-btn action-default" type="button" aria-label="Apply to all cells" title="Apply to all cells"><svg class="icon" aria-hidden="true"><use href="#i-wrench"></use></svg></button>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table class="cells-table">
+              <colgroup>
+                <col class="col-name" />
+                <col class="col-status" />
+                <col class="col-cid" />
+                <col class="col-cpu10s" />
+                <col class="col-age" />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Status</th>
+                  <th>CID</th>
+                  <th>CPU10s</th>
+                  <th>Age</th>
+                </tr>
+              </thead>
+              <tbody id="cellsBody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="pane detail-pane">
+          <div class="pane-title">Cell Details</div>
+          <div id="cellDetails" class="detail-grid"></div>
+          <div class="action-bar">
+            <button id="startBtn" class="btn icon-btn action-start" type="button" aria-label="Start selected cell" title="Start selected cell"><svg class="icon" aria-hidden="true"><use href="#i-play"></use></svg></button>
+            <button id="stopBtn" class="btn icon-btn action-stop" type="button" aria-label="Stop selected cell" title="Stop selected cell"><svg class="icon" aria-hidden="true"><use href="#i-stop"></use></svg></button>
+            <button id="restartBtn" class="btn icon-btn action-restart" type="button" aria-label="Restart selected cell" title="Restart selected cell"><svg class="icon" aria-hidden="true"><use href="#i-refresh"></use></svg></button>
+          </div>
+        </div>
+      </section>
+
+      <section id="storageView" class="view hidden reveal">
+        <div class="pane table-pane">
+          <div class="pane-title">Volumes & Overlays</div>
+          <div class="table-wrap">
+            <table class="storage-table">
+              <colgroup>
+                <col class="col-kind" />
+                <col class="col-name" />
+                <col class="col-runtime" />
+                <col class="col-mounted" />
+                <col class="col-refs" />
+                <col class="col-mode" />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>Kind</th>
+                  <th>Name</th>
+                  <th>Runtime</th>
+                  <th>Mounted</th>
+                  <th>Refs</th>
+                  <th>Mode</th>
+                </tr>
+              </thead>
+              <tbody id="storageBody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="pane detail-pane">
+          <div class="pane-title">Backups</div>
+          <div id="storageDetails" class="detail-grid"></div>
+          <div class="table-wrap slim">
+            <table class="backups-table">
+              <colgroup>
+                <col class="col-timestamp" />
+                <col class="col-size" />
+                <col class="col-archive" />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>Timestamp</th>
+                  <th>Size</th>
+                  <th>Archive</th>
+                </tr>
+              </thead>
+              <tbody id="backupsBody"></tbody>
+            </table>
+          </div>
+          <div class="action-bar">
+            <button id="backupCreateBtn" class="btn icon-btn action-backup-create" type="button" aria-label="Create backup" title="Create backup"><svg class="icon" aria-hidden="true"><use href="#i-archive"></use></svg></button>
+            <button id="backupRestoreBtn" class="btn icon-btn action-backup-restore" type="button" aria-label="Restore backup" title="Restore backup"><svg class="icon" aria-hidden="true"><use href="#i-download"></use></svg></button>
+            <button id="backupRestoreManifestBtn" class="btn icon-btn action-backup-restore" type="button" aria-label="Restore backup and manifest" title="Restore backup and manifest"><svg class="icon" aria-hidden="true"><use href="#i-refresh"></use></svg></button>
+            <button id="backupDeleteBtn" class="btn danger icon-btn" type="button" aria-label="Delete backup" title="Delete backup"><svg class="icon" aria-hidden="true"><use href="#i-trash"></use></svg></button>
+          </div>
+        </div>
+      </section>
+
+      <section class="pane status-pane reveal">
+        <div class="pane-title">Console</div>
+        <pre id="statusBox">Ready.</pre>
+      </section>
+    </section>
+  </main>
+
+  <button id="statusToggleBtn" class="status-ribbon" type="button" aria-label="Show console" title="Show console" aria-pressed="false">
+    <svg class="icon" aria-hidden="true"><use href="#i-terminal"></use></svg>
+  </button>
+
+  <div id="actionModal" class="action-modal" role="status" aria-live="polite" aria-modal="true" aria-hidden="true">
+    <div class="action-modal-card">
+      <div class="action-modal-spinner" aria-hidden="true"></div>
+      <div id="actionModalText" class="action-modal-text">Action in progress ...</div>
+    </div>
+  </div>
+
+  <div id="confirmModal" class="confirm-modal" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="confirmModalTitle" aria-describedby="confirmModalMessage">
+    <div class="confirm-modal-card" role="document">
+      <div id="confirmModalTitle" class="confirm-modal-title">Confirm action</div>
+      <div id="confirmModalMessage" class="confirm-modal-message">Are you sure?</div>
+      <pre id="confirmModalMeta" class="confirm-modal-meta hidden"></pre>
+      <div class="confirm-modal-actions">
+        <button id="confirmModalCancelBtn" class="btn ghost" type="button">Cancel</button>
+        <button id="confirmModalConfirmBtn" class="btn danger" type="button">Confirm</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/usr.sbin/cellweb/cmd/cellweb/web/style.css
+++ b/usr.sbin/cellweb/cmd/cellweb/web/style.css
@@ -1,0 +1,1783 @@
+:root {
+  --brand-orange: #d57b39;
+  --brand-blue: #2f5e8e;
+  --brand-neutral: #6b6f72;
+  --brand-ink: #080e2a;
+
+  --font-ui: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", "Fira Code", monospace;
+
+  --radius-surface: 10px;
+  --radius-interactive: 12px;
+  --radius-pill: 999px;
+  --surface-pad: 10px;
+  --section-gap: 10px;
+  --cluster-gap: 10px;
+  --glass-blur: 0px;
+}
+
+html[data-theme="dark"] {
+  --bg-0: #0c1626;
+  --bg-a: rgba(44, 102, 158, 0.14);
+  --bg-b: rgba(213, 123, 57, 0.08);
+
+  --surface-1: rgba(17, 27, 42, 0.94);
+  --surface-2: rgba(22, 34, 51, 0.97);
+  --surface-3: rgba(30, 45, 66, 0.98);
+
+  --border: #37506d;
+  --border-strong: #4f7399;
+
+  --text: #e9f1fb;
+  --muted: #9cb3cd;
+  --accent: #d57b39;
+  --accent-soft: #e3a16d;
+  --primary: #85acd4;
+
+  --ok: #39bf78;
+  --warning: #e5a94b;
+  --danger: #d9624d;
+
+  --action-main-bg: #2f5e8e;
+  --action-main-border: #4f79a2;
+  --action-main-text: #f4f9ff;
+
+  --btn-bg: #2f5e8e;
+  --btn-ghost-bg: rgba(18, 27, 41, 0.95);
+  --btn-text: #f3f7fc;
+  --btn-border: #4f79a2;
+  --ghost-border: #4f6784;
+  --danger-border: #c06456;
+  --danger-bg: #a94a3d;
+
+  --grid-line: rgba(237, 242, 250, 0.16);
+  --focus-ring: rgba(90, 134, 177, 0.54);
+  --seg-active-bg: rgba(86, 143, 196, 0.32);
+  --table-row-border: rgba(96, 123, 150, 0.5);
+  --row-hover: rgba(83, 143, 199, 0.2);
+  --row-selected: rgba(83, 143, 199, 0.32);
+
+  --header-bg: rgba(42, 85, 128, 0.94);
+  --header-bg-2: rgba(33, 70, 109, 0.97);
+  --header-border: #587ea6;
+  --header-brand: #e4f2ff;
+  --header-subtext: rgba(229, 241, 255, 0.9);
+  --seg-text: rgba(235, 244, 255, 0.9);
+  --metric-label: rgba(231, 242, 255, 0.86);
+  --metric-value: #f6fbff;
+
+  --trend-user: #8fc1f3;
+  --trend-system: #e4b36a;
+  --trend-memory: #6fd1b0;
+  --trend-memory-fill: rgba(111, 209, 176, 0.14);
+  --decor-grid-opacity: 0;
+
+  --code-bg: rgba(13, 18, 26, 0.92);
+  --shadow: 0 10px 24px rgba(2, 12, 27, 0.28);
+}
+
+html[data-theme="light"] {
+  --bg-0: #e4edf7;
+  --bg-a: rgba(58, 116, 172, 0.1);
+  --bg-b: rgba(213, 123, 57, 0.07);
+
+  --surface-1: rgba(255, 255, 255, 0.95);
+  --surface-2: rgba(246, 250, 255, 0.98);
+  --surface-3: rgba(236, 244, 253, 0.99);
+
+  --border: #b4c8dd;
+  --border-strong: #96b0ca;
+
+  --text: #111a2d;
+  --muted: #4b627c;
+  --accent: #cb6f33;
+  --accent-soft: #de915f;
+  --primary: #2f5e8e;
+
+  --ok: #2f8f5f;
+  --warning: #b17322;
+  --danger: #b74937;
+
+  --action-main-bg: #3b6f9f;
+  --action-main-border: #2c5b8a;
+  --action-main-text: #f5faff;
+
+  --btn-bg: #3b6f9f;
+  --btn-ghost-bg: rgba(232, 240, 249, 0.98);
+  --btn-text: #f8fbff;
+  --btn-border: #3e6f9e;
+  --ghost-border: #8ea3b8;
+  --danger-border: #a74333;
+  --danger-bg: #be594b;
+
+  --grid-line: rgba(17, 26, 45, 0.12);
+  --focus-ring: rgba(59, 111, 160, 0.4);
+  --seg-active-bg: rgba(68, 125, 178, 0.2);
+  --table-row-border: rgba(137, 164, 189, 0.48);
+  --row-hover: rgba(57, 112, 166, 0.11);
+  --row-selected: rgba(57, 112, 166, 0.2);
+
+  --header-bg: rgba(67, 116, 164, 0.9);
+  --header-bg-2: rgba(52, 95, 140, 0.93);
+  --header-border: #789ec2;
+  --header-brand: #e8f3ff;
+  --header-subtext: rgba(225, 241, 255, 0.92);
+  --seg-text: #1b4267;
+  --metric-label: #355777;
+  --metric-value: #0f2f4d;
+
+  --trend-user: #2f6ea9;
+  --trend-system: #9d6b1f;
+  --trend-memory: #237a62;
+  --trend-memory-fill: rgba(35, 122, 98, 0.12);
+  --decor-grid-opacity: 0;
+
+  --code-bg: rgba(237, 245, 252, 0.95);
+  --shadow: 0 8px 18px rgba(34, 61, 92, 0.14);
+}
+
+html[data-theme="retro"] {
+  color-scheme: light;
+
+  --bg-0: #bdb093;
+  --bg-a: rgba(255, 244, 214, 0.35);
+  --bg-b: rgba(94, 77, 53, 0.18);
+
+  --surface-1: rgba(198, 185, 155, 0.98);
+  --surface-2: rgba(210, 197, 167, 0.99);
+  --surface-3: rgba(184, 170, 139, 0.99);
+
+  --border: #8b7a5d;
+  --border-strong: #746349;
+
+  --text: #1f1912;
+  --muted: #60523f;
+  --accent: #b63f2e;
+  --accent-soft: #355f84;
+  --primary: #2d3b4e;
+
+  --ok: #2f6942;
+  --warning: #99691f;
+  --danger: #8f332e;
+
+  --action-main-bg: linear-gradient(180deg, #40424a 0%, #25262c 100%);
+  --action-main-border: #14151a;
+  --action-main-text: #f0e5d1;
+
+  --btn-bg: linear-gradient(180deg, #40424a 0%, #25262c 100%);
+  --btn-ghost-bg: linear-gradient(180deg, #4a4b53 0%, #2d2e35 100%);
+  --btn-text: #f0e5d1;
+  --btn-border: #15161b;
+  --ghost-border: #23242a;
+  --danger-border: #5d1b16;
+  --danger-bg: linear-gradient(180deg, #864039 0%, #6b2c27 100%);
+
+  --grid-line: rgba(61, 50, 34, 0.17);
+  --focus-ring: rgba(182, 63, 46, 0.45);
+  --seg-active-bg: linear-gradient(180deg, #40424a 0%, #25262c 100%);
+  --table-row-border: rgba(103, 86, 59, 0.42);
+  --row-hover: rgba(52, 45, 36, 0.12);
+  --row-selected: rgba(52, 45, 36, 0.2);
+
+  --header-bg: rgba(184, 170, 139, 0.97);
+  --header-bg-2: rgba(166, 151, 121, 0.98);
+  --header-border: #7f6d52;
+  --header-brand: #1f1912;
+  --header-subtext: rgba(54, 45, 34, 0.94);
+  --seg-text: #2e2418;
+  --metric-label: #4f4335;
+  --metric-value: #241c13;
+
+  --trend-user: #355f84;
+  --trend-system: #95641d;
+  --trend-memory: #2f6a56;
+  --trend-memory-fill: rgba(47, 106, 86, 0.16);
+  --decor-grid-opacity: 0.06;
+
+  --code-bg: rgba(41, 34, 24, 0.95);
+  --shadow: 0 10px 24px rgba(56, 43, 25, 0.24);
+
+  --font-ui: "Trebuchet MS", "Verdana", "Avenir Next", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  min-height: 100%;
+  overflow: hidden;
+  color: var(--text);
+  background: var(--bg-0);
+  font-family: var(--font-ui);
+}
+
+body {
+  overflow: hidden;
+  line-height: 1.45;
+  background:
+    radial-gradient(1100px 760px at -14% -20%, var(--bg-a), transparent 64%),
+    radial-gradient(900px 580px at 108% 115%, var(--bg-b), transparent 67%),
+    var(--bg-0);
+}
+
+.icon-sprite,
+body > svg[aria-hidden="true"] {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.bg-orb {
+  display: none;
+  position: fixed;
+  pointer-events: none;
+  border-radius: 50%;
+  filter: blur(24px);
+  opacity: 0.55;
+  z-index: 0;
+}
+
+.orb-1 {
+  width: 520px;
+  height: 520px;
+  top: -210px;
+  left: -140px;
+  background: radial-gradient(circle at 35% 35%, rgba(255, 153, 86, 0.72), rgba(255, 141, 66, 0.18));
+  animation: driftA 19s ease-in-out infinite;
+}
+
+.orb-2 {
+  width: 600px;
+  height: 600px;
+  bottom: -290px;
+  right: -190px;
+  background: radial-gradient(circle at 40% 40%, rgba(106, 170, 228, 0.58), rgba(44, 95, 146, 0.18));
+  animation: driftB 22s ease-in-out infinite;
+}
+
+.bg-grid {
+  position: fixed;
+  inset: 0;
+  display: none;
+  pointer-events: none;
+  z-index: 0;
+  opacity: var(--decor-grid-opacity);
+  background-image:
+    linear-gradient(rgba(148, 181, 213, 0.15) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 181, 213, 0.12) 1px, transparent 1px);
+  background-size: 46px 46px;
+  -webkit-mask-image: radial-gradient(circle at 50% 30%, #000 44%, transparent 92%);
+  mask-image: radial-gradient(circle at 50% 30%, #000 44%, transparent 92%);
+}
+
+.layout {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  max-width: none;
+  margin: 0;
+  padding: 10px;
+}
+
+.card,
+.pane,
+.commandbar,
+.topbar,
+.toolbar,
+.status-pane {
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.card,
+.pane,
+.commandbar {
+  position: relative;
+}
+
+.card::before,
+.pane::before,
+.commandbar::before {
+  content: "";
+  position: absolute;
+  left: 1px;
+  right: 1px;
+  top: 1px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+  pointer-events: none;
+}
+
+.reveal {
+  animation: reveal 260ms ease-out;
+}
+
+.hidden {
+  display: none !important;
+}
+
+#loginCard.hidden {
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+.login-card {
+  width: min(480px, 96vw);
+  max-height: calc(100dvh - 20px);
+  margin: auto;
+  padding: 24px;
+  overflow: auto;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  letter-spacing: 0.19em;
+  text-transform: uppercase;
+  font-size: 0.73rem;
+  color: var(--accent-soft);
+  font-weight: 700;
+  text-shadow: none;
+}
+
+h1 {
+  margin: 8px 0 8px;
+  font-size: clamp(1.46rem, 1.8vw, 1.95rem);
+  line-height: 1.22;
+  letter-spacing: 0;
+}
+
+p,
+.subtitle,
+.hint {
+  color: var(--muted);
+}
+
+label {
+  display: block;
+  margin-top: 10px;
+  font-size: 0.92rem;
+}
+
+input {
+  width: 100%;
+  margin-top: 6px;
+  padding: 10px 12px;
+  border-radius: var(--radius-interactive);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-2);
+  color: var(--text);
+  transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+input:focus,
+button:focus {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+input:focus {
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 3px rgba(53, 120, 187, 0.12);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+#loginButton {
+  margin-top: 14px;
+  width: 100%;
+  justify-content: center;
+}
+
+.bootstrap-card {
+  width: min(560px, 96vw);
+}
+
+.bootstrap-help {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  color: var(--muted);
+}
+
+.bootstrap-help li {
+  margin: 6px 0;
+}
+
+.bootstrap-actions {
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.bootstrap-actions .btn {
+  flex: 1 1 220px;
+  justify-content: center;
+}
+
+.app,
+.view,
+.pane,
+.commandbar,
+.topbar,
+.toolbar,
+.table-pane,
+.detail-pane {
+  min-width: 0;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  gap: var(--section-gap);
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  margin-top: 0;
+}
+
+.app.status-open {
+  padding-bottom: 0;
+}
+
+.commandbar,
+.status-pane {
+  padding: var(--surface-pad);
+}
+
+.commandbar {
+  background: linear-gradient(135deg, var(--header-bg), var(--header-bg-2));
+  border-color: var(--header-border);
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 10px 24px rgba(10, 34, 63, 0.22);
+}
+
+.commandbar .brand {
+  color: var(--header-brand);
+}
+
+.commandbar .subtitle,
+.commandbar .session-inline {
+  color: var(--header-subtext);
+}
+
+.commandbar-primary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  min-width: 0;
+}
+
+.identity-block {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.identity-block .subtitle {
+  margin-top: 2px;
+}
+
+.session-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 0.93rem;
+  white-space: nowrap;
+}
+
+.session-inline::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ok);
+  box-shadow: 0 0 0 2px rgba(57, 191, 120, 0.22);
+}
+
+.commandbar-icons {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 40px;
+  overflow: visible;
+}
+
+.commandbar-secondary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-height: 0;
+  padding-top: 8px;
+  border-top: 1px solid rgba(227, 241, 255, 0.14);
+}
+
+.chrome-btn {
+  border-radius: 10px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.chip {
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-surface);
+  padding: 6px 12px;
+  color: var(--muted);
+  background: var(--surface-2);
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  min-height: 0;
+}
+
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.push-right {
+  margin-left: auto;
+}
+
+.segmented {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 3px;
+  background: var(--surface-2);
+  box-shadow: none;
+}
+
+.seg {
+  border: 0;
+  border-radius: var(--radius-pill);
+  color: var(--seg-text);
+  background: transparent;
+  padding: 7px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  line-height: 1;
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.seg .icon {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+.seg.active {
+  background: var(--seg-active-bg);
+  color: var(--text);
+  box-shadow: none;
+}
+
+.seg:hover {
+  transform: none;
+}
+
+.metrics {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 0;
+}
+
+.metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 5px 9px;
+  background: var(--surface-2);
+  min-width: 0;
+  box-shadow: none;
+}
+
+.metric .label {
+  display: inline;
+  color: var(--metric-label);
+  font-size: 0.67rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric .value {
+  display: inline;
+  margin-top: 0;
+  font-size: 0.87rem;
+  font-weight: 700;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--metric-value);
+}
+
+.view {
+  display: grid;
+  flex: 1 1 auto;
+  height: auto;
+  gap: var(--section-gap);
+  padding: 0;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  align-items: stretch;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#systemView,
+#cellsView,
+#storageView {
+  margin-top: 0;
+  min-height: 0;
+}
+
+#cellsView {
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 1fr);
+}
+
+#systemView > .pane,
+#cellsView > .pane,
+#storageView > .pane {
+  align-self: stretch;
+  margin-top: 0;
+}
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  padding: var(--surface-pad);
+}
+
+.pane-title {
+  display: flex;
+  align-items: center;
+  min-height: 34px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 8px;
+  text-shadow: none;
+}
+
+.table-pane > .pane-title {
+  margin-bottom: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--table-row-border);
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+  row-gap: 8px;
+  min-height: 34px;
+  margin-bottom: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--table-row-border);
+}
+
+.pane-header .pane-title {
+  margin-bottom: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+#cellsView .detail-pane > .pane-title {
+  min-height: 34px;
+}
+
+.detail-pane > .pane-title {
+  margin-bottom: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--table-row-border);
+}
+
+.bulk-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  margin-left: auto;
+  flex: 0 1 auto;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.bulk-label {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bulk-actions .icon-btn {
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+}
+
+.table-wrap {
+  overflow-y: auto;
+  overflow-x: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-surface);
+  min-height: 0;
+  max-height: none;
+  width: 100%;
+  background: var(--surface-2);
+  flex: 1 1 auto;
+}
+
+#cellsView .table-wrap {
+  min-height: 220px;
+}
+
+.table-wrap.slim {
+  max-height: none;
+}
+
+table {
+  width: 100%;
+  min-width: 0;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 0.9rem;
+}
+
+.cells-table col.col-status {
+  width: 124px;
+}
+
+.cells-table col.col-cid {
+  width: 74px;
+}
+
+.cells-table col.col-cpu10s {
+  width: 92px;
+}
+
+.cells-table col.col-age {
+  width: 98px;
+}
+
+.storage-table col.col-kind {
+  width: 10ch;
+}
+
+.storage-table col.col-runtime {
+  width: 11ch;
+}
+
+.storage-table col.col-mounted {
+  width: 11ch;
+}
+
+.storage-table col.col-refs {
+  width: 7ch;
+}
+
+.storage-table col.col-mode {
+  width: 8ch;
+}
+
+.backups-table col.col-timestamp {
+  width: 21ch;
+}
+
+.backups-table col.col-size {
+  width: 11ch;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--table-row-border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+tbody tr {
+  transition: background-color 140ms ease;
+}
+
+tbody tr:hover {
+  background: var(--row-hover);
+}
+
+tbody tr.selected {
+  background: var(--row-selected);
+}
+
+th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--surface-3);
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.state-running {
+  color: var(--ok);
+}
+
+.state-stopped {
+  color: var(--danger);
+}
+
+.state-warn {
+  color: var(--warning);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(150px, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+#cellDetails,
+#storageDetails,
+#systemSummary {
+  min-height: 0;
+  overflow: auto;
+  align-content: start;
+}
+
+#cellDetails {
+  flex: 1 1 auto;
+  margin-bottom: 0;
+}
+
+#cellDetails.detail-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+#cellDetails .detail-item.span-2 {
+  grid-column: span 2;
+}
+
+#cellDetails .detail-item.span-3 {
+  grid-column: 1 / -1;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(190px, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.trend-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.trend-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-surface);
+  background: var(--surface-2);
+  padding: 8px;
+  min-width: 0;
+}
+
+.trend-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.trend-title {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trend-legend {
+  display: inline-flex;
+  align-items: center;
+  justify-self: end;
+  gap: 6px;
+  font-size: 0.84rem;
+  line-height: 1;
+  color: var(--text);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.trend-legend::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  box-shadow: 0 0 0 0 rgba(244, 121, 45, 0.35);
+  animation: trendPulse 1.8s ease-out infinite;
+}
+
+.trend-canvas {
+  height: 96px;
+  border: 1px solid var(--table-row-border);
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(to right, transparent 0, transparent calc(12.5% - 1px), var(--grid-line) calc(12.5% - 1px), var(--grid-line) 12.5%),
+    repeating-linear-gradient(to top, transparent 0, transparent calc(20% - 1px), var(--grid-line) calc(20% - 1px), var(--grid-line) 20%),
+    var(--surface-3);
+  overflow: hidden;
+}
+
+.trend-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.trend-line {
+  fill: none;
+  stroke-width: 1.6;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.trend-line-user {
+  stroke: var(--trend-user);
+}
+
+.trend-line-system {
+  stroke: var(--trend-system);
+}
+
+.trend-line-memory {
+  stroke: var(--trend-memory);
+}
+
+.trend-area {
+  fill: var(--trend-memory-fill);
+}
+
+.sub-title {
+  margin: 10px 0 6px;
+  font-size: 0.75rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.detail-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-surface);
+  padding: 8px;
+  background: var(--surface-2);
+  min-width: 0;
+  box-shadow: none;
+}
+
+.detail-item .k {
+  color: var(--muted);
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.detail-item .v {
+  margin-top: 4px;
+  overflow-wrap: anywhere;
+}
+
+.action-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cluster-gap);
+  margin-top: 8px;
+  min-height: 36px;
+  padding-top: 8px;
+  padding-bottom: 2px;
+  overflow: visible;
+  justify-content: flex-start;
+  align-items: center;
+  border-top: 1px solid var(--table-row-border);
+}
+
+.action-bar .btn {
+  flex: 0 0 auto;
+  margin: 0;
+}
+
+.icon-btn {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+  padding: 0;
+  line-height: 1;
+  overflow: visible;
+  justify-content: center;
+}
+
+.icon-btn .icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  display: block;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.btn {
+  appearance: none;
+  -webkit-appearance: none;
+  text-decoration: none;
+  border: 1px solid var(--btn-border);
+  border-radius: var(--radius-interactive);
+  padding: 8px 12px;
+  background: var(--btn-bg);
+  color: var(--btn-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  box-shadow: none;
+  transition: transform 120ms ease, filter 120ms ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.03);
+}
+
+.btn:active {
+  transform: translateY(0);
+  filter: brightness(0.98);
+  box-shadow: none;
+}
+
+.btn.ghost {
+  background: var(--btn-ghost-bg);
+  color: var(--text);
+  border-color: var(--ghost-border);
+}
+
+.btn.danger {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+}
+
+.btn.action-default,
+.btn.ghost.action-default,
+.btn.action-start,
+.btn.ghost.action-start,
+.btn.action-stop,
+.btn.ghost.action-stop,
+.btn.action-restart,
+.btn.ghost.action-restart,
+.btn.action-backup-restore,
+.btn.ghost.action-backup-restore,
+.btn.action-backup-create,
+.btn.ghost.action-backup-create {
+  border-color: var(--action-main-border);
+  background: var(--action-main-bg);
+  color: var(--action-main-text);
+}
+
+.btn:disabled {
+  opacity: 0.52;
+  cursor: not-allowed;
+  transform: none;
+  filter: none;
+  box-shadow: none;
+}
+
+.theme-toggle {
+  min-width: 136px;
+  justify-content: center;
+}
+
+.theme-toggle.icon-only {
+  min-width: 0;
+}
+
+.status-pane {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 12;
+  background: #000;
+  border: 0;
+  border-radius: 0;
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.45);
+  padding: 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(16px);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.status-pane.open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.status-pane .pane-title {
+  margin: 0;
+  padding: 8px 12px 6px;
+  color: #848b93;
+  background: #000;
+}
+
+.status-pane pre {
+  margin: 0;
+  min-height: 74px;
+  max-height: 168px;
+  overflow: auto;
+  white-space: pre-wrap;
+  font-family: var(--font-mono);
+  color: #949ca5;
+  border: 0;
+  border-radius: 0;
+  background: #000;
+  padding: 10px 12px;
+}
+
+.status {
+  margin-top: 11px;
+  min-height: 22px;
+  color: var(--muted);
+}
+
+.status.error {
+  color: var(--danger);
+}
+
+.status.success {
+  color: var(--ok);
+}
+
+.hint {
+  margin-top: 10px;
+  font-size: 0.88rem;
+}
+
+code {
+  font-family: var(--font-mono);
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 6px;
+}
+
+.icon {
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+}
+
+.status-ribbon {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  width: 88px;
+  height: 88px;
+  border: 0;
+  clip-path: polygon(100% 0, 0 100%, 100% 100%);
+  background: linear-gradient(135deg, #df823f, #c86826);
+  color: #f7fbff;
+  z-index: 14;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 0 12px 12px 0;
+  box-shadow: 0 8px 20px rgba(14, 23, 39, 0.3);
+  transition: filter 120ms ease, transform 120ms ease;
+}
+
+.status-ribbon:hover {
+  filter: brightness(1.07);
+}
+
+.status-ribbon:active {
+  transform: translateY(1px);
+}
+
+.status-ribbon.active {
+  filter: saturate(1.15) brightness(1.08);
+}
+
+.status-ribbon .icon {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.status-ribbon:focus {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.action-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(8, 12, 18, 0.5);
+  backdrop-filter: blur(2px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 140ms ease, visibility 140ms ease;
+}
+
+.action-modal.open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.action-modal-card {
+  min-width: min(420px, 92vw);
+  max-width: 92vw;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--radius-interactive);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-1);
+  box-shadow: var(--shadow);
+}
+
+.action-modal-spinner {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent);
+  animation: spin 720ms linear infinite;
+  flex: 0 0 auto;
+}
+
+.action-modal-text {
+  font-size: 0.96rem;
+  color: var(--text);
+}
+
+.confirm-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 34;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(8, 12, 18, 0.6);
+  backdrop-filter: blur(2px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 140ms ease, visibility 140ms ease;
+}
+
+.confirm-modal.open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.confirm-modal-card {
+  width: min(500px, 94vw);
+  max-width: 94vw;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-interactive);
+  background: var(--surface-1);
+  box-shadow: var(--shadow);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.confirm-modal-title {
+  font-size: 0.94rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.confirm-modal-message {
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.confirm-modal-meta {
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-surface);
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.confirm-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+html[data-theme="retro"] body {
+  background:
+    radial-gradient(1200px 760px at -8% -22%, var(--bg-a), transparent 66%),
+    radial-gradient(860px 560px at 108% 110%, var(--bg-b), transparent 67%),
+    var(--bg-0);
+}
+
+html[data-theme="retro"] .card,
+html[data-theme="retro"] .pane,
+html[data-theme="retro"] .commandbar,
+html[data-theme="retro"] .topbar,
+html[data-theme="retro"] .toolbar {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 246, 226, 0.82),
+    inset 0 -2px 0 rgba(106, 88, 60, 0.25),
+    0 8px 18px rgba(84, 66, 41, 0.22);
+}
+
+html[data-theme="retro"] .commandbar {
+  background: linear-gradient(180deg, var(--header-bg), var(--header-bg-2));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 246, 226, 0.86),
+    inset 0 -2px 0 rgba(94, 77, 52, 0.25),
+    0 10px 24px rgba(80, 62, 38, 0.24);
+}
+
+html[data-theme="retro"] .commandbar::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  top: 46px;
+  height: 14px;
+  border-radius: 3px;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(88, 72, 48, 0.54) 0 1px,
+    transparent 1px 4px
+  );
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+html[data-theme="retro"] .commandbar-secondary {
+  border-top-color: rgba(90, 73, 49, 0.36);
+}
+
+html[data-theme="retro"] .btn {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.36),
+    0 2px 0 rgba(16, 17, 22, 0.86);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
+}
+
+html[data-theme="retro"] .btn.ghost {
+  color: var(--btn-text);
+}
+
+html[data-theme="retro"] .btn:active {
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.42),
+    0 1px 0 rgba(16, 17, 22, 0.86);
+}
+
+html[data-theme="retro"] .segmented,
+html[data-theme="retro"] .metric,
+html[data-theme="retro"] .chip,
+html[data-theme="retro"] .detail-item,
+html[data-theme="retro"] .trend-card {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 244, 221, 0.66),
+    inset 0 -1px 0 rgba(106, 88, 60, 0.22);
+}
+
+html[data-theme="retro"] .seg.active {
+  color: #f0e6d4;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
+}
+
+html[data-theme="retro"] .status-pane {
+  background: #13140f;
+  border-color: #322b20;
+  box-shadow:
+    inset 0 1px 0 rgba(72, 71, 53, 0.4),
+    0 -8px 24px rgba(0, 0, 0, 0.5);
+}
+
+html[data-theme="retro"] .status-pane .pane-title {
+  color: #9ebd90;
+  background: #11120d;
+}
+
+html[data-theme="retro"] .status-pane pre {
+  color: #a7ce94;
+  background: #10110d;
+  text-shadow: 0 0 4px rgba(167, 206, 148, 0.25);
+}
+
+html[data-theme="retro"] .status-ribbon {
+  background: linear-gradient(135deg, #4d4232, #30281d);
+  color: #f3e8d3;
+}
+
+@media (max-width: 1180px) {
+  .view {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  #cellsView {
+    grid-template-columns: 1fr;
+  }
+
+  #cellsView .detail-pane,
+  #storageView .detail-pane {
+    padding-bottom: calc(var(--surface-pad) + 8px);
+  }
+
+  #cellsView .detail-pane .action-bar {
+    padding-bottom: 10px;
+    margin-bottom: 2px;
+  }
+
+}
+
+@media (max-height: 820px) {
+  .layout {
+    --surface-pad: 8px;
+    --section-gap: 8px;
+    padding: var(--surface-pad);
+  }
+
+  .pane-title {
+    margin-bottom: 6px;
+    font-size: 0.76rem;
+  }
+
+  .seg {
+    padding: 6px 10px;
+  }
+
+  th,
+  td {
+    padding: 6px 8px;
+    font-size: 0.85rem;
+  }
+
+  .detail-item {
+    padding: 7px;
+  }
+
+  .detail-item .k {
+    font-size: 0.7rem;
+  }
+
+  .detail-item .v {
+    margin-top: 2px;
+  }
+}
+
+@media (max-width: 800px) {
+  html,
+  body {
+    height: auto;
+    min-height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  .layout {
+    --surface-pad: 8px;
+    --section-gap: 8px;
+    height: auto;
+    min-height: 100dvh;
+    padding: var(--surface-pad);
+  }
+
+  .bg-orb,
+  .bg-grid {
+    display: none;
+  }
+
+  .app,
+  .view,
+  .pane {
+    height: auto;
+    overflow: visible;
+  }
+
+  .view {
+    grid-template-rows: auto auto;
+  }
+
+  .card-header,
+  .commandbar-primary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .commandbar-icons {
+    width: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+
+  .session-inline {
+    padding-left: 1px;
+  }
+
+  .commandbar-secondary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .toolbar-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .metrics {
+    justify-content: flex-start;
+  }
+
+  .detail-grid,
+  .summary-grid,
+  .trend-grid {
+    grid-template-columns: 1fr;
+  }
+
+  #cellDetails.detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  #cellDetails .detail-item.span-2,
+  #cellDetails .detail-item.span-3 {
+    grid-column: auto;
+  }
+
+  .pane-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .bulk-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .bulk-actions,
+  .action-bar {
+    gap: 8px;
+  }
+
+  .bulk-label {
+    min-height: 34px;
+  }
+
+  .commandbar-secondary {
+    gap: 8px;
+  }
+
+  .push-right {
+    margin-left: 0;
+  }
+
+  .status-pane pre {
+    max-height: 146px;
+  }
+
+  .status-ribbon {
+    width: 76px;
+    height: 76px;
+    padding: 0 10px 10px 0;
+  }
+
+  .confirm-modal-card {
+    width: 100%;
+  }
+
+  .confirm-modal-actions .btn {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .orb-1,
+  .orb-2,
+  .btn,
+  .trend-legend::before {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+@keyframes driftA {
+  0% {
+    transform: translate(0, 0) scale(1);
+  }
+
+  50% {
+    transform: translate(24px, 22px) scale(1.08);
+  }
+
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+@keyframes driftB {
+  0% {
+    transform: translate(0, 0) scale(1);
+  }
+
+  50% {
+    transform: translate(-20px, -18px) scale(1.07);
+  }
+
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+@keyframes reveal {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes trendPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(244, 121, 45, 0.35);
+  }
+
+  80% {
+    box-shadow: 0 0 0 8px rgba(244, 121, 45, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(244, 121, 45, 0);
+  }
+}

--- a/usr.sbin/cellweb/go.mod
+++ b/usr.sbin/cellweb/go.mod
@@ -1,0 +1,3 @@
+module cellweb
+
+go 1.22


### PR DESCRIPTION
cellweb introduces an authenticated browser frontend for day-to-day cell and storage operations on top of the existing cellmgr backend/IPC contract. The UI prioritizes fast operational scanning, clearer tables, and readable detail views.

cellmgr and cellui changes in this commit are compatibility adjustments only, made on-the-fly to match the updated API/formatting contract used by cellweb.